### PR TITLE
feat(dsc): restore missing Windows settings as DSC resources

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -26,7 +26,8 @@ setup.cmd                        ← 唯一のエントリーポイント
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
             │    └─ Docker Desktop → イメージ pull
-            └─ Phase 6: Windows Update & 後処理
+            ├─ Phase 6: リモートデスクトップ         (Enable-RemoteDesktop)
+            └─ Phase 7: Windows Update & 後処理
 ```
 
 ## OS サポート

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ setup.cmd                        ← single entry point
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
             │    └─ Docker Desktop → image pulls
-            └─ Phase 6: Windows Update & teardown
+            ├─ Phase 6: Remote Desktop            (Enable-RemoteDesktop)
+            └─ Phase 7: Windows Update & teardown
 ```
 
 ## OS Support

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -87,10 +87,22 @@ if (Test-Path $postInstall) {
 }
 
 ###########################################################################
-### Phase 6 — Teardown
+### Phase 6 — Remote Desktop
 ###########################################################################
-Write-Host '[Phase 6] Finalizing...' -ForegroundColor Cyan
+# Not declarable as a PSDscResources/Registry resource: Boxstarter's
+# Enable-RemoteDesktop calls the Win32_TerminalServiceSetting /
+# Win32_TSGeneralSetting WMI methods (SetAllowTsConnections,
+# SetUserAuthenticationRequired), not a direct registry write. See
+# docs/dsc-migration-notes.md for the full rationale.
+Write-Host '[Phase 6] Enabling Remote Desktop...' -ForegroundColor Cyan
+Enable-RemoteDesktop
+Write-Host '[Phase 6] Remote Desktop enabled.' -ForegroundColor Green
+
+###########################################################################
+### Phase 7 — Teardown
+###########################################################################
+Write-Host '[Phase 7] Finalizing...' -ForegroundColor Cyan
 Enable-MicrosoftUpdate
 Enable-UAC
 Install-WindowsUpdate
-Write-Host '[Phase 6] Setup complete!' -ForegroundColor Green
+Write-Host '[Phase 7] Setup complete!' -ForegroundColor Green

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -38,6 +38,422 @@ properties:
         Force: true
 
     # ================================================================
