### PR TITLE
feat(ci): add advisory-convergence and post-merge-cleanup gates

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -43,5 +43,11 @@
   },
   "worktreeGuard": {
     "enabled": true
+  },
+  "ciGate": {
+    "externalChecks": {
+      "waivable": [{ "selector": "idd-advisory-convergence" }]
+    },
+    "externalCheckWaivers": { "mode": "maintainer-authorized" }
   }
 }

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,0 +1,102 @@
+# Trust model: this workflow is a required-check gate (once #61
+# registers its job id in branch protection), so tampering matters more
+# here than in an ordinary lint check. This file is NOT self-protecting:
+# for `pull_request`, GitHub runs the PR's own copy of this workflow
+# file (unlike `pull_request_target`, which always resolves from the
+# base branch) -- so a PR editing this file does take effect for its own
+# run. What IS protected:
+#   - `ref: master` on the checkout step means a PR cannot substitute its
+#     own edited `.github/idd/config.json` (markerPrefix,
+#     trustedMarkerActors, advisoryBotLogins) to weaken the verdict.
+#   - Under this repository's `ephemeral-npx` helper-runtime profile
+#     (`.github/idd/config.json`'s `helperRuntime.profile`), the actual
+#     verdict logic (`advisory-convergence.mjs`) runs straight from the
+#     pinned upstream npm tarball below, never from a checked-out copy --
+#     there is no in-repository script for a PR to edit.
+#   - Once #61 registers this job's id as a required status check,
+#     deleting/renaming the job or the trigger events in a PR makes the
+#     required check simply never report for that PR, rather than
+#     report a false "ready" -- required checks fail closed on absence.
+#     Until #61 lands, this workflow is advisory only; a PR that edits
+#     it to always pass would not yet be blocked by branch protection,
+#     only caught by ordinary human/bot review of the diff.
+# If a future change adds a `ref:` override that resolves to the PR head,
+# vendors the helper script into this repository, or widens
+# `permissions:` below, re-review this trust model before merging that
+# change.
+name: IDD advisory-convergence gate
+# Read-only: contents: read + issues: read + pull-requests: read. The
+# helper only queries the GitHub API for reviews, review threads, PR
+# conversation comments, and waiver markers; it never mutates GitHub
+# state. `issues: read` is required (not just pull-requests: read)
+# because the helper reads the PR's own conversation comments via the
+# issue-comments REST endpoint, which GitHub gates under the Issues
+# permission category even when the issue number is a pull request --
+# see post-merge-cleanup.yml, which needs the same permission for the
+# identical endpoint shape.
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+  # Covers E6 disposition replies (and any other reply/edit/delete on a
+  # review thread): Clause 2 of the verdict is "every advisory-bot
+  # thread resolved or dispositioned", which changes exactly when one of
+  # these events fires, not just on a new push or review submission.
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to re-check (e.g. after posting a maintainer waiver)
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+concurrency:
+  # Grouped by PR number, not github.ref: pull_request_review and
+  # pull_request_review_comment are not pull_request-family events, so
+  # github.ref does not resolve the same way for them as it does for
+  # lint.yml's pull_request-only trigger. cancel-in-progress stays true
+  # deliberately: a narrower group or cancel-in-progress:false both trade
+  # this race for an equally-racy alternative rather than closing it (see
+  # upstream idd-skill#1381) -- if the rollup ever appears stuck on a
+  # stale run for the current HEAD SHA, `gh run rerun <run-id>` on the
+  # existing pull_request-family run for that SHA is the known recovery.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+jobs:
+  # The job id doubles as this check's required-status-check context name
+  # and as the `ciGate.externalChecks.waivable[].selector` value in
+  # `.github/idd/config.json` -- keep both in sync if this id ever
+  # changes. Branch-protection registration itself is out of scope here
+  # (tracked separately in #61, which is blocked on this workflow
+  # existing first).
+  idd-advisory-convergence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Run advisory-convergence verdict (--assert)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+            idd-advisory-convergence --pr "$PR_NUMBER" --assert

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -115,6 +115,9 @@ jobs:
             fi
           else
             echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT with no parseable JSON; posting helper-error evidence"
