### PR TITLE
Cumulative updates include that drops installation for unsupported Node.js: v16 and v19

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,10 @@
   "files.watcherExclude": {
     "**/.vagrant/**": true
   },
+  "git.branchProtection": ["master"],
+  "search.exclude": {
+    "**/.vagrant/**": true
+  },
   "yaml.schemas": {
     "https://raw.githubusercontent.com/reviewpad/schemas/main/latest/schema.json": [
       "reviewpad.yml"

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ NOTICE: In the Home edition, some features are excluded and installed.
 - Network client
   - NFS Client
   - NFS Administration tools
-  - **`!`** OpenSSH (install via the Chocolatey when on Windows 8.1)
+  - **`!`** OpenSSH
   - Telnet client
   - TFTP client
 - Languages

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Unless otherwise specified, as a general rule, install via Chocolatey.
 - [CMake](https://cmake.org)
 - [fnm: Fast Node Manager](https://fnm.vercel.app/)
   - Node.js (via fnm)
-    - v16 LTS Gallium
     - v18 LTS Hydrogen
     - v20
 - [Mono](https://www.mono-project.com/)
@@ -390,17 +389,17 @@ Also, by starting Firefox in this process, if the root store does not exist, it 
 <!-- markdownlint-disable MD033 -->
 <details><summary>list</summary>
 
-| Image                         | Tag                                                                                              |
-| :---------------------------- | :----------------------------------------------------------------------------------------------- |
-| `hello-world`                 | _`latest`_                                                                                       |
-| `alpine`                      | _`latest`_                                                                                       |
-| `busybox`                     | _`latest`_                                                                                       |
-| `debian`                      | _`latest`_                                                                                       |
-| `ubuntu`                      | _`latest`_                                                                                       |
-| `docker`                      | `dind`, `git`, _`latest`_                                                                        |
-| `node`                        | `16`, `16-alpine` `16-bullseye-slim`, `18`, `18-alpine`, `18-slim`, `20`, `20-alpine`, `20-slim` |
-| `gitlab/gitlab-runner`        | _`latest`_                                                                                       |
-| `ghcr.io/catthehacker/ubuntu` | `act-22.04`, `act-latest`, ~~`ubuntu:full-20.04`~~, ~~`ubuntu:full-latest`~~                     |
+| Image                         | Tag                                                                          |
+| :---------------------------- | :--------------------------------------------------------------------------- |
+| `hello-world`                 | _`latest`_                                                                   |
+| `alpine`                      | _`latest`_                                                                   |
+| `busybox`                     | _`latest`_                                                                   |
+| `debian`                      | _`latest`_                                                                   |
+| `ubuntu`                      | _`latest`_                                                                   |
+| `docker`                      | `dind`, `git`, _`latest`_                                                    |
+| `node`                        | `18`, `18-alpine`, `18-slim`, `20`, `20-alpine`, `20-slim`                   |
+| `gitlab/gitlab-runner`        | _`latest`_                                                                   |
+| `ghcr.io/catthehacker/ubuntu` | `act-22.04`, `act-latest`, ~~`ubuntu:full-20.04`~~, ~~`ubuntu:full-latest`~~ |
 
 </details>
 <!-- markdownlint-enable MD033 -->

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Unless otherwise specified, as a general rule, install via Chocolatey.
   - Node.js (via fnm)
     - v18 LTS Hydrogen
     - v20
+    - v21
 - [Mono](https://www.mono-project.com/)
 - `(-M)` [Microsoft Visual Studio Build Tools](https://www.visualstudio.com/)
   - version 2017

--- a/boxstarter.min.ps1
+++ b/boxstarter.min.ps1
@@ -392,6 +392,7 @@ function Install-FNM()
   fnm env --use-on-cd | Out-String | Invoke-Expression
   Install-NodeJS -NodeVersion 18 -NPMVersion 9
   Install-NodeJS -NodeVersion 20
+  Install-NodeJS -NodeVersion 21
   <#
   .SYNOPSIS
   Install the Node.js via FNM, and install some global packages.

--- a/boxstarter.min.ps1
+++ b/boxstarter.min.ps1
@@ -390,8 +390,7 @@ function Install-FNM()
 {
   choco install fnm
   fnm env --use-on-cd | Out-String | Invoke-Expression
-  Install-NodeJS -NodeVersion 16 -NPMVersion 8
-  Install-NodeJS -NodeVersion 18
+  Install-NodeJS -NodeVersion 18 -NPMVersion 9
   Install-NodeJS -NodeVersion 20
   <#
   .SYNOPSIS

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -392,6 +392,7 @@ function Install-FNM()
   fnm env --use-on-cd | Out-String | Invoke-Expression
   Install-NodeJS -NodeVersion 18 -NPMVersion 9
   Install-NodeJS -NodeVersion 20
+  Install-NodeJS -NodeVersion 21
   <#
   .SYNOPSIS
   Install the Node.js via FNM, and install some global packages.

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -390,9 +390,7 @@ function Install-FNM()
 {
   choco install fnm
   fnm env --use-on-cd | Out-String | Invoke-Expression
-  Install-NodeJS -NodeVersion 16 -NPMVersion 8
-  Install-NodeJS -NodeVersion 18
-  Install-NodeJS -NodeVersion 19
+  Install-NodeJS -NodeVersion 18 -NPMVersion 9
   Install-NodeJS -NodeVersion 20
   <#
   .SYNOPSIS

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -393,6 +393,7 @@ function Install-FNM()
   Install-NodeJS -NodeVersion 16 -NPMVersion 8
   Install-NodeJS -NodeVersion 18
   Install-NodeJS -NodeVersion 19
+  Install-NodeJS -NodeVersion 20
   <#
   .SYNOPSIS
   Install the Node.js via FNM, and install some global packages.

--- a/libs/docker.ps1
+++ b/libs/docker.ps1
@@ -66,9 +66,6 @@ docker pull ubuntu
 docker pull docker
 docker pull docker:dind
 docker pull docker:git
-docker pull node:16
-docker pull node:16-alpine
-docker pull node:16-bullseye-slim
 docker pull node:18
 docker pull node:18-alpine
 docker pull node:18-slim


### PR DESCRIPTION
## Features

- added and removed some apps
  - Node.js
    - 057ee4a: ~~v16 LTS Gallium~~
    - 057ee4a: ~~v19~~
    - 179f6c1: v20
    - 95083a3: v21

## Other updates

cce5c98: removed the Windows8.1 notation
d0b9bae: improved the VSCode configuration
