### PR TITLE
Removed deprecated Node.js version 23

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,15 @@
 root = true
 
 [*]
-  charset = utf-8
-  end_of_line = lf
-  indent_size = 2
-  indent_style = space
-  insert_final_newline = true
-  trim_trailing_whitespace = true
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.cmd]
-  charset = latin1
+charset = latin1
 
 [*.md]
-  trim_trailing_whitespace = false
+trim_trailing_whitespace = false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Linting workflow
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run cspell
+        uses: streetsidesoftware/cspell-action@v7
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v20

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Mark stale issues
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: '0 0 * * 1'
 permissions:
   issues: write
   pull-requests: write

--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Unless otherwise specified, as a general rule, install via Winget.
   - Node.js (via fnm)
     - v20 LTS Iron
     - v22 LTS Jod
-    - v23
     - v24
 - [Mono](https://www.mono-project.com/)
 - [Microsoft Visual Studio Build Tools](https://www.visualstudio.com/)
@@ -386,16 +385,16 @@ it will be initialized.
 
 <details><summary>list</summary>
 
-| Image                         | Tag                                                                                                                    |
-| :---------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
-| `hello-world`                 | _`latest`_                                                                                                             |
-| `alpine`                      | _`latest`_                                                                                                             |
-| `busybox`                     | _`latest`_                                                                                                             |
-| `debian`                      | _`latest`_                                                                                                             |
-| `ubuntu`                      | _`latest`_                                                                                                             |
-| `docker`                      | `dind`, `git`, _`latest`_                                                                                              |
-| `node`                        | `20`, `20-alpine`, `20-slim`, `22`, `22-alpine`, `22-slim`, `23`, `23-alpine`, `23-slim`, `24`, `24-alpine`, `24-slim` |
-| `ghcr.io/catthehacker/ubuntu` | `act-22.04`, `act-latest`, ~~`ubuntu:full-20.04`~~, ~~`ubuntu:full-latest`~~                                           |
+| Image                         | Tag                                                                                      |
+| :---------------------------- | :--------------------------------------------------------------------------------------- |
+| `hello-world`                 | _`latest`_                                                                               |
+| `alpine`                      | _`latest`_                                                                               |
+| `busybox`                     | _`latest`_                                                                               |
+| `debian`                      | _`latest`_                                                                               |
+| `ubuntu`                      | _`latest`_                                                                               |
+| `docker`                      | `dind`, `git`, _`latest`_                                                                |
+| `node`                        | `20`, `20-alpine`, `20-slim`, `22`, `22-alpine`, `22-slim`, `24`, `24-alpine`, `24-slim` |
+| `ghcr.io/catthehacker/ubuntu` | `act-22.04`, `act-latest`, ~~`ubuntu:full-20.04`~~, ~~`ubuntu:full-latest`~~             |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -461,4 +461,4 @@ please refer to [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## License
 
-MIT
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -359,14 +359,17 @@ PS> .\additional-setup
   - version 2019.4.31f1
     - Module: Android Build Support
     - Module: Documentation
+    - Module: iOS Build Support
     - Module: Language Pack (Japanese)
   - version 2022.3.6f1
     - Module: Android Build Support
     - Module: Documentation
+    - Module: iOS Build Support
     - Module: Language Pack (Japanese)
   - version 2022.3.22f1
     - Module: Android Build Support
     - Module: Documentation
+    - Module: iOS Build Support
     - Module: Language Pack (Japanese)
 
 ### Initialize for web-frontend development environment

--- a/boxstarter.min.ps1
+++ b/boxstarter.min.ps1
@@ -258,7 +258,7 @@ Install-WingetApps Mozilla.Firefox.ESR
 if (Get-Command fnm -ErrorAction SilentlyContinue | Out-Null)
 {
   fnm env --use-on-cd | Out-String | Invoke-Expression
-  @(20, 22, 23, 24) | ForEach-Object { fnm install $_; fnm default $_ }
+  @(20, 22, 24) | ForEach-Object { fnm install $_; fnm default $_ }
 }
 
 ### git-vrc

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -258,7 +258,7 @@ Install-WingetApps TorProject.TorBrowser
 if (Get-Command fnm -ErrorAction SilentlyContinue | Out-Null)
 {
   fnm env --use-on-cd | Out-String | Invoke-Expression
-  @(20, 22, 23, 24) | ForEach-Object { fnm install $_; fnm default $_ }
+  @(20, 22, 24) | ForEach-Object { fnm install $_; fnm default $_ }
 }
 
 ### git-vrc

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -19,7 +19,7 @@ ignorePaths:
   - .github/CODE_OF_CONDUCT.*
   - .vscode/extensions.json
   - cspell.config.yml
-language: en,eo,ja
+language: en,ja
 useGitignore: true
 version: "0.2"
 words:

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -8,6 +8,8 @@ dictionaries:
   - lorem-ipsum
   - markdown
   - misc
+  - npm
+  - shell
   - softwareTerms
 enableGlobDot: true
 features:
@@ -19,20 +21,47 @@ ignorePaths:
   - .github/CODE_OF_CONDUCT.*
   - .vscode/extensions.json
   - cspell.config.yml
+  - test
+ignoreRegExpList:
+  - '\b[0-9A-Z]{12,14}\b'
+  - Install-WingetApps .*\.
 language: en,ja
 useGitignore: true
 version: "0.2"
 words:
+  - alsa
+  - apic
   - antlr
+  - audioin
+  - biosapic
   - choco
   - dind
+  - dsound
+  - ghub
+  - hkcu
+  - hklm
+  - hpet
+  - hwvirtex
+  - iexplore
   - imgbotconfig
+  - ioapic
   - izotope
   - kito
   - kuron
   - kuroné
+  - modifyvm
+  - mswin
   - maxon
+  - nprocessors
   - tldr
+  - usbxhci
+  - useb
   - vbguest
+  - vboxsvga
+  - vcredist
+  - vrchat
   - vrcx
+  - vtxux
+  - vtxvpid
   - wkhtmltopdf
+  - wkhtmltox

--- a/libs/additional-setup.ps1
+++ b/libs/additional-setup.ps1
@@ -5,7 +5,7 @@ The entrypoint of the setup script.
 Set-StrictMode -Version Latest
 Push-Location $PSScriptRoot
 
-Write-Host 'Launched the additonal setup script. Continue...'
+Write-Host 'Launched the additional setup script. Continue...'
 
 ./mkcert.ps1
 ./unity.ps1

--- a/libs/docker.ps1
+++ b/libs/docker.ps1
@@ -72,9 +72,6 @@ docker pull node:20-slim
 docker pull node:22
 docker pull node:22-alpine
 docker pull node:22-slim
-docker pull node:23
-docker pull node:23-alpine
-docker pull node:23-slim
 docker pull node:24
 docker pull node:24-alpine
 docker pull node:24-slim

--- a/libs/docker.ps1
+++ b/libs/docker.ps1
@@ -81,7 +81,7 @@ docker pull node:24-slim
 docker pull ghcr.io/catthehacker/ubuntu:act-22.04
 docker pull ghcr.io/catthehacker/ubuntu:act-latest
 
-# ! Commented out because the container is too lerge!
+# ! Commented out because the container is too large!
 # docker pull ghcr.io/catthehacker/ubuntu:full-20.04
 # docker pull ghcr.io/catthehacker/ubuntu:full-latest
 


### PR DESCRIPTION
## Fixes and refactors

- b6b9c5b: ⚠️ Removed deprecated Node.js version 23 from installation scripts
- 95cb057: Fixed some typo

## Documents

- bde50f7: Improved the README

## Other updates

- a45fde9: Improved the CSpell configuration
- f668f6b: Imported from the latest [generic template](https://github.com/kurone-kito/template)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added CI linting workflow (spell-check and Markdown lint) for pushes and PRs.
  - Adjusted stale issue schedule to weekly (Mondays).
  - Updated setup scripts to drop Node.js v23 installation.
  - Expanded spell-check configuration (dictionaries, ignores, and terms).

- Documentation
  - Updated README: Node.js versions, added Unity iOS Build Support entries, linked LICENSE, and refined tables/formatting.

- Style
  - Reformatted .editorconfig without changing behavior.
  - Corrected typos in console message and a comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->