+            echo "::group::idd-audit-pr-cleanup stderr"
+            cat cleanup-stderr.log || true
+            echo "::endgroup::"
             STATUS="helper-error"
             APPLIED=0
             FAILED=0

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -1,0 +1,168 @@
+# Trust model: this workflow triggers on `pull_request_target`, which runs
+# with base-repository permissions and secrets even for pull requests from
+# forks. That is safe here only because all of the following hold, and any
+# future edit to this file must preserve them:
+#   - No unreviewed PR-head content is ever checked out: the sole
+#     `actions/checkout` step below carries no `ref:` override, so it
+#     resolves to the `pull_request_target` default -- the base branch's
+#     tip at event time. Because the job only proceeds after an explicit
+#     merged check (see the `Verify merged` step for workflow_dispatch,
+#     and the job-level `if:` for the pull_request_target trigger), that
+#     tip already includes this PR's own merge -- it is never the PR's
+#     own head SHA, and never content that has not already passed
+#     through the merge decision.
+#   - No PR-head code, workflow, or action is ever executed: under this
+#     repository's `ephemeral-npx` helper-runtime profile, the cleanup
+#     logic (`idd-audit-pr-cleanup`) runs from the pinned upstream npm
+#     tarball below, never from a checked-out copy -- so a PR editing its
+#     own copy of that script (if one even existed in this repository,
+#     which it does not) could not affect this workflow. The PR number is
+#     passed as `env:`-sourced numeric data, never interpolated into the
+#     script body.
+#   - The `cleanup` job only runs when
+#     `github.event.pull_request.merged == true`, or via an explicit,
+#     human-triggered `workflow_dispatch` that re-verifies merged status
+#     itself before doing anything else -- never against an open or
+#     unmerged pull request.
+#   - `permissions:` stays least-privilege: `contents: read`,
+#     `issues: write`, `pull-requests: write` -- no `contents: write` and
+#     no elevated or secret-bearing scopes.
+# If a future change adds a `ref:` override on the checkout step, downloads
+# or executes PR-head content, widens `permissions:`, or removes the
+# merged-only guard, re-review this trust model before merging that change.
+#
+# Note: this file is read from the base branch for `pull_request_target`,
+# so it cannot run for the PR that first introduces it -- that PR's own
+# F4 cleanup must be done through the normal IDD flow instead. This
+# workflow only takes effect for PRs merged after it lands on `master`.
+name: Post-merge cleanup
+on:
+  pull_request_target:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to clean up
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+concurrency:
+  group: post-merge-cleanup-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+jobs:
+  cleanup:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Verify merged (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          MERGED=$(gh pr view "$PR_NUMBER" --json merged -q '.merged')
+          if [ "$MERGED" != "true" ]; then
+            echo "::error::PR #${PR_NUMBER} is not merged; refusing to run F4 cleanup via manual dispatch."
+            exit 1
+          fi
+      - name: Run F4 cleanup (server-side fallback)
+        id: cleanup
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set +e
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::PR_NUMBER is empty"
+            exit 1
+          fi
+          JSON=$(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+            idd-audit-pr-cleanup \
+            --pr "$PR_NUMBER" \
+            --apply \
+            --skip-claim-check \
+            --format json 2>cleanup-stderr.log)
+          HELPER_EXIT=$?
+          set -e
+          # Prefer the helper's JSON report when it is parseable, even on
+          # non-zero exit (the helper writes the report then exits 1 when
+          # failed.length > 0, so the report is still authoritative).
+          PARSED_STATUS=""
+          if [ -n "$JSON" ]; then
+            PARSED_STATUS=$(printf '%s' "$JSON" | jq -r '.status // ""' 2>/dev/null || echo "")
+          fi
+          if [ -n "$PARSED_STATUS" ]; then
+            printf '%s\n' "$JSON" > cleanup-report.json
+            STATUS="$PARSED_STATUS"
+            APPLIED=$(printf '%s' "$JSON" | jq -r '(.applied // []) | length')
+            FAILED=$(printf '%s' "$JSON" | jq -r '(.failed // []) | length')
+            SKIPPED=$(printf '%s' "$JSON" | jq -r '(.skipped // []) | length')
+            BLOCKED=$(printf '%s' "$JSON" | jq -r '[(.skipped // [])[] | select(.isMinimized==false and .viewerCanMinimize==false)] | length')
+            if [ "$HELPER_EXIT" -ne 0 ]; then
+              echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
+            fi
+          else
+            echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT with no parseable JSON; posting helper-error evidence"
+            STATUS="helper-error"
+            APPLIED=0
+            FAILED=0
+            SKIPPED=0
+            BLOCKED=0
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "status=$STATUS"
+            echo "applied=$APPLIED"
+            echo "failed=$FAILED"
+            echo "skipped=$SKIPPED"
+            echo "blocked=$BLOCKED"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post cleanup evidence comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cleanup.outputs.pr_number }}
+          STATUS: ${{ steps.cleanup.outputs.status }}
+          APPLIED: ${{ steps.cleanup.outputs.applied }}
+          FAILED: ${{ steps.cleanup.outputs.failed }}
+          SKIPPED: ${{ steps.cleanup.outputs.skipped }}
+          BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+        run: |
+          # Avoid duplicate evidence comments. Workflow-level concurrency
+          # only serialises this workflow's own runs; an agent F4 (or a
+          # maintainer rerunning workflow_dispatch on the same PR) can
+          # still have posted an evidence comment outside this run. Skip
+          # if any <!-- idd-cleanup-evidence: ... --> comment is already
+          # on the PR.
+          EXISTING=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id' \
+            | head -n1)
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #${PR_NUMBER} already has an idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+            exit 0
+          fi
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+            "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
+            "| Field              | Value |" \
+            "| ------------------ | ----- |" \
+            "| Status             | ${STATUS} |" \
+            "| Applied            | ${APPLIED} |" \
+            "| Failed             | ${FAILED} |" \
+            "| Skipped            | ${SKIPPED} |" \
+            "| Permission-blocked | ${BLOCKED} |" \
+            "| Posted by          | post-merge-cleanup workflow |" \
+          )
+          printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -44,6 +44,57 @@ recorded in `.github/idd/config.json`)
 - **generation timeout**: `PT10M` (matches the distributed default)
 - **rerun policy**: `rerun-once`
 
