### PR TITLE
test: add Pester test infrastructure

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -20,8 +20,8 @@
   "commands": {
     "install-deps": "true",
     "fix-validate": "npx -y markdownlint-cli2 --fix \"**/*.md\" && npx -y markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx -y markdownlint-cli2 \"**/*.md\" && npx -y cspell lint \"**\" --no-progress && pwsh -c \"Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit\"",
-    "post-fix-validate": "npx -y markdownlint-cli2 --fix \"**/*.md\" && npx -y markdownlint-cli2 \"**/*.md\" && npx -y cspell lint \"**\" --no-progress && pwsh -c \"Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit\""
+    "pre-push-validate": "npx -y markdownlint-cli2 \"**/*.md\" && npx -y cspell lint \"**\" --no-progress && pwsh -c \"Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit\" && pwsh -c \"Invoke-Pester -Path ./tests/powershell -CI\"",
+    "post-fix-validate": "npx -y markdownlint-cli2 --fix \"**/*.md\" && npx -y markdownlint-cli2 \"**/*.md\" && npx -y cspell lint \"**\" --no-progress && pwsh -c \"Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit\" && pwsh -c \"Invoke-Pester -Path ./tests/powershell -CI\""
   },
   "helperRuntime": {
     "profile": "ephemeral-npx"

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -262,8 +262,8 @@ enabled and default approval actors to
 | Name | Commands |
 | --- | --- |
 | **fix-validate** | `npx -y markdownlint-cli2 --fix "**/*.md" && npx -y markdownlint-cli2 "**/*.md"` |
-| **pre-push-validate** | `npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress && pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit"` |
-| **post-fix-validate** | `npx -y markdownlint-cli2 --fix "**/*.md" && npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress && pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit"` |
+| **pre-push-validate** | `npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress && pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit" && pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"` |
+| **post-fix-validate** | `npx -y markdownlint-cli2 --fix "**/*.md" && npx -y markdownlint-cli2 "**/*.md" && npx -y cspell lint "**" --no-progress && pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit" && pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"` |
 | **install-deps** | `true` |
 | **issue-scope** | `roadmap-first` |
 | **orphan-first-policy** | `none` |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,13 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit
+  pester:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module -Name Pester -RequiredVersion 6.0.1 -Force -Scope CurrentUser -Repository PSGallery
+      - name: Run Pester tests
+        shell: pwsh
+        run: Invoke-Pester -Path ./tests/powershell -CI

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install Pester
         shell: pwsh
         run: Install-Module -Name Pester -RequiredVersion 6.0.1 -Force -Scope CurrentUser -Repository PSGallery

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,powershell,vagrant,vim,visualstudiocode,windows
+
+### Pester ###
+# Test result output from Invoke-Pester -CI (TestResult.Enabled = $true)
+testResults.xml

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,83 @@
+# Testing PowerShell scripts
+
+This repository uses [Pester](https://pester.dev/) to test PowerShell
+logic that has clear inputs and outputs (parsers, generators, pure
+decision functions), as opposed to imperative installer scripts. Static
+analysis (PSScriptAnalyzer) catches style problems; Pester catches
+"does this return the right output for this input" problems that
+static analysis cannot.
+
+## When to add a test
+
+Add a test alongside any new script under `libs/` or `scripts/` whose
+logic is pure enough to unit-test: parsing, generation, or a decision
+function with clear inputs and outputs. Imperative installer scripts
+(package installs, registry writes) generally don't need one — there's
+nothing to assert against without a real Windows machine.
+
+## Where tests live
+
+Test files live under `tests/powershell/` and follow Pester's
+`<Name>.Tests.ps1` naming convention, mirroring the path of the file
+under test where practical (e.g. `libs/os-guard.ps1` is tested by
+`tests/powershell/os-guard.Tests.ps1`).
+
+## Pester version
+
+CI and local development both pin `Pester 6.0.1` (`Install-Module
+-Name Pester -RequiredVersion 6.0.1 -Force -Scope CurrentUser
+-Repository PSGallery`, matching the existing `PSScriptAnalyzer`
+job's `-RequiredVersion` pattern in `.github/workflows/lint.yml`).
+An explicit version was chosen over an unpinned `Install-Module` so
+that a new Pester major release can't silently change test syntax or
+behavior underneath CI; bump `-RequiredVersion` deliberately when
+upgrading.
+
+## Running tests locally
+
+```powershell
+Invoke-Pester -Path ./tests/powershell -CI
+```
+
+`-CI` enables a non-zero exit code on failure (`Run.Exit = $true`), so
+it's the same invocation `pre-push-validate` / `post-fix-validate` and
+CI use. It also writes `testResults.xml` to the working directory
+(gitignored) — delete it or ignore it, it's not meaningful outside the
+run that produced it.
+
+## Mocking Windows-only cmdlets on a non-Windows runner
+
+CI's `pester` job runs on `ubuntu-latest`, and local development in
+this repository may also happen on Linux. Cmdlets that ship only in
+Windows-specific modules — `Get-CimInstance` (module `CimCmdlets`)
+being the recurring example — don't exist there, and Pester's `Mock`
+requires the target command to exist before it can be mocked.
+
+The fix is a global placeholder function declared before the file
+under test is dot-sourced:
+
+```powershell
+BeforeAll {
+  function global:Get-CimInstance { }
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'os-guard.ps1')
+}
+```
+
+`Mock Get-CimInstance { ... }` then replaces this placeholder for the
+duration of the test, exactly as it would replace the real cmdlet on
+Windows. See `tests/powershell/os-guard.Tests.ps1` for a complete
+example, including `-ForEach`-driven boundary-value cases and
+`Should -Invoke` assertions that confirm the mock was actually called
+(a mock that silently fails to intercept produces a confusing
+downstream assertion failure instead of a clear error).
+
+Cmdlets that exist cross-platform but whose target doesn't (e.g.
+`Get-ItemProperty` against an `HKLM:` path, which is Windows-only) need
+no placeholder — they mock normally, since the command itself is real.
+
+## What CI runs
+
+`.github/workflows/lint.yml`'s `pester` job runs `Invoke-Pester -Path
+./tests/powershell -CI` on every push and pull request, same as the
+`powershell-analyzer` job. A red Pester run blocks the same way a red
+PSScriptAnalyzer run does.

--- a/tests/powershell/os-guard.Tests.ps1
+++ b/tests/powershell/os-guard.Tests.ps1
@@ -1,0 +1,39 @@
+BeforeAll {
+  # Get-CimInstance ships in the Windows-only CimCmdlets module, so it
+  # does not exist on the Linux runner Pester runs on here. A global
+  # placeholder makes it mockable; Test-OsSupport never calls the real
+  # cmdlet under test, only this mock.
+  function global:Get-CimInstance { }
+
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'os-guard.ps1')
+}
+
+Describe 'Test-OsSupport' {
+  Context 'boundary and gap cases' {
+    It 'returns Tier <ExpectedTier> (Supported=<ExpectedSupported>) for build <BuildNumber>, <Description>' -ForEach @(
+      @{ Description = 'Windows 11 Pro, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 1; ExpectedIsServer = $false }
+      @{ Description = 'Windows 11 Home, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Home'; EditionID = 'Core'; ExpectedSupported = $true; ExpectedTier = 2; ExpectedIsServer = $false }
+      @{ Description = 'Windows 10 22H2 Pro, the build-19045 EOL-warning boundary'; BuildNumber = '19045'; Caption = 'Microsoft Windows 10 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 3; ExpectedIsServer = $false }
+      @{ Description = 'Windows 10 22H2 Home, the build-19045 EOL-warning boundary'; BuildNumber = '19045'; Caption = 'Microsoft Windows 10 Home'; EditionID = 'Core'; ExpectedSupported = $true; ExpectedTier = 4; ExpectedIsServer = $false }
+      @{ Description = 'one build below the 22H2 boundary'; BuildNumber = '19044'; Caption = 'Microsoft Windows 10 Pro'; EditionID = 'Professional'; ExpectedSupported = $false; ExpectedTier = 99; ExpectedIsServer = $false }
+      @{ Description = 'the unnamed gap above 22H2 and below Windows 11'; BuildNumber = '21999'; Caption = 'Microsoft Windows 10 Pro'; EditionID = 'Professional'; ExpectedSupported = $false; ExpectedTier = 99; ExpectedIsServer = $false }
+      @{ Description = 'Windows Server 2019, the build-17763 server floor'; BuildNumber = '17763'; Caption = 'Microsoft Windows Server 2019 Standard'; EditionID = 'ServerStandard'; ExpectedSupported = $true; ExpectedTier = 5; ExpectedIsServer = $true }
+      @{ Description = 'pre-Windows-10 (build below 10240)'; BuildNumber = '10239'; Caption = 'Microsoft Windows 8.1 Pro'; EditionID = 'Professional'; ExpectedSupported = $false; ExpectedTier = 99; ExpectedIsServer = $false }
+    ) {
+      Mock Get-CimInstance {
+        [pscustomobject]@{ BuildNumber = $BuildNumber; Caption = $Caption }
+      }
+      Mock Get-ItemProperty {
+        [pscustomobject]@{ EditionID = $EditionID }
+      }
+
+      $result = Test-OsSupport
+
+      $result.Supported | Should -Be $ExpectedSupported
+      $result.Tier | Should -Be $ExpectedTier
+      $result.IsServer | Should -Be $ExpectedIsServer
+      Should -Invoke Get-CimInstance -Times 1
+      Should -Invoke Get-ItemProperty -Times 1
+    }
+  }
+}

--- a/tests/powershell/os-guard.Tests.ps1
+++ b/tests/powershell/os-guard.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
 Describe 'Test-OsSupport' {
   Context 'boundary and gap cases' {
     It 'returns Tier <ExpectedTier> (Supported=<ExpectedSupported>) for build <BuildNumber>, <Description>' -ForEach @(
-      @{ Description = 'Windows 11 Pro, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 2; ExpectedIsServer = $false }
+      @{ Description = 'Windows 11 Pro, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 1; ExpectedIsServer = $false }
       @{ Description = 'Windows 11 Home, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Home'; EditionID = 'Core'; ExpectedSupported = $true; ExpectedTier = 2; ExpectedIsServer = $false }
       @{ Description = 'Windows 10 22H2 Pro, the build-19045 EOL-warning boundary'; BuildNumber = '19045'; Caption = 'Microsoft Windows 10 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 3; ExpectedIsServer = $false }
       @{ Description = 'Windows 10 22H2 Home, the build-19045 EOL-warning boundary'; BuildNumber = '19045'; Caption = 'Microsoft Windows 10 Home'; EditionID = 'Core'; ExpectedSupported = $true; ExpectedTier = 4; ExpectedIsServer = $false }

--- a/tests/powershell/os-guard.Tests.ps1
+++ b/tests/powershell/os-guard.Tests.ps1
@@ -6,6 +6,15 @@ BeforeAll {
   function global:Get-CimInstance { }
 
   . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'os-guard.ps1')
+
+  # GitHub Actions' `shell: pwsh` steps implicitly set
+  # $ErrorActionPreference = 'Stop' for the whole step, which turns
+  # Test-OsSupport's non-terminating Write-Error calls (its documented
+  # signal for the unsupported-OS branches) into terminating exceptions
+  # here -- unlike a plain local `pwsh -c` invocation, where the
+  # session default of 'Continue' lets those branches return normally.
+  # Reset it explicitly so this suite behaves the same in both places.
+  $ErrorActionPreference = 'Continue'
 }
 
 Describe 'Test-OsSupport' {

--- a/tests/powershell/os-guard.Tests.ps1
+++ b/tests/powershell/os-guard.Tests.ps1
@@ -20,7 +20,7 @@ BeforeAll {
 Describe 'Test-OsSupport' {
   Context 'boundary and gap cases' {
     It 'returns Tier <ExpectedTier> (Supported=<ExpectedSupported>) for build <BuildNumber>, <Description>' -ForEach @(
-      @{ Description = 'Windows 11 Pro, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 1; ExpectedIsServer = $false }
+      @{ Description = 'Windows 11 Pro, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 2; ExpectedIsServer = $false }
       @{ Description = 'Windows 11 Home, the build-22000 lower boundary'; BuildNumber = '22000'; Caption = 'Microsoft Windows 11 Home'; EditionID = 'Core'; ExpectedSupported = $true; ExpectedTier = 2; ExpectedIsServer = $false }
       @{ Description = 'Windows 10 22H2 Pro, the build-19045 EOL-warning boundary'; BuildNumber = '19045'; Caption = 'Microsoft Windows 10 Pro'; EditionID = 'Professional'; ExpectedSupported = $true; ExpectedTier = 3; ExpectedIsServer = $false }
       @{ Description = 'Windows 10 22H2 Home, the build-19045 EOL-warning boundary'; BuildNumber = '19045'; Caption = 'Microsoft Windows 10 Home'; EditionID = 'Core'; ExpectedSupported = $true; ExpectedTier = 4; ExpectedIsServer = $false }

--- a/tests/powershell/os-guard.Tests.ps1
+++ b/tests/powershell/os-guard.Tests.ps1
@@ -1,8 +1,11 @@
 BeforeAll {
+  $script:originalErrorActionPreference = $ErrorActionPreference
+
   # Get-CimInstance ships in the Windows-only CimCmdlets module, so it
   # does not exist on the Linux runner Pester runs on here. A global
   # placeholder makes it mockable; Test-OsSupport never calls the real
-  # cmdlet under test, only this mock.
+  # cmdlet under test, only this mock. Removed again in AfterAll below
+  # so it can't shadow the real cmdlet on a Windows run.
   function global:Get-CimInstance { }
 
   . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'os-guard.ps1')
@@ -13,8 +16,15 @@ BeforeAll {
   # signal for the unsupported-OS branches) into terminating exceptions
   # here -- unlike a plain local `pwsh -c` invocation, where the
   # session default of 'Continue' lets those branches return normally.
-  # Reset it explicitly so this suite behaves the same in both places.
+  # Reset it explicitly so this suite behaves the same in both places;
+  # restored in AfterAll below so it doesn't leak into other test files
+  # run in the same Invoke-Pester session.
   $ErrorActionPreference = 'Continue'
+}
+
+AfterAll {
+  Remove-Item -Path function:Get-CimInstance -ErrorAction SilentlyContinue
+  $ErrorActionPreference = $script:originalErrorActionPreference
 }
 
 Describe 'Test-OsSupport' {


### PR DESCRIPTION
## Summary

Closes #72.

This repository's only verification so far has been static (lint,
cspell, PSScriptAnalyzer) — none of it checks "does this return the
right output for this input." The declarative-migration roadmap
(#62) is about to add real input/output logic (`Build-Configurations.ps1`
in #66, `Test-PackageIds.ps1`), so this PR introduces Pester as the
unit-test layer before those land.

## What changed

- **`tests/powershell/os-guard.Tests.ps1`** (new): tests
  `libs/os-guard.ps1`'s `Test-OsSupport` across its boundary and gap
  values — build 22000 (Windows 11 floor, Pro/Home), build 19045
  (Windows 10 22H2 floor, Pro/Home), build 19044 (one below 22H2),
  build 21999 (the unnamed gap between 22H2 and Windows 11), build
  17763 (Windows Server 2019 floor), and build 10239 (pre-Windows-10).
  Data-driven via Pester's `-ForEach`.
- **`.github/workflows/lint.yml`**: new `pester` job (`ubuntu-latest`,
  `Install-Module -Name Pester -RequiredVersion 6.0.1 -Force -Scope
  CurrentUser -Repository PSGallery`, matching the existing
  `powershell-analyzer` job's version-pin pattern). Kept as its own
  job rather than folded into `powershell-analyzer` — different tools,
  different purpose, and `powershell-analyzer` isn't referenced
  anywhere else so renaming/merging it had no upside.
- **`.github/idd/config.json`** / **`idd-overview-core.instructions.md`**:
  `pre-push-validate` and `post-fix-validate` both gained
  `pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"`. Verified
  programmatically (not by eye) that the two command strings stay
  character-identical after the edit.
- **`docs/testing.md`** (new): when to add a test, where tests live,
  the Pester version-pin rationale, how to run tests locally, and the
  `Get-CimInstance` mocking pattern below.
- **`.gitignore`**: `testResults.xml` (`Invoke-Pester -CI`'s
  `TestResult.Enabled` output).

## The `Get-CimInstance` mocking problem

`Get-CimInstance` ships in the Windows-only `CimCmdlets` module, so it
doesn't exist on `ubuntu-latest` (or in this Linux dev environment).
Pester's `Mock` requires the target command to exist before it can
mock it, so a naive `Mock Get-CimInstance { ... }` fails with
`CommandNotFoundException` — confirmed by a throwaway spike before
writing the real suite. The fix: declare a global placeholder function
before dot-sourcing the file under test:

```powershell
BeforeAll {
  function global:Get-CimInstance { }
  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'os-guard.ps1')
}
```

`Mock Get-CimInstance { ... }` then replaces this placeholder exactly
as it would replace the real cmdlet on Windows. Documented in both the
test file and `docs/testing.md` so the next test added to this suite
doesn't have to rediscover it. `Get-ItemProperty` needed no such
placeholder — it exists cross-platform even though the `HKLM:`
path it targets doesn't, so it mocks normally.

## The `$ErrorActionPreference` problem (found and fixed during this PR)

The first push of this branch (`5d93826`) went red on CI —
[run 30717940698](https://github.com/kurone-kito/setup.windows/actions/runs/30717940698/job/91416695397),
`pester` job — while passing locally. Root cause: GitHub Actions'
`shell: pwsh` steps implicitly set `$ErrorActionPreference = 'Stop'`
for the whole step. `Test-OsSupport`'s unsupported-OS branches signal
via a non-terminating `Write-Error`; under `Stop`, that becomes a
terminating exception instead, so the three unsupported-branch cases
(builds 19044, 21999, 10239) blew up mid-function instead of
returning. A plain local `pwsh -c` invocation defaults to `Continue`,
so it never surfaced there.

Reproduced locally by wrapping the same `Invoke-Pester` call in a
script with `$ErrorActionPreference = 'Stop'` set first — reproduced
the exact 3-case failure. Fixed in `3c672f7` by resetting the
preference to `'Continue'` in `BeforeAll`, confirmed the fix under the
same reproduction (8/8 pass), then confirmed on CI itself
(`3c672f7`'s push went green).

**Trade-off, disclosed rather than hidden**: `'Continue'` also
swallows any *unexpected* non-terminating error from code under test.
If `Test-OsSupport` ever started emitting `Write-Error` on a
*supported* branch, this suite wouldn't flag it as a new failure mode
— it would just see the branch's other assertions pass or fail on
their own merits. Accepted here because the alternative (asserting on
specific error records) would meaningfully complicate every future
test in this suite for a failure mode `Test-OsSupport`'s current
design doesn't create.

## Verified: CI actually goes red on a real failure

Two separate demonstrations, both on this branch before opening the
PR:

1. **Accidental** (the `$ErrorActionPreference` bug above): CI went
   red on `5d93826` from a genuine suite/environment mismatch, not a
   contrived one — arguably stronger evidence the suite catches real
   problems than a synthetic failure would be.
2. **Deliberate** (issue #72's own acceptance criterion): flipped the
   Windows-11-Pro case's `ExpectedTier` from `1` to `2` in `35233e6`,
   pushed, and confirmed
   [run 30718286562](https://github.com/kurone-kito/setup.windows/actions/runs/30718286562/job/91417610090)'s
   `pester` job failed (`Tests Passed: 7, Failed: 1`) while `lint` and
   `powershell-analyzer` stayed green in the same run. Reverted in
   `7b0c9c2`, confirmed CI green again
   ([run 30718349518](https://github.com/kurone-kito/setup.windows/actions/runs/30718349518)).

## Verification

- `markdownlint-cli2 "**/*.md"` — 0 issues
- `cspell lint "**" --no-progress` — 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` — exit 0, including
  against the new test file (an early standalone PSA run against just
  `tests/powershell/os-guard.Tests.ps1` caught one
  `PSAvoidUsingPositionalParameters` info-level finding on `Join-Path`,
  fixed before it reached the full-suite run)
- `pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"` — 8/8 pass
  locally, exit 0 (verified the actual process exit code directly,
  not through a pipeline where `$?` would reflect the wrong command)
- `.github/idd/config.json`'s and `idd-overview-core.instructions.md`'s
  `pre-push-validate`/`post-fix-validate` strings verified
  character-identical via a small Python diff, not by eye

## Test plan

- [x] `tests/powershell/` contains a Pester test file
- [x] Pester version-pin method decided (`-RequiredVersion 6.0.1`) and
      rationale recorded in `docs/testing.md`
- [x] `Test-OsSupport` has tests covering build 22000 / 19045 / below,
      plus the 21999 gap and 17763 Server floor
- [x] The test mocks `Get-CimInstance` and `Get-ItemProperty`, so it
      doesn't depend on the OS it runs on
- [x] All tests pass locally
- [x] CI test job added and green on this PR
- [x] Deliberately broke a test and confirmed CI goes red (see above,
      both the deliberate case and the accidental one that surfaced a
      real bug in this PR's own first draft)
- [x] `pre-push-validate` and `post-fix-validate` include test
      execution
- [x] `.github/idd/config.json` `commands` and the Project commands
      table match exactly (verified programmatically)
- [x] Test-writing and how-to-run docs added under `docs/`
      (`docs/testing.md`)
- [x] PSScriptAnalyzer reports nothing for the test file
- [x] `pre-push-validate` exits 0 on a clean worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated PowerShell tests covering supported Windows client and server versions, unsupported versions, and boundary cases.
  * Validation now runs these tests alongside existing checks before pushes and after fixes.
  * Added continuous integration coverage for PowerShell tests.

* **Documentation**
  * Added guidance for running, maintaining, and troubleshooting PowerShell tests locally and in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->