### PR TITLE
docs(idd): agent entry files と IDD ポリシー記録を整備する

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,8 +24,8 @@ for the shared claim/marker/safety-gate definitions, then follow
 [`docs/idd-workflow.md`](../docs/idd-workflow.md) as the phase-by-phase
 entry point (Discover → Claim → Work → PR Submit → CI Wait → Review
 Triage → Review Fix → Merge → Cleanup → Loop). Phase routing is manual:
-when a phase changes, open the routing target the current phase file
-names — this repository does not auto-route between phase files.
+when a phase changes, open the next-phase file the current phase
+instructions name — this repository does not auto-route between phase files.
 
 See [`docs/idd-policy.md`](../docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ for the shared claim/marker/safety-gate definitions, then follow
 [`docs/idd-workflow.md`](docs/idd-workflow.md) as the phase-by-phase entry
 point (Discover → Claim → Work → PR Submit → CI Wait → Review Triage →
 Review Fix → Merge → Cleanup → Loop). Phase routing is manual: when a
-phase changes, open the routing target the current phase file names —
-this repository does not auto-route between phase files.
+phase changes, open the next-phase file the current phase instructions
+name — this repository does not auto-route between phase files.
 
 See [`docs/idd-policy.md`](docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,7 @@
-# Guidelines for AI Agents
+# Guidelines for AI Agents (Codex CLI / OpenCode)
+
+This is the shared entry point for Codex CLI and OpenCode; no
+OpenCode-specific file is maintained separately.
 
 This project sets up the dev environment for Windows.
 
@@ -19,14 +22,14 @@ the project's standards and practices:
 
 This repository uses an Issue-Driven Development workflow for autonomous
 and semi-autonomous contribution loops. Before starting IDD work, open
-[`.github/instructions/idd-overview-core.instructions.md`](instructions/idd-overview-core.instructions.md)
+[`.github/instructions/idd-overview-core.instructions.md`](.github/instructions/idd-overview-core.instructions.md)
 for the shared claim/marker/safety-gate definitions, then follow
-[`docs/idd-workflow.md`](../docs/idd-workflow.md) as the phase-by-phase
-entry point (Discover → Claim → Work → PR Submit → CI Wait → Review
-Triage → Review Fix → Merge → Cleanup → Loop). Phase routing is manual:
-when a phase changes, open the routing target the current phase file
-names — this repository does not auto-route between phase files.
+[`docs/idd-workflow.md`](docs/idd-workflow.md) as the phase-by-phase entry
+point (Discover → Claim → Work → PR Submit → CI Wait → Review Triage →
+Review Fix → Merge → Cleanup → Loop). Phase routing is manual: when a
+phase changes, open the routing target the current phase file names —
+this repository does not auto-route between phase files.
 
-See [`docs/idd-policy.md`](../docs/idd-policy.md) for this repository's
+See [`docs/idd-policy.md`](docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim
 timing, CI wait, helper runtime, and related settings).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ for the shared claim/marker/safety-gate definitions, then follow
 [`docs/idd-workflow.md`](docs/idd-workflow.md) as the phase-by-phase entry
 point (Discover → Claim → Work → PR Submit → CI Wait → Review Triage →
 Review Fix → Merge → Cleanup → Loop). Phase routing is manual: when a
-phase changes, open the routing target the current phase file names —
-this repository does not auto-route between phase files.
+phase changes, open the next-phase file the current phase instructions
+name — this repository does not auto-route between phase files.
 
 See [`docs/idd-policy.md`](docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Guidelines for AI Agents
+# Guidelines for Claude Code
 
 This project sets up the dev environment for Windows.
 
@@ -19,14 +19,14 @@ the project's standards and practices:
 
 This repository uses an Issue-Driven Development workflow for autonomous
 and semi-autonomous contribution loops. Before starting IDD work, open
-[`.github/instructions/idd-overview-core.instructions.md`](instructions/idd-overview-core.instructions.md)
+[`.github/instructions/idd-overview-core.instructions.md`](.github/instructions/idd-overview-core.instructions.md)
 for the shared claim/marker/safety-gate definitions, then follow
-[`docs/idd-workflow.md`](../docs/idd-workflow.md) as the phase-by-phase
-entry point (Discover → Claim → Work → PR Submit → CI Wait → Review
-Triage → Review Fix → Merge → Cleanup → Loop). Phase routing is manual:
-when a phase changes, open the routing target the current phase file
-names — this repository does not auto-route between phase files.
+[`docs/idd-workflow.md`](docs/idd-workflow.md) as the phase-by-phase entry
+point (Discover → Claim → Work → PR Submit → CI Wait → Review Triage →
+Review Fix → Merge → Cleanup → Loop). Phase routing is manual: when a
+phase changes, open the routing target the current phase file names —
+this repository does not auto-route between phase files.
 
-See [`docs/idd-policy.md`](../docs/idd-policy.md) for this repository's
+See [`docs/idd-policy.md`](docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim
 timing, CI wait, helper runtime, and related settings).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,8 +24,8 @@ for the shared claim/marker/safety-gate definitions, then follow
 [`docs/idd-workflow.md`](docs/idd-workflow.md) as the phase-by-phase entry
 point (Discover → Claim → Work → PR Submit → CI Wait → Review Triage →
 Review Fix → Merge → Cleanup → Loop). Phase routing is manual: when a
-phase changes, open the routing target the current phase file names —
-this repository does not auto-route between phase files.
+phase changes, open the next-phase file the current phase instructions
+name — this repository does not auto-route between phase files.
 
 See [`docs/idd-policy.md`](docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,4 @@
-# Guidelines for AI Agents
+# Guidelines for Gemini / Antigravity CLI
 
 This project sets up the dev environment for Windows.
 
@@ -19,14 +19,14 @@ the project's standards and practices:
 
 This repository uses an Issue-Driven Development workflow for autonomous
 and semi-autonomous contribution loops. Before starting IDD work, open
-[`.github/instructions/idd-overview-core.instructions.md`](instructions/idd-overview-core.instructions.md)
+[`.github/instructions/idd-overview-core.instructions.md`](.github/instructions/idd-overview-core.instructions.md)
 for the shared claim/marker/safety-gate definitions, then follow
-[`docs/idd-workflow.md`](../docs/idd-workflow.md) as the phase-by-phase
-entry point (Discover → Claim → Work → PR Submit → CI Wait → Review
-Triage → Review Fix → Merge → Cleanup → Loop). Phase routing is manual:
-when a phase changes, open the routing target the current phase file
-names — this repository does not auto-route between phase files.
+[`docs/idd-workflow.md`](docs/idd-workflow.md) as the phase-by-phase entry
+point (Discover → Claim → Work → PR Submit → CI Wait → Review Triage →
+Review Fix → Merge → Cleanup → Loop). Phase routing is manual: when a
+phase changes, open the routing target the current phase file names —
+this repository does not auto-route between phase files.
 
-See [`docs/idd-policy.md`](../docs/idd-policy.md) for this repository's
+See [`docs/idd-policy.md`](docs/idd-policy.md) for this repository's
 recorded IDD policy decisions (merge policy, review policy, claim
 timing, CI wait, helper runtime, and related settings).

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -1,0 +1,145 @@
+# IDD Policy Record
+
+This page records the IDD (Issue-Driven Development) policy decisions
+made when this repository adopted the workflow (roadmap #55). It is the
+human-readable counterpart to the machine-readable
+[`.github/idd/config.json`](../.github/idd/config.json); keep both in
+sync when either changes.
+
+## IDD Policy Configuration
+
+This repository uses the following IDD policies:
+
+### Merge Policy
+
+**Policy**: `fully_autonomous_merge`
+
+### PR Review Policy
+
+**Profile**: `copilot-advisory`
+
+Advisory bots: `copilot-pull-request-reviewer[bot]`,
+`coderabbitai[bot]`.
+
+### Review-Thread Resolution Policy
+
+**Policy**: `fast-agent-resolve`
+
+### Critique-Loop Profile
+
+**Profile**: distributed defaults (no `critiqueLoopProfile` override
+recorded in `.github/idd/config.json`)
+
+### Claim Timing
+
+- **claim-stale-age**: `PT12H` (repository override; distributed
+  default is `PT24H`)
+- **claim-heartbeat-interval**: `PT6H` (repository override;
+  distributed default is `PT12H`)
+
+### CI Wait Policy
+
+- **running timeout**: `PT10M` (repository override; distributed
+  default is `PT30M`)
+- **generation timeout**: `PT10M` (matches the distributed default)
+- **rerun policy**: `rerun-once`
+
+### Credential Scope
+
+**Worker credentials**: same scope as any other IDD session running in
+this repository — no separate least-privilege worker identity is
+configured.
+
+**Merge-capable credentials**: same as worker. `mergePolicy` is
+`fully_autonomous_merge`, so no `separate_merge_agent` identity or
+elevated merge-only credential set exists; any session holding a valid
+claim may carry it through to merge.
+
+### Helper Runtime Profile
+
+**Profile**: `ephemeral-npx`
+
+Helper scripts run via `npx` against the pinned upstream package spec
+(see [Upstream pin](#upstream-pin) below) rather than being vendored
+into this repository or installed as a project dependency:
+
+```sh
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d <idd-command>
+```
+
+### Issue-Author Approval Gate
+
+- **Gate posture**: opted out
+- **Opt-out state**: `skipIssueAuthorApprovalGate: true`
+- **`maintainer-approval-actors` policy**: `owners-and-maintainers-only`
+- **Approval signals**: not applicable — the gate itself is opted out,
+  so no `approvalSignals.readyLabelName` /
+  `approvalSignals.labelFreshnessMode` override is recorded
+- **Missing-approval behavior**: not applicable for the same reason
+
+### Issue-Authoring Companion
+
+**Status**: not installed yet — tracked separately by
+[#59](https://github.com/kurone-kito/setup.windows/issues/59), which
+introduces `.claude/skills/issue-authoring/`.
+
+- **`issueAuthoring.maxClarificationRounds`**: not yet configured
+  (defaults apply once #59 lands)
+
+### IDD Label Names
+
+Distribution defaults, no `labels.*` override recorded in
+`.github/idd/config.json`:
+
+- roadmap label: `roadmap`
+- blocked-by-human label: `status:blocked-by-human`
+- needs-decision label: `status:needs-decision`
+
+## Worktree guard: local activation
+
+`worktreeGuard.enabled: true` is set in
+[`.github/idd/config.json`](../.github/idd/config.json), but
+`core.hooksPath` is a per-clone Git config value and is **not**
+committed to the repository. Run the following in every clone or
+worktree that should enforce the guard (this is required again for
+each newly created clone, worktree, or disposable environment):
+
+```sh
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit .githooks/pre-push
+```
+
+Without this step, `worktreeGuard.enabled: true` has no local effect:
+`idd-doctor` reports the guard as enabled-but-inert (commit/push are
+not actually blocked) until `core.hooksPath` is configured in that
+clone.
+
+## Upstream pin
+
+Template files and helper scripts are pinned to:
+
+```text
+kurone-kito/idd-skill @ 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
+```
+
+When a future change bumps this pin, treat it as a **named-gap
+import**, not a blind resync: reconcile only the specific files that
+changed between the old and new pinned commit against this repository's
+recorded policy values above (do not let an upstream default silently
+overwrite an intentional local override such as the claim-timing or
+CI-wait values), then re-run the onboarding verification checklist and
+`idd-doctor` after reconciling, using the same pinned `npx` form shown
+above:
+
+```sh
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/<new-pinned-SHA> idd-onboard.mjs --verify
+```
+
+## Machine-readable policy file
+
+`.github/idd/config.json` is the machine-readable record of the same
+policy decisions above. When present and valid, its `commands` object
+overrides the command table in
+[`idd-overview-core.instructions.md`](../.github/instructions/idd-overview-core.instructions.md).
+Keep this page and `.github/idd/config.json` aligned in the same
+change whenever either is updated.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` as cross-agent IDD entry
  points (Claude Code; Codex CLI + OpenCode; Gemini/Antigravity CLI),
  each carrying forward `.github/copilot-instructions.md`'s existing
  conversational-language / documentation-language guidance verbatim
  and pointing to `docs/idd-workflow.md` +
  `.github/instructions/idd-overview-core.instructions.md`
- Appends (does not replace) an IDD section to
  `.github/copilot-instructions.md`
- Adds `docs/idd-policy.md` — the human-readable counterpart to
  `.github/idd/config.json`, following upstream's
  `docs/onboarding/policy-decisions.md` "Recording the selected
  policies" template, populated with this repo's actual committed
  values (not template placeholders)

Closes #58.

## Verification

- Every value in `docs/idd-policy.md` was cross-checked field-by-field
  against the live `.github/idd/config.json` (mergePolicy,
  reviewPolicy + advisoryBotLogins, threadResolutionPolicy,
  claimTiming, ciWait, helperRuntime.profile,
  skipIssueAuthorApprovalGate, maintainerApprovalActorPolicy,
  worktreeGuard.enabled, and the absence of `critiqueLoopProfile`/
  `labels.*` overrides)
- Every relative link in the 4 changed/new files resolves to an
  existing file
- `.github/copilot-instructions.md`'s original content is preserved
  byte-identically (pure append)
- The named-gap-import summary and pinned-SHA `npx` snippet in
  `docs/idd-policy.md` match the pinned upstream source's
  `ONBOARDING.md` ("Re-importing: import named gaps, not a blind
  resync") and issue #55's roadmap Bootstrap section verbatim
- `pre-push-validate` (markdownlint-cli2 + cspell +
  PSScriptAnalyzer) exits 0 on a clean worktree

## Test plan

- [x] `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` exist at repo root
- [x] All three reference `docs/idd-workflow.md` and
      `idd-overview-core.instructions.md`
- [x] `.github/copilot-instructions.md` has an IDD section appended,
      existing guidance intact
- [x] `docs/idd-policy.md` exists and records every item listed in
      the issue's Proposed change §3
- [x] Recorded values match `.github/idd/config.json`'s corresponding
      fields
- [x] Worktree-guard local activation steps documented, with the
      enabled-but-inert-without-it caveat
- [x] Upstream pinned SHA documented
- [x] All three entry files + `.github/copilot-instructions.md` link
      to `docs/idd-policy.md`
- [x] `pre-push-validate` exits 0 on a clean worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added shared contribution guidance for AI-assisted development across supported tools.
  * Documented the Issue-Driven Development workflow, phase routing, required references, and repository policies.
  * Added guidance for Windows development, documentation standards, uncertainty handling, and approval processes.
  * Published a human-readable reference covering contribution configuration, review practices, credentials, CI, and issue management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->