+### CI Gate (External Checks)
+
+- **Required-check gate**: `.github/workflows/idd-advisory-convergence.yml`
+  (job id `idd-advisory-convergence`) asserts that the primary advisory
+  bot's review has converged on the current PR HEAD, turning the F2
+  advisory/disposition sub-gate into a non-bypassable GitHub status
+  check. Branch-protection registration of this check as a required
+  status check is tracked separately in #61 (human-blocked; this
+  workflow must exist first).
+- **`ciGate.externalChecks.waivable`**: `[{ "selector":
+  "idd-advisory-convergence" }]` — this repository's only waivable
+  external check.
+- **`ciGate.externalCheckWaivers.mode`**: `maintainer-authorized`
+  (repository override; distributed default is `disabled`). All other
+  `externalCheckWaivers` fields (`authorityPolicy`, `maxValidity`) are
+  not overridden and use the bundle's distributed defaults
+  (`owners-and-maintainers-only`, `PT24H`).
+- **Not yet live until this change merges**: `idd-advisory-convergence.yml`
+  reads `.github/idd/config.json` from `master`, so this `ciGate`
+  addition only takes effect once this PR itself merges. A waiver
+  posted against the PR that introduces it would fail closed as an
+  unknown selector.
+- **Waiver path**: when installed, prefer the helper facade over
+  hand-writing marker comments:
+
+  ```sh
+  npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+    idd-external-check-waiver --pr <number> \
+    --check idd-advisory-convergence \
+    --reason "<short reason>" \
+    --expires-in PT2H \
+    --apply --yes
+  ```
+
+  **Posting a waiver comment alone does not turn the check green.** A PR
+  comment is not one of `idd-advisory-convergence.yml`'s trigger events,
+  and a completed run's conclusion never changes on its own — after
+  posting a valid waiver, re-run the check via
+  `gh run rerun <run-id>` on the existing `pull_request`-family run for
+  the current HEAD SHA (found via `gh run list
+  --workflow=idd-advisory-convergence.yml --json
+  databaseId,headSha,event,url`), or `workflow_dispatch` if no such run
+  exists yet for that HEAD.
+- **Post-merge cleanup**: `.github/workflows/post-merge-cleanup.yml`
+  runs F4 cleanup (`idd-audit-pr-cleanup --apply --skip-claim-check`) as
+  a server-side fallback after a PR merges, in case the merging session
+  did not reach F4 itself. It cannot run for the PR that first
+  introduces it (GitHub reads `pull_request_target` workflow files from
+  the base branch) — that PR's own F4 cleanup goes through the normal
+  IDD flow instead.
+
 ### Credential Scope
 
 **Worker credentials**: same scope as any other IDD session running in

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -85,8 +85,13 @@ recorded in `.github/idd/config.json`)
   `gh run rerun <run-id>` on the existing `pull_request`-family run for
   the current HEAD SHA (found via `gh run list
   --workflow=idd-advisory-convergence.yml --json
-  databaseId,headSha,event,url`), or `workflow_dispatch` if no such run
-  exists yet for that HEAD.
+  databaseId,headSha,event,url`). **Prefer this over `workflow_dispatch`**:
+  a manually dispatched run is not reliably associated with the PR's own
+  HEAD SHA / required-check rollup (GitHub can attribute it to the
+  default branch instead), so even a successful dispatched run may not
+  actually clear the check. If no `pull_request`-family run exists yet
+  for this HEAD, trigger one first (a new push, or re-opening the PR)
+  rather than falling back to `workflow_dispatch`.
 - **Post-merge cleanup**: `.github/workflows/post-merge-cleanup.yml`
   runs F4 cleanup (`idd-audit-pr-cleanup --apply --skip-claim-check`) as
   a server-side fallback after a PR merges, in case the merging session


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/idd-advisory-convergence.yml`: a required-check
  gate (job id `idd-advisory-convergence`) that asserts the primary
  advisory bot's review has converged on the current PR HEAD, turning
  the F2 advisory/disposition sub-gate into a non-bypassable GitHub
  status check
