### PR TITLE
feat: removed the Windows Sandbox installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,6 @@ NOTICE: In the Home edition, some features are excluded and installed.
   - **`!`** Hyper-V
   - **`!`** Virtual Machine Platform
   - **`!`** Hypervisor Platform
-  - Windows Sandbox
   - **`!`** `(-8)` Windows Subsystem for Linux
 - Network client
   - NFS Client

--- a/boxstarter.min.ps1
+++ b/boxstarter.min.ps1
@@ -432,7 +432,6 @@ function Install-SomeWindowsFeatures() {
     'Microsoft-Hyper-V-All',
     'VirtualMachinePlatform',
     'HypervisorPlatform',
-    'Containers-DisposableClientVM',
     'Microsoft-Windows-Subsystem-Linux',
 
     # NFS

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -432,7 +432,6 @@ function Install-SomeWindowsFeatures() {
     'Microsoft-Hyper-V-All',
     'VirtualMachinePlatform',
     'HypervisorPlatform',
-    'Containers-DisposableClientVM',
     'Microsoft-Windows-Subsystem-Linux',
 
     # NFS


### PR DESCRIPTION
Windows Sandbox isn't suitable for experimenting with apps across reboots.
And it can cause inexplicable communication errors in Unity3D on the host environment.

Incidentally, I use [Vagrant](https://www.vagrantup.com/) to build such sandboxes.