+    # Windows Explorer / Taskbar / Search UI settings
+    # Restored from the pre-migration boxstarter.ps1's Boxstarter setting
+    # commands (Set-WindowsExplorerOptions, Set-BoxstarterTaskbarOptions)
+    # and its direct Explorer/Taskbar Set-ItemProperty calls. See
+    # docs/dsc-migration-notes.md for the source-to-resource mapping.
+    # ================================================================
+    - resource: PSDscResources/Registry
+      id: explorer.showHiddenFiles
+      directives:
+        description: Show hidden files, folders, and drives in Explorer
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: Hidden
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.showFileExtensions
+      directives:
+        description: Show file extensions for known file types in Explorer
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: HideFileExt
+        ValueType: Dword
+        ValueData: "0"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.navPaneExpandToCurrentFolder
+      directives:
+        description: Expand Explorer's navigation pane to the current folder
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: NavPaneExpandToCurrentFolder
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.separateProcess
+      directives:
+        description: Launch folder windows in a separate process
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: SeparateProcess
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.showCompColor
+      directives:
+        description: Show encrypted or compressed NTFS files in color
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: ShowCompColor
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.showRecentInQuickAccess
+      directives:
+        description: Show recently used files in Quick Access
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer
+        ValueName: ShowRecent
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.showFrequentInQuickAccess
+      directives:
+        description: Show frequently used folders in Quick Access
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer
+        ValueName: ShowFrequent
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: explorer.hideRibbon
+      directives:
+        description: Keep Explorer's ribbon minimized outside tablet mode
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Ribbon
+        ValueName: MinimizedStateTabletModeOff
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: taskbar.multiMonitorEnabled
+      directives:
+        description: Show the taskbar on all monitors
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: MMTaskbarEnabled
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: taskbar.multiMonitorMode
+      directives:
+        description: Show all taskbar buttons on every monitor
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: MMTaskbarMode
+        ValueType: Dword
+        ValueData: "0"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: taskbar.multiMonitorGlomLevel
+      directives:
+        description: Always combine taskbar buttons on every monitor
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+        ValueName: MMTaskbarGlomLevel
+        ValueType: Dword
+        ValueData: "0"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: search.searchboxTaskbarMode
+      directives:
+        description: Show the search box on the taskbar
+        securityContext: current
+      settings:
+        Key: HKCU:\Software\Microsoft\Windows\CurrentVersion\Search
+        ValueName: SearchboxTaskbarMode
+        ValueType: Dword
+        ValueData: "1"
+        Ensure: Present
+        Force: true
+
+    # ================================================================
+    # Disk Cleanup sageset registrations
+    # Restored from the pre-migration boxstarter.ps1. Each entry marks
+    # one Disk Cleanup category as selected for cleanmgr's sageset 1
+    # (StateFlags0001). See docs/dsc-migration-notes.md for the source.
+    # ================================================================
+    - resource: PSDscResources/Registry
+      id: sageset.activeSetupTempFolders
+      directives:
+        description: "Disk Cleanup sageset: Active Setup Temp Folders"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Active Setup Temp Folders"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.branchCache
+      directives:
+        description: "Disk Cleanup sageset: BranchCache"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\BranchCache"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.d3dShaderCache
+      directives:
+        description: "Disk Cleanup sageset: D3D Shader Cache"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\D3D Shader Cache"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.deliveryOptimizationFiles
+      directives:
+        description: "Disk Cleanup sageset: Delivery Optimization Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Delivery Optimization Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.diagnosticDataViewerDatabaseFiles
+      directives:
+        description: "Disk Cleanup sageset: Diagnostic Data Viewer database files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Diagnostic Data Viewer database files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.downloadedProgramFiles
+      directives:
+        description: "Disk Cleanup sageset: Downloaded Program Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Downloaded Program Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.internetCacheFiles
+      directives:
+        description: "Disk Cleanup sageset: Internet Cache Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Internet Cache Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.oldChkDskFiles
+      directives:
+        description: "Disk Cleanup sageset: Old ChkDsk Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Old ChkDsk Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.recycleBin
+      directives:
+        description: "Disk Cleanup sageset: Recycle Bin"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Recycle Bin"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.retailDemoOfflineContent
+      directives:
+        description: "Disk Cleanup sageset: RetailDemo Offline Content"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\RetailDemo Offline Content"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.setupLogFiles
+      directives:
+        description: "Disk Cleanup sageset: Setup Log Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Setup Log Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.systemErrorMemoryDumpFiles
+      directives:
+        description: "Disk Cleanup sageset: System error memory dump files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\System error memory dump files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.systemErrorMinidumpFiles
+      directives:
+        description: "Disk Cleanup sageset: System error minidump files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\System error minidump files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.temporaryFiles
+      directives:
+        description: "Disk Cleanup sageset: Temporary Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Temporary Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.thumbnailCache
+      directives:
+        description: "Disk Cleanup sageset: Thumbnail Cache"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Thumbnail Cache"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.updateCleanup
+      directives:
+        description: "Disk Cleanup sageset: Update Cleanup"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Update Cleanup"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.userFileVersions
+      directives:
+        description: "Disk Cleanup sageset: User file versions"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\User file versions"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.windowsDefender
+      directives:
+        description: "Disk Cleanup sageset: Windows Defender"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Windows Defender"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    - resource: PSDscResources/Registry
+      id: sageset.windowsErrorReportingFiles
+      directives:
+        description: "Disk Cleanup sageset: Windows Error Reporting Files"
+        securityContext: elevated
+      settings:
+        Key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VolumeCaches\\Windows Error Reporting Files"
+        ValueName: StateFlags0001
+        ValueType: Dword
+        ValueData: "2"
+        Ensure: Present
+        Force: true
+
+    # ================================================================
     # Package managers & dependencies
     # ================================================================
     - resource: Microsoft.WinGet.DSC/WinGetPackage

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1,8 +1,10 @@
 # DSC Migration Notes
 
 This document records what happened to each file removed when
-`migrate-to-dsc` was merged into `master` (issue #63), and lists the
-Windows configuration processing that has no replacement yet.
+`migrate-to-dsc` was merged into `master` (issue #63), and the
+disposition of the Windows configuration processing that had no DSC
+equivalent at that point (declared as a DSC resource by issue #64, or
+recorded as staying imperative and why).
 
 ## Removed files and their relocation
 
@@ -21,13 +23,15 @@ Windows configuration processing that has no replacement yet.
 | `t/deploy.ps1` | Not relocated. Deployed `t/sw-launcher.cmd` into the `Vagrantfile` VM for the manual E2E flow; removed alongside `Vagrantfile` / `test` for the same reason. |
 | `t/sw-launcher.cmd` | Not relocated. Launched `setup.cmd` from inside the `Vagrantfile` VM as part of the manual E2E flow; removed alongside `Vagrantfile` / `test` for the same reason. |
 
-## Windows configuration processing with no DSC replacement (as of this merge)
+## Disposition of the remaining Windows configuration processing
 
-The following processing existed in the pre-migration `boxstarter.ps1`
-but has no equivalent in `configurations/packages.dsc.yaml`,
-`configurations/packages.min.dsc.yaml`, or `libs/*.ps1` after this
-merge. Restoring these is out of scope for issue #63 (tracked by
-roadmap #62's #64).
+Issue #63 left the following pre-migration `boxstarter.ps1` processing
+without a DSC equivalent. Issue #64 investigated each item against
+Boxstarter's own source (`chocolatey/boxstarter`,
+`Boxstarter.WinConfig/*.ps1`) and, for each, either declared it as a
+`PSDscResources/Registry` resource in `configurations/packages.dsc.yaml`,
+restored it imperatively, or recorded why it should not be restored at
+all.
 
 ### Boxstarter setting commands (5)
 
@@ -41,41 +45,121 @@ Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowFileEx
 Enable-RemoteDesktop
 ```
 
+Disposition of each command:
+
+- **`Set-ExplorerOptions -showHiddenFilesFoldersDrives -showFileExtensions`**
+  — Not declared as a separate resource. This cmdlet is deprecated in
+  Boxstarter's own source and internally forwards to
+  `Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives
+  -EnableShowFileExtensions`, writing the exact same
+  `Explorer\Advanced\Hidden` / `HideFileExt` values as the fourth
+  command below. The original script called both, so this call was
+  fully redundant; declaring `explorer.showHiddenFiles` /
+  `explorer.showFileExtensions` once (from the fourth command) covers
+  it without duplication.
+- **`Set-StartScreenOptions ...`** — Not declared. All five switches
+  this call sets (`OpenAtLogon`, `MonitorOverride`, `MakeAllAppsDefault`,
+  `GlobalSearchInApps`, `DesktopFirst`) write under
+  `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage`,
+  a Windows 8/8.1 Start *Screen* key. Boxstarter's own implementation
+  guards every write with `if (Test-Path -Path $startPageKey)`; on
+  Windows 10/11 — the only OS tier this repository's
+  `Microsoft.Windows.Developer/OsVersion` assertion (build 19045+)
+  supports — that key does not exist, so the pre-migration script
+  wrote nothing here on any machine this repo targets. Declaring it as
+  a `Force: true` DSC resource would *create* registry state the old
+  script never created, which is a behavior change, not a faithful
+  migration. Not declared, and not restored to `boxstarter.ps1` either
+  (the call was already absent after #63's rewrite — this only
+  documents why it stays absent). This is the one command in this list
+  where the discriminating fact is that its target key is dead across
+  the *entire* supported OS range; `Explorer\Advanced`, `Explorer`,
+  and `Explorer\Ribbon` (used by the declared resources below) are all
+  live on Windows 10 22H2+, so the same `Test-Path`-guard concern does
+  not apply to them.
+- **`Set-BoxstarterTaskbarOptions -MultiMonitorOn -MultiMonitorMode All
+  -MultiMonitorCombine Always`** — Declared as
+  `taskbar.multiMonitorEnabled` (`MMTaskbarEnabled=1`),
+  `taskbar.multiMonitorMode` (`MMTaskbarMode=0`), and
+  `taskbar.multiMonitorGlomLevel` (`MMTaskbarGlomLevel=0`), all under
+  `HKCU:\...\Explorer\Advanced`. The function also has a
+  byte-array-manipulation branch (`StuckRects2\Settings`) for
+  dock/auto-hide switches, but the original call never used those
+  switches, so it isn't represented here. The function ends with
+  `Restart-Explorer`, which DSC does not replicate — the setting takes
+  effect at next sign-in instead of immediately.
+- **`Set-WindowsExplorerOptions ...`** — Declared as
+  `explorer.showHiddenFiles` (`Advanced\Hidden=1`),
+  `explorer.showFileExtensions` (`Advanced\HideFileExt=0`),
+  `explorer.navPaneExpandToCurrentFolder`
+  (`Advanced\NavPaneExpandToCurrentFolder=1`),
+  `explorer.showRecentInQuickAccess` (`Explorer\ShowRecent=1`),
+  `explorer.showFrequentInQuickAccess` (`Explorer\ShowFrequent=1`), and
+  `explorer.hideRibbon` (`Explorer\Ribbon\MinimizedStateTabletModeOff=1`).
+  This function also ends with `Restart-Explorer` (same caveat as
+  above).
+- **`Enable-RemoteDesktop`** — Not declared; kept as a literal call in
+  `boxstarter.ps1`'s Phase 6. Boxstarter's implementation enables
+  Remote Desktop through WMI method calls
+  (`Win32_TerminalServiceSetting.SetAllowTsConnections`,
+  `Win32_TSGeneralSetting.SetUserAuthenticationRequired`), not a direct
+  registry write, so `PSDscResources/Registry` cannot express it.
+  (Its own doc comment also claims it enables a firewall rule, but the
+  implementation contains no firewall-rule code — that claim is not
+  repeated here since it wasn't verified against the source.)
+
 ### Explorer / Search registry values (4)
 
-| Registry path | Value name | Type | Value |
-| --- | --- | --- | --- |
-| `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `NavPaneExpandToCurrentFolder` | DWord (implicit via `Set-ItemProperty`) | `1` |
-| `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `SeparateProcess` | DWord (implicit via `Set-ItemProperty`) | `1` |
-| `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `ShowCompColor` | DWord (implicit via `Set-ItemProperty`) | `1` |
-| `HKCU:\Software\Microsoft\Windows\CurrentVersion\Search` | `SearchboxTaskbarMode` | DWord (implicit via `Set-ItemProperty`) | `1` |
+Declared in `configurations/packages.dsc.yaml`, all HKCU /
+`securityContext: current`:
+
+| Resource id | Registry path | Value name | Type | Value |
+| --- | --- | --- | --- | --- |
+| `explorer.navPaneExpandToCurrentFolder` | `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `NavPaneExpandToCurrentFolder` | Dword | `1` |
+| `explorer.separateProcess` | `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `SeparateProcess` | Dword | `1` |
+| `explorer.showCompColor` | `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced` | `ShowCompColor` | Dword | `1` |
+| `search.searchboxTaskbarMode` | `HKCU:\Software\Microsoft\Windows\CurrentVersion\Search` | `SearchboxTaskbarMode` | Dword | `1` |
 
 ### Disk Cleanup sageset registrations (19)
 
-All 19 entries share the same registry shape: base path
+Declared in `configurations/packages.dsc.yaml` as `sageset.<slug>`, all
+HKLM / `securityContext: elevated`. All 19 entries share the same
+registry shape: base path
 `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\<name>`,
-value name `StateFlags0001`, type `DWord`, value `2`.
+value name `StateFlags0001`, type `Dword`, value `2`. `Force: true`
+follows the same style as the resources above; on a system where a
+given `VolumeCaches\<name>` subkey does not already exist, it will
+create the key rather than fail.
 
-`<name>` values:
+| Resource id | `<name>` |
+| --- | --- |
+| `sageset.activeSetupTempFolders` | Active Setup Temp Folders |
+| `sageset.branchCache` | BranchCache |
+| `sageset.d3dShaderCache` | D3D Shader Cache |
+| `sageset.deliveryOptimizationFiles` | Delivery Optimization Files |
+| `sageset.diagnosticDataViewerDatabaseFiles` | Diagnostic Data Viewer database files |
+| `sageset.downloadedProgramFiles` | Downloaded Program Files |
+| `sageset.internetCacheFiles` | Internet Cache Files |
+| `sageset.oldChkDskFiles` | Old ChkDsk Files |
+| `sageset.recycleBin` | Recycle Bin |
+| `sageset.retailDemoOfflineContent` | RetailDemo Offline Content |
+| `sageset.setupLogFiles` | Setup Log Files |
+| `sageset.systemErrorMemoryDumpFiles` | System error memory dump files |
+| `sageset.systemErrorMinidumpFiles` | System error minidump files |
+| `sageset.temporaryFiles` | Temporary Files |
+| `sageset.thumbnailCache` | Thumbnail Cache |
+| `sageset.updateCleanup` | Update Cleanup |
+| `sageset.userFileVersions` | User file versions |
+| `sageset.windowsDefender` | Windows Defender |
+| `sageset.windowsErrorReportingFiles` | Windows Error Reporting Files |
 
-```text
-Active Setup Temp Folders
-BranchCache
-D3D Shader Cache
-Delivery Optimization Files
-Diagnostic Data Viewer database files
-Downloaded Program Files
-Internet Cache Files
-Old ChkDsk Files
-Recycle Bin
-RetailDemo Offline Content
-Setup Log Files
-System error memory dump files
-System error minidump files
-Temporary Files
-Thumbnail Cache
-Update Cleanup
-User file versions
-Windows Defender
-Windows Error Reporting Files
-```
+### min profile inclusion
+
+None of the resources above are included in
+`configurations/packages.min.dsc.yaml`. The min profile's existing
+non-package resources (`windows11-native-nvme-driver-{1,2,3}`) enable
+hardware functionality that can matter for correct operation on
+affected devices; the Explorer/Taskbar/Search/sageset resources above
+are convenience UI/cleanup preferences with no functional necessity.
+Keeping the min profile limited to packages plus that one
+hardware-enablement exception preserves its "minimal" intent.


### PR DESCRIPTION
## Summary

Closes #64.

Issue #63 left 5 Boxstarter setting commands, 4 standalone Explorer/
Search registry values, and 19 Disk Cleanup sageset entries without a
DSC equivalent (recorded in `docs/dsc-migration-notes.md` at
restoration-ready granularity). This PR investigates each of the 5
commands against Boxstarter's own source
([`chocolatey/boxstarter`](https://github.com/chocolatey/boxstarter),
`Boxstarter.WinConfig/*.ps1`) and gives every one of the original
5/4/19 items an explicit disposition.

## What changed

- **`configurations/packages.dsc.yaml`**: 31 new
  `PSDscResources/Registry` resources.
  - 12 Explorer/Taskbar/Search values (HKCU,
    `securityContext: current`): the 3 previously-documented
    standalone values (`explorer.separateProcess`,
    `explorer.showCompColor`, `search.searchboxTaskbarMode`) plus 9
    derived from `Set-BoxstarterTaskbarOptions`'s and
    `Set-WindowsExplorerOptions`'s actual invocation (see disposition
    notes below for the exact switch → value mapping).
  - 19 Disk Cleanup sageset registrations (HKLM,
    `securityContext: elevated`), `sageset.<slug>` per entry.
- **`boxstarter.ps1`**: new Phase 6 (`Enable-RemoteDesktop`, kept
  imperative — see below), pushing the former Phase 6 (Teardown) to
  Phase 7.
- **`docs/dsc-migration-notes.md`**: rewritten to record the
  disposition of all 5 Boxstarter commands, the exact resource id for
  every declared value, and the min-profile exclusion rationale. No
  `未移設` markers remain.
- **`README.md` / `README.ja.md`**: architecture diagrams updated for
  the new phase numbering.

## Disposition of the 5 Boxstarter commands

| Command | Disposition |
| --- | --- |
| `Set-ExplorerOptions -showHiddenFilesFoldersDrives -showFileExtensions` | Not declared separately — deprecated in Boxstarter's own source, forwards to `Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowFileExtensions`, which the original script also called directly (4th command below). Fully redundant; covered once. |
| `Set-StartScreenOptions ...` | **Not declared, not restored.** All 5 values (`OpenAtLogon`, `MonitorOverride`, `MakeAllAppsDefault`, `GlobalSearchInApps`, `DesktopFirst`) write under `Explorer\StartPage` — a Windows 8/8.1 Start *Screen* key. Boxstarter's own source guards every write with `if (Test-Path -Path $startPageKey)`, and that key does not exist on Windows 10/11 (this repo's supported range, build 19045+ per the `OsVersion` assertion). The pre-migration script wrote nothing here on any machine this repo targets; declaring it with `Force: true` would create registry state the old script never created — a behavior change, not a faithful migration. |
| `Set-BoxstarterTaskbarOptions -MultiMonitorOn -MultiMonitorMode All -MultiMonitorCombine Always` | Declared as `taskbar.multiMonitorEnabled`/`multiMonitorMode`/`multiMonitorGlomLevel`. (The function also has a byte-array `StuckRects2\Settings` branch for dock/auto-hide, unused by the original call, not represented.) |
| `Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowFileExtensions -EnableExpandToOpenFolder -EnableShowRecentFilesInQuickAccess -EnableShowFrequentFoldersInQuickAccess -DisableShowRibbon` | Declared as `explorer.showHiddenFiles`/`showFileExtensions`/`navPaneExpandToCurrentFolder`/`showRecentInQuickAccess`/`showFrequentInQuickAccess`/`hideRibbon`. |
| `Enable-RemoteDesktop` | **Not declared; restored imperatively** (new Phase 6 in `boxstarter.ps1`, unconditional — same as pre-migration). Boxstarter's implementation enables RDP through WMI method calls (`Win32_TerminalServiceSetting.SetAllowTsConnections`, `Win32_TSGeneralSetting.SetUserAuthenticationRequired`), not a direct registry write, so `PSDscResources/Registry` cannot express it. Its own doc comment also claims a firewall-rule side effect, but the implementation contains no firewall code — not repeated here since it wasn't verified. **Note for reviewers**: this restores pre-migration behavior as-is (RDP enabled, NLA required) — not a new decision introduced by this PR. |

Why `Explorer\StartPage` is excluded but `Explorer\Ribbon` (used by
`explorer.hideRibbon`) and the 19 `VolumeCaches` subkeys are not: the
discriminating fact is that `StartPage` is dead across the *entire*
supported OS range, whereas `Explorer`, `Explorer\Advanced`, and
`Explorer\Ribbon` are all live on Windows 10 22H2+. `Force: true` on
the sageset resources follows the same style as the rest of the file;
on a system where a given `VolumeCaches\<name>` subkey doesn't already
exist, it creates the key rather than fail.

## min profile

None of the 31 new resources are added to
`configurations/packages.min.dsc.yaml`. Rationale recorded in
`docs/dsc-migration-notes.md`: the min profile's existing non-package
exception (`windows11-native-nvme-driver-{1,2,3}`) enables hardware
functionality that can affect correct device operation; the
Explorer/Taskbar/Search/sageset resources are convenience UI/cleanup
preferences with no functional necessity, so they stay out of the
"minimal" profile.

## Verification

- `markdownlint-cli2 "**/*.md"` — 0 issues
- `cspell lint "**" --no-progress` — 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` — exit 0
- `configurations/packages.dsc.yaml` parses as valid YAML (verified
  with a Python `yaml.safe_load` check — 137 resources total, no
  duplicate `id`s) and every new resource's
  Key/ValueName/ValueType/ValueData was diffed against
  `docs/dsc-migration-notes.md`'s tables programmatically. Full
  `winget configure` schema validation against the real DSC schema
  requires Windows and was not run in this Linux environment.

## Test plan

- [x] The 4 previously-documented Explorer/Search registry values and
      the 19 sageset entries are declared with Key/ValueName/ValueType/
      ValueData matching `docs/dsc-migration-notes.md` exactly
- [x] All 19 sageset resources have `securityContext: elevated`
- [x] Each of the 5 Boxstarter commands has an explicit
      declarative-vs-imperative disposition recorded in
      `docs/dsc-migration-notes.md` (table above)
- [x] No `未移設` entries remain in `docs/dsc-migration-notes.md`
- [x] min-profile inclusion rationale is documented
- [x] YAML syntax validated (Python `yaml.safe_load`); full schema
      validation documented as unverifiable without Windows
- [x] `pre-push-validate` (markdownlint-cli2 + cspell + PSScriptAnalyzer)
      exits 0 on a clean worktree