- Adds `.github/workflows/post-merge-cleanup.yml`: a server-side F4
  cleanup fallback that runs after a PR merges, in case the merging
  session did not reach F4 itself
- Adds `ciGate.externalChecks.waivable` /
  `ciGate.externalCheckWaivers.mode: "maintainer-authorized"` to
  `.github/idd/config.json`
- Documents the waiver path (helper command + the "posting a waiver
  alone doesn't turn the check green, must re-run" caveat) in
  `docs/idd-policy.md`

Closes #60.

## Adaptation notes (diverges from both upstream references)

I read two upstream reference implementations before writing these
files: the portable `idd-template/.github/workflows/*.yml` mirror, and
upstream's own dogfooded (source-repo) copies. Neither was copied
as-is — both needed adaptation to this repository's constraints:

- **`runs-on: ubuntu-latest` for both jobs**, not the repository's
  existing `ubuntu-slim` lint runner (`lint.yml`'s `lint` job) or
  upstream's own `ubuntu-slim`. Per the issue's own proposed-change
  text: these jobs use `npx` (to fetch the pinned helper package) and
  `gh`/`jq`, which `ubuntu-slim` cannot be assumed to carry.
- **`node scripts/*.mjs` → pinned `npx` invocations.** This repository
  uses the `ephemeral-npx` helper-runtime profile
  (`.github/idd/config.json`'s `helperRuntime.profile`), not vendored
  scripts, so every upstream `node scripts/advisory-convergence.mjs`/
  `node scripts/audit-pr-cleanup.mjs` call became
  `npx --yes --package
  https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
  idd-advisory-convergence`/`idd-audit-pr-cleanup` (verified both bin
  names resolve via `--help` before writing the YAML).
- **`node-version-file: .nvmrc`** via `actions/setup-node@v6`, not
  upstream's hardcoded `node-version: 24.x` — this repository's `.nvmrc`
  (added in #56) is the source of truth for the pinned Node version.
- **Tag-form actions** (`actions/checkout@v7`, `actions/setup-node@v6`),
  matching this repository's existing `lint.yml` convention, not
  upstream's SHA-pinned actions.
- **`ref: master`**, not upstream's `ref: main` — this repository's
  default branch.
- **Trust-model header comments were rewritten, not copied**, because
  the `ephemeral-npx` profile changes what the checkout step actually
  protects: under upstream's own profile, the checkout supplies the
  trusted *script*; here the script never touches the checkout at all
  (it runs from the pinned npm tarball), so the checkout's only job is
  supplying a trusted `.github/idd/config.json`. Also corrected: an
  earlier draft of `idd-advisory-convergence.yml`'s header claimed this
  file is read from the base branch for `pull_request` the way
  `pull_request_target` files are — that's wrong (`pull_request` runs
  the PR's own copy of the workflow file, which is precisely why
  `pull_request_target` exists as a separate trigger). The corrected
  comment states what's actually protected here: the `config.json`
  checkout pin, the tarball-only script execution, and (once #61 lands)
  required-checks' fail-closed-on-absence behavior — not self-protection
  of this file's own content.
- **`post-merge-cleanup.yml`'s PR-number handling passes the number via
  `env:` in every step** (`Verify merged`, `Run F4 cleanup`), not
  interpolated into the shell script body — same for
  `idd-advisory-convergence.yml`'s single run step. Upstream's own
  dogfooded copy interpolates directly; I kept the `env:`-indirection
  the issue's own proposed-change text calls for.
- **`post-merge-cleanup.yml`'s `workflow_dispatch` path re-verifies
  merged status itself** (`gh pr view --json merged`, fails closed if
  false) before running cleanup — upstream's `if:` guard only checks
  `github.event.pull_request.merged == true` for the
  `pull_request_target` trigger and treats any `workflow_dispatch` as
  implicitly authorized. This repository's version does not extend that
  trust to a dispatch against an unmerged PR.

## Known limitations (by design, not gaps)

- **`post-merge-cleanup.yml` cannot run for this PR.** GitHub resolves
  `pull_request_target` workflow files from the *base* branch, which
  won't have this file until after this PR merges. This PR's own F4
  cleanup goes through the normal IDD flow instead, not this workflow.
- **The new `ciGate` block in `config.json` is not live for this PR
  either.** `idd-advisory-convergence.yml` reads
  `.github/idd/config.json` from `master` (via the pinned `ref: master`
  checkout), so the waivable-check registration only takes effect once
  this PR merges. A waiver posted against this PR would fail closed as
  an unknown selector — documented in `docs/idd-policy.md`.
- **`idd-advisory-convergence.yml` will run against this PR and may
  report red before Copilot has reviewed HEAD.** That is the intended
  behavior (a "pending" advisory-convergence verdict has no distinct
  non-failing GitHub Actions check state), not a bug in the check.
  Branch protection does not yet require this check (tracked separately
  in #61, human-blocked, which depends on this workflow existing
  first), so it does not block this PR's own merge gate.

## Verification

- `actionlint` passes clean on both new workflow files
- `node -e 'JSON.parse(...)'` confirms `config.json` stays valid JSON;
  `idd-doctor.mjs --json` confirms `.github/idd/config.json` still
  validates against `policy.schema.json` after the `ciGate` addition
- Verified both `idd-advisory-convergence` and `idd-audit-pr-cleanup`
  bin names resolve via the pinned `npx --package <tarball> <bin>
  --help` form before referencing them in YAML
- `pre-push-validate` (markdownlint-cli2 + cspell + PSScriptAnalyzer)
  exits 0 on a clean worktree

## Test plan

- [x] Both workflow files exist and pass `actionlint` schema validation
- [x] Both npx package specs pinned to
      `4e8c7043edcb00dd8447dee83e7a17e5b2604d5d`
- [x] `idd-advisory-convergence.yml`: `contents: read` /
      `issues: read` / `pull-requests: read` only
- [x] `post-merge-cleanup.yml`: `contents: read` / `issues: write` /
      `pull-requests: write` only
- [x] No `ref:` override on `post-merge-cleanup.yml`'s checkout step
- [x] Trust-boundary header comments present on both files
- [x] `config.json`'s `ciGate` addition passes schema validation
- [x] `docs/idd-policy.md` documents the waiver path and the
      not-yet-live caveat
- [x] `pre-push-validate` exits 0 on a clean worktree
- [ ] After push: confirm `idd-advisory-convergence` is scheduled via
      `gh run list --workflow=idd-advisory-convergence.yml` and produces
      a verdict (not-ready failure is fine; a crash or zero-jobs-
      scheduled result is not)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated advisory-convergence checks for pull request updates, reviews, comments, and manual runs.
  - Added automated cleanup after merged pull requests, including status reporting and deduplicated evidence comments.
- **Bug Fixes**
  - Improved handling of cleanup results, including partial failures and non-zero command outcomes.
- **Documentation**
  - Documented required checks, authorized waiver procedures, rerun requirements, activation timing, and post-merge cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->