### PR TITLE
feat(setup): add side-effect-free winget configuration route probe

### DIFF
--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -32,6 +32,17 @@ $ARCH -like 'ARM64*' `
 ###########################################################################
 ### Phase 2 — WinGet Configuration (DSC)
 ###########################################################################
+. (Join-Path $scriptRoot 'libs\strategy.ps1')
+$strategy = Test-ConfigurationStrategy
+Write-Host "[Phase 2] Configuration route: $($strategy.Route) -- $($strategy.Reason)" -ForegroundColor Cyan
+if ($strategy.Route -eq 'unsupported') {
+  Write-Error 'Unsupported winget capability. Aborting setup.'
+  return
+}
+
+# Route selection is logged above for visibility only; the import route
+# still runs winget configure at this point (issue #65 scope). Acting on
+# the selected route (running winget import instead) is issue #67's scope.
 $dscFile = Join-Path $scriptRoot 'configurations\packages.dsc.yaml'
 if (Test-Path $dscFile) {
   Write-Host '[Phase 2] Applying WinGet Configuration (DSC)...' -ForegroundColor Cyan

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -36,7 +36,7 @@ $ARCH -like 'ARM64*' `
 $strategy = Test-ConfigurationStrategy
 Write-Host "[Phase 2] Configuration route: $($strategy.Route) -- $($strategy.Reason)" -ForegroundColor Cyan
 if ($strategy.Route -eq 'unsupported') {
-  Write-Error 'Unsupported winget capability. Aborting setup.'
+  Write-Error "Unsupported winget capability: $($strategy.Reason) Aborting setup."
   return
 }
 

--- a/libs/strategy.ps1
+++ b/libs/strategy.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+Decides, without side effects, which winget-based configuration route
+boxstarter.ps1 should use: the primary `dsc` route (`winget configure`
+against configurations/packages.dsc.yaml) or the degraded `import`
+route (`winget import` against the .import.json fallback).
+
+This file is dot-sourced (not imported as a module) from
+boxstarter.ps1's Phase 2 -- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+function Test-ConfigurationStrategy {
+  if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    return @{
+      Route  = 'unsupported'
+      Reason = 'winget was not found on PATH. The import.json route also depends on winget, so no route can run.'
+    }
+  }
+
+  $wingetVersion = (winget --version | Select-Object -First 1) -replace '^v', ''
+
+  winget configure --help *> $null
+  $configureAvailable = $LASTEXITCODE -eq 0
+
+  if ($configureAvailable) {
+    return @{
+      Route  = 'dsc'
+      Reason = "winget $wingetVersion recognizes the 'configure' subcommand (winget configure --help exited 0)."
+    }
+  }
+
+  return @{
+    Route  = 'import'
+    Reason = "winget $wingetVersion does not recognize the 'configure' subcommand (winget configure --help exited $LASTEXITCODE)."
+  }
+  <#
+  .SYNOPSIS
+  Tests which winget configuration route is available and returns the
+  selected route together with the evidence used to select it.
+
+  .DESCRIPTION
+  Candidates considered for the probe, and why `winget configure --help`
+  was the one chosen:
+  - winget command existence (Get-Command) -- kept. This is the
+    precondition for every route: import.json also depends on winget,
+    so a missing winget makes the whole setup unsupported regardless
+    of which route would otherwise be picked.
+  - `winget --version` compared against a known minimum -- rejected as
+    the primary signal. Which release made `configure` non-experimental
+    is a moving target tied to Microsoft's own release cadence; hard-
+    coding a version threshold here would silently go stale. The
+    version string is still captured and included in the reason text
+    as supporting evidence, not as the decision itself.
+  - `winget settings export`'s experimentalFeatures.configuration flag
+    -- rejected. Whether that flag exists or matters depends on the
+    installed winget's own settings schema, which has changed across
+    releases; parsing it is more brittle than asking winget directly
+    whether it recognizes the subcommand.
+  - `winget configure --help` exit code -- chosen. It asks winget
+    directly whether it recognizes the `configure` subcommand on this
+    machine, right now, without installing or changing anything.
+    Exit 0 means `configure` is available (dsc route); any non-zero
+    exit means it isn't (import route).
+
+  This function performs no installation and changes no configuration
+  -- every winget call here is a read-only `--help`/`--version`
+  invocation.
+
+  Route selection happens once, here, before any package installation
+  starts. It is intentionally NOT re-evaluated if `winget configure`
+  fails partway through Phase 2: a mid-run failure is either a bad
+  package ID or a transient single-package error, and neither is fixed
+  by silently switching to the import route -- id/source mismatches
+  fail identically under `winget import`, and transient failures are a
+  retry concern, not a routing concern. Re-routing after a partial
+  `winget configure` apply would also layer a second, differently-
+  scoped install operation on top of whatever the first one already
+  changed. See issue #65 for the full rationale.
+
+  .OUTPUTS
+  Hashtable with Route ('dsc' | 'import' | 'unsupported') and Reason
+  (string describing the evidence behind the selected route). Returning
+  a hashtable from a `Test-` function follows the same precedent as
+  `Test-OsSupport` in libs/os-guard.ps1, per issue #65's own naming
+  request.
+  #>
+}

--- a/libs/strategy.ps1
+++ b/libs/strategy.ps1
@@ -11,7 +11,7 @@ boxstarter.ps1's Phase 2 -- do not add Export-ModuleMember here.
 Set-StrictMode -Version Latest
 
 function Test-ConfigurationStrategy {
-  if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+  if (-not (Get-Command winget -CommandType Application -ErrorAction SilentlyContinue)) {
     return @{
       Route  = 'unsupported'
       Reason = 'winget was not found on PATH. The import.json route also depends on winget, so no route can run.'
@@ -21,7 +21,8 @@ function Test-ConfigurationStrategy {
   $wingetVersion = (winget --version | Select-Object -First 1) -replace '^v', ''
 
   winget configure --help *> $null
-  $configureAvailable = $LASTEXITCODE -eq 0
+  $configureExitCode = $LASTEXITCODE
+  $configureAvailable = $configureExitCode -eq 0
 
   if ($configureAvailable) {
     return @{
@@ -32,7 +33,7 @@ function Test-ConfigurationStrategy {
 
   return @{
     Route  = 'import'
-    Reason = "winget $wingetVersion does not recognize the 'configure' subcommand (winget configure --help exited $LASTEXITCODE)."
+    Reason = "winget $wingetVersion does not recognize the 'configure' subcommand (winget configure --help exited $configureExitCode)."
   }
   <#
   .SYNOPSIS


### PR DESCRIPTION
## Summary

Closes #65.

`configurations/packages.dsc.yaml` (primary) and
`configurations/packages.min.import.json` (degraded fallback) both
target winget, but nothing currently decides *before* installation
starts which one `boxstarter.ps1` should drive. This PR adds that
decision as a side-effect-free probe, per the issue's own design
constraint: switching routes on a runtime failure is wrong, because
two of the three failure classes a mid-run switch would "recover"
from (bad package ID, transient single-package failure) aren't fixed
by the import route at all — they fail identically there, just after
wasting the first route's run time.

## What changed

- **`libs/strategy.ps1`** (new): `Test-ConfigurationStrategy` returns
  `@{ Route; Reason }`, `Route` being `dsc` / `import` / `unsupported`.
  - Probes via `winget configure --help`'s exit code — a read-only
    call that asks winget directly whether it recognizes the
    `configure` subcommand, without installing or changing anything.
  - Returns `unsupported` when `winget` itself isn't on PATH, since
    the import route depends on winget too.
  - The doc comment (at the function's end, matching
    `Test-OsSupport`/`Test-CommandExists`'s existing style) records
    which other probe candidates were considered and rejected:
    version-string comparison against a hardcoded minimum (rejected —
    would silently go stale as winget releases), and `winget
    settings`'s `experimentalFeatures.configuration` flag (rejected —
    schema has changed across releases, more brittle than asking
    winget directly).
  - Also documents why route selection is intentionally never
    re-evaluated after a partial `winget configure` failure mid-run.
- **`boxstarter.ps1`**: Phase 2 now dot-sources `strategy.ps1`, calls
  the probe, logs the selected route and reason, and aborts on
  `unsupported`. **Scope note**: acting on a dsc-vs-import split
  (actually running `winget import` on the import route) is issue
  #67's job, not this one — per issue #65's own instructions, both
  `dsc` and `import` verdicts still run `winget configure` here.

## Verification

- **Empirically verified, not just documented**: this Linux
  environment genuinely has no `winget` on PATH. Running
  `pwsh -c '. ./libs/strategy.ps1; Test-ConfigurationStrategy | ConvertTo-Json'`
  here returns `{"Route": "unsupported", "Reason": "winget was not
  found on PATH..."}`. This directly exercises the acceptance
  criterion "winget が存在しない環境で unsupported を返す" rather than
  leaving it as an assumption.
- **Untested assumption (disclosed)**: I could not verify winget's
  actual exit-code behavior for `winget configure --help` on a machine
  where `configure` is unrecognized (would need Windows with an older
  winget). The dsc/import branch of the probe rests on the assumption
  that an unrecognized subcommand makes `--help` exit non-zero;
  standard CLI convention, but unverified against real winget.
- `markdownlint-cli2 "**/*.md"` — 0 issues (no markdown changed)
- `cspell lint "**" --no-progress` — 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` — exit 0
- Confirmed `setup.cmd`'s `Get-ChildItem -Recurse 'libs\*.ps1' |
  Unblock-File` globs the whole `libs/` directory, so the new
  `strategy.ps1` is covered without a `setup.cmd` change.

## Test plan

- [x] `libs/strategy.ps1` exists and exports a side-effect-free
      decision function
- [x] The function returns one of `dsc` / `import` / `unsupported`
      plus its reason
- [x] The function performs no installation or configuration change
      (read-only winget calls only)
- [x] Returns `unsupported` when winget is absent — verified
      empirically on this Linux environment, not just by inspection
- [x] Considered-and-rejected probe candidates are recorded in the
      function's doc comment
- [x] The "never re-route on a runtime failure" design decision is
      documented in the function's doc comment
- [x] `boxstarter.ps1` calls the probe and logs the selected route and
      reason
- [x] `boxstarter.ps1` aborts on `unsupported`
- [x] PSScriptAnalyzer reports nothing for `libs/strategy.ps1`
- [x] `pre-push-validate` exits 0 on a clean worktree
