### PR TITLE
feat(setup): 経路実行と終了コード判定を実装する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,7 +17,8 @@ setup.cmd                        ← 唯一のエントリーポイント
             ├─ Phase 0: OS サポート確認          (libs/os-guard.ps1)
             ├─ Phase 1: 環境検出
             ├─ Phase 2: winget configure または   (configurations/packages.dsc.yaml
-            │    winget import（縮退モード）        または packages.import.json, libs/strategy.ps1)
+            │    winget import（縮退モード）        または configurations/packages.import.json,
+            │                                      libs/strategy.ps1)
             ├─ Phase 3: Chocolatey（フォント、vb-cable）+ posh-git（PowerShellGet）
             ├─ Phase 4: アーキテクチャ依存パッケージ
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
@@ -66,6 +67,8 @@ setup.cmd                        ← 唯一のエントリーポイント
 1. **Chocolatey** と **Boxstarter** が未インストールならインストール
 2. `Install-BoxstarterPackage` 経由で `boxstarter.ps1` を起動（再起動耐性あり）
 3. **WinGet Configuration (DSC)** で 105 個のパッケージを宣言的にインストール
+   （利用できない場合は **`winget import`**（縮退モード）にフォール
+   バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール
 5. インストール後セットアップ（Node.js, Rust/cargo パッケージ, Unity, Docker イメージ）
 6. Microsoft Update を有効化し、Windows Update を実行

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,8 @@ setup.cmd                        ← 唯一のエントリーポイント
        └─ boxstarter.ps1
             ├─ Phase 0: OS サポート確認          (libs/os-guard.ps1)
             ├─ Phase 1: 環境検出
-            ├─ Phase 2: winget configure (DSC)   (configurations/packages.dsc.yaml)
+            ├─ Phase 2: winget configure または   (configurations/packages.dsc.yaml
+            │    winget import（縮退モード）        または packages.import.json, libs/strategy.ps1)
             ├─ Phase 3: Chocolatey（フォント、vb-cable）+ posh-git（PowerShellGet）
             ├─ Phase 4: アーキテクチャ依存パッケージ
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
@@ -75,8 +76,9 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 ### 最小インストール
 
 軽量構成（開発ツールのみ、ゲーミング/メディア系なし）を使用する場合は、
-`boxstarter.ps1` 内の DSC ファイル参照を `packages.dsc.yaml` から
-`packages.min.dsc.yaml` に変更してください。
+`boxstarter.ps1` の Phase 2 にある `$ConfigProfile` を `'full'` から
+`'min'` に変更してください。この 1 つの値が DSC ファイル・対応する
+`import.json`・未適用リソース一覧をまとめて切り替えます。
 
 ## インストールされるもの
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ setup.cmd                        ← single entry point
             ├─ Phase 0: OS support check        (libs/os-guard.ps1)
             ├─ Phase 1: Environment detection
             ├─ Phase 2: winget configure or      (configurations/packages.dsc.yaml
-            │    winget import (degraded mode)    or packages.import.json, libs/strategy.ps1)
+            │    winget import (degraded mode)    or configurations/packages.import.json,
+            │                                      libs/strategy.ps1)
             ├─ Phase 3: Chocolatey (fonts, vb-cable) + posh-git (PowerShellGet)
             ├─ Phase 4: Architecture-conditional packages
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
@@ -64,7 +65,10 @@ The script will:
 
 1. Install **Chocolatey** and **Boxstarter** if not already present
 2. Launch `boxstarter.ps1` via `Install-BoxstarterPackage` (reboot-resilient)
-3. Apply the **WinGet Configuration (DSC)** to install 105 packages declaratively
+3. Apply the **WinGet Configuration (DSC)** to install 105 packages
+   declaratively when available, otherwise fall back to
+   **`winget import`** (degraded mode) and report any resources it
+   could not apply
 4. Install remaining packages via Chocolatey (fonts and audio drivers)
 5. Run post-install setup (Node.js, Rust/cargo packages, Unity, Docker images)
 6. Enable Microsoft Update and run Windows Update

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ setup.cmd                        ← single entry point
        └─ boxstarter.ps1
             ├─ Phase 0: OS support check        (libs/os-guard.ps1)
             ├─ Phase 1: Environment detection
-            ├─ Phase 2: winget configure (DSC)   (configurations/packages.dsc.yaml)
+            ├─ Phase 2: winget configure or      (configurations/packages.dsc.yaml
+            │    winget import (degraded mode)    or packages.import.json, libs/strategy.ps1)
             ├─ Phase 3: Chocolatey (fonts, vb-cable) + posh-git (PowerShellGet)
             ├─ Phase 4: Architecture-conditional packages
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
@@ -75,8 +76,9 @@ simply re-run `.\setup.cmd` — all phases are **idempotent**.
 
 To use the lighter configuration (development tools only, no gaming/media):
 
-Edit `boxstarter.ps1` and change the DSC file reference from
-`packages.dsc.yaml` to `packages.min.dsc.yaml`.
+Edit `boxstarter.ps1`'s Phase 2 and change `$ConfigProfile` from `'full'`
+to `'min'`. This single value selects the DSC file, its `import.json`
+fallback, and its unapplied-resources list together.
 
 ## What Gets Installed
 

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -30,8 +30,19 @@ $ARCH -like 'ARM64*' `
   | Set-Variable -Name IS_ARM64 -Option Constant -Scope local
 
 ###########################################################################
-### Phase 2 — WinGet Configuration (DSC)
+### Phase 2 — WinGet Configuration (DSC or import, degraded mode)
 ###########################################################################
+# Single point of profile selection (issue #67): switching this one value
+# switches the DSC file, its import.json fallback, and its unapplied-
+# resources list together, so they can't drift out of sync with each
+# other the way three independently-edited references could. See
+# README.md's "Minimal Install" section to switch to 'min'.
+$ConfigProfile = 'full'
+$profileSuffix = if ($ConfigProfile -eq 'min') { '.min' } else { '' }
+$dscFile = Join-Path $scriptRoot "configurations\packages$profileSuffix.dsc.yaml"
+$importJsonFile = Join-Path $scriptRoot "configurations\packages$profileSuffix.import.json"
+$unappliedResourcesFile = Join-Path $scriptRoot "configurations\packages$profileSuffix.unapplied.json"
+
 . (Join-Path $scriptRoot 'libs\strategy.ps1')
 $strategy = Test-ConfigurationStrategy
 Write-Host "[Phase 2] Configuration route: $($strategy.Route) -- $($strategy.Reason)" -ForegroundColor Cyan
@@ -40,17 +51,61 @@ if ($strategy.Route -eq 'unsupported') {
   return
 }
 
-# Route selection is logged above for visibility only; the import route
-# still runs winget configure at this point (issue #65 scope). Acting on
-# the selected route (running winget import instead) is issue #67's scope.
-$dscFile = Join-Path $scriptRoot 'configurations\packages.dsc.yaml'
-if (Test-Path $dscFile) {
+if ($strategy.Route -eq 'dsc') {
   Write-Host '[Phase 2] Applying WinGet Configuration (DSC)...' -ForegroundColor Cyan
   winget configure --accept-configuration-agreements --disable-interactivity $dscFile
+  $exitCode = $LASTEXITCODE
+  if ($exitCode -ne 0) {
+    # Never re-route on a runtime failure (see libs/strategy.ps1's own
+    # rationale): a bad package ID or a transient single-package error
+    # in this route fails identically under winget import, so falling
+    # back would only waste time re-running the same failure under a
+    # different command. Abort instead, matching Phase 0's precedent
+    # for a setup-blocking condition (Write-Error + return, not throw
+    # -- consistent within this script, and correct under Boxstarter's
+    # $ErrorActionPreference = 'Continue').
+    Write-Error "[Phase 2] winget configure failed (exit code $exitCode). Command: winget configure --accept-configuration-agreements --disable-interactivity `"$dscFile`". Aborting setup."
+    return
+  }
   Write-Host '[Phase 2] WinGet Configuration complete.' -ForegroundColor Green
 }
 else {
-  Write-Warning "[Phase 2] DSC file not found: $dscFile — skipping."
+  # import route (degraded mode): only PackageIdentifiers can be
+  # expressed in import.json, so PSDscResources/Registry resources and
+  # the OsVersion assertion from $dscFile are not applied here -- see
+  # the unapplied-resources warning below.
+  Write-Host '[Phase 2] Applying WinGet import (degraded mode)...' -ForegroundColor Cyan
+  # --ignore-unavailable: chosen so one package that's unavailable on
+  # this machine/region (e.g. an msstore entry not offered here) does
+  # not abort the whole import. This deliberately narrows what counts
+  # as a Phase 2 failure on this route to *installation* failures, not
+  # *availability* failures -- an asymmetry with the dsc route's exit-
+  # code check, accepted because availability gaps are still visible
+  # in winget's own per-package output in this log, satisfying "trace
+  # which package was skipped" without extra bookkeeping here.
+  winget import --accept-package-agreements --accept-source-agreements --disable-interactivity --ignore-unavailable $importJsonFile
+  $exitCode = $LASTEXITCODE
+  if ($exitCode -ne 0) {
+    Write-Error "[Phase 2] winget import failed (exit code $exitCode). Command: winget import --accept-package-agreements --accept-source-agreements --disable-interactivity --ignore-unavailable `"$importJsonFile`". Aborting setup."
+    return
+  }
+  Write-Host '[Phase 2] WinGet import complete.' -ForegroundColor Green
+
+  if (Test-Path $unappliedResourcesFile) {
+    # @(...) guards against ConvertFrom-Json unrolling a single-element
+    # JSON array to a bare object, which would make .Count read $null
+    # under Set-StrictMode instead of 1.
+    $unapplied = @(Get-Content -Raw -Path $unappliedResourcesFile | ConvertFrom-Json)
+    if ($unapplied.Count -gt 0) {
+      Write-Warning "[Phase 2] Degraded mode: $($unapplied.Count) resource(s) from $dscFile were not applied by the import route:"
+      foreach ($item in $unapplied) {
+        Write-Warning "  - $($item.Resource) $($item.Id): $($item.Description)"
+      }
+    }
+  }
+  else {
+    Write-Warning "[Phase 2] Unapplied-resources list not found: $unappliedResourcesFile -- skipping the degraded-mode warning."
+  }
 }
 
 ###########################################################################

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -38,6 +38,14 @@ $ARCH -like 'ARM64*' `
 # other the way three independently-edited references could. See
 # README.md's "Minimal Install" section to switch to 'min'.
 $ConfigProfile = 'full'
+if ($ConfigProfile -notin @('full', 'min')) {
+  # This selection controls what gets installed; failing loudly on a
+  # typo (e.g. 'Min', 'mini') is safer than silently falling back to
+  # full, which the previous `if ($ConfigProfile -eq 'min') {...} else
+  # {...}` form would have done.
+  Write-Error "Unknown ConfigProfile '$ConfigProfile' -- expected 'full' or 'min'. Aborting setup."
+  return
+}
 $profileSuffix = if ($ConfigProfile -eq 'min') { '.min' } else { '' }
 $dscFile = Join-Path $scriptRoot "configurations\packages$profileSuffix.dsc.yaml"
 $importJsonFile = Join-Path $scriptRoot "configurations\packages$profileSuffix.import.json"
@@ -52,28 +60,38 @@ if ($strategy.Route -eq 'unsupported') {
 }
 
 if ($strategy.Route -eq 'dsc') {
+  if (-not (Test-Path $dscFile)) {
+    Write-Error "[Phase 2] DSC file not found: $dscFile. Aborting setup."
+    return
+  }
   Write-Host '[Phase 2] Applying WinGet Configuration (DSC)...' -ForegroundColor Cyan
   winget configure --accept-configuration-agreements --disable-interactivity $dscFile
   $exitCode = $LASTEXITCODE
   if ($exitCode -ne 0) {
     # Never re-route on a runtime failure (see libs/strategy.ps1's own
-    # rationale): a bad package ID or a transient single-package error
-    # in this route fails identically under winget import, so falling
-    # back would only waste time re-running the same failure under a
-    # different command. Abort instead, matching Phase 0's precedent
-    # for a setup-blocking condition (Write-Error + return, not throw
-    # -- consistent within this script, and correct under Boxstarter's
+    # rationale): re-running under winget import risks a *partial
+    # apply* on top of whatever this attempt already changed, and the
+    # two routes cover different resource scopes -- a Registry/
+    # OsVersion failure here would not even be attempted under import,
+    # so switching wouldn't retry the same failure, it would silently
+    # drop it. Abort instead, matching Phase 0's precedent for a
+    # setup-blocking condition (Write-Error + return, not throw --
+    # consistent within this script, and correct under Boxstarter's
     # $ErrorActionPreference = 'Continue').
     Write-Error "[Phase 2] winget configure failed (exit code $exitCode). Command: winget configure --accept-configuration-agreements --disable-interactivity `"$dscFile`". Aborting setup."
     return
   }
   Write-Host '[Phase 2] WinGet Configuration complete.' -ForegroundColor Green
 }
-else {
+elseif ($strategy.Route -eq 'import') {
   # import route (degraded mode): only PackageIdentifiers can be
   # expressed in import.json, so PSDscResources/Registry resources and
   # the OsVersion assertion from $dscFile are not applied here -- see
   # the unapplied-resources warning below.
+  if (-not (Test-Path $importJsonFile)) {
+    Write-Error "[Phase 2] import.json file not found: $importJsonFile. Aborting setup."
+    return
+  }
   Write-Host '[Phase 2] Applying WinGet import (degraded mode)...' -ForegroundColor Cyan
   # --ignore-unavailable: chosen so one package that's unavailable on
   # this machine/region (e.g. an msstore entry not offered here) does
@@ -102,10 +120,23 @@ else {
         Write-Warning "  - $($item.Resource) $($item.Id): $($item.Description)"
       }
     }
+    else {
+      Write-Host '[Phase 2] Degraded mode: no unapplied resources for this profile.' -ForegroundColor Green
+    }
   }
   else {
     Write-Warning "[Phase 2] Unapplied-resources list not found: $unappliedResourcesFile -- skipping the degraded-mode warning."
   }
+}
+else {
+  # Defensive guard, not a reachable branch under
+  # Test-ConfigurationStrategy's documented contract (Route is always
+  # 'dsc' | 'import' | 'unsupported', and 'unsupported' already
+  # returned above) -- but Phase 2 chooses between two real winget
+  # commands based on this value, so a future change to that contract
+  # should fail loudly here instead of silently running winget import.
+  Write-Error "[Phase 2] Unexpected configuration route '$($strategy.Route)'. Aborting setup."
+  return
 }
 
 ###########################################################################

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -47,11 +47,12 @@ installation starts:
   `OsVersion` assertion.
 - **`import`**: `winget import` against `packages.import.json`,
   **degraded mode**. `import.json` can only express `PackageIdentifier`s
-  (see `winget-packages.schema.2.0.json`), so the Registry resources
-  and the assertion are silently out of scope for this command --
-  Phase 2 reads `packages.unapplied.json` afterward and warns about
-  each one by name, so this is visible to the person running setup
-  instead of a silent gap.
+  (schema: <https://aka.ms/winget-packages.schema.2.0.json>, not a file
+  checked into this repository), so the Registry resources and the
+  assertion are silently out of scope for this command -- Phase 2
+  reads `packages.unapplied.json` afterward and warns about each one
+  by name, so this is visible to the person running setup instead of a
+  silent gap.
 
 Both routes check `$LASTEXITCODE` after the winget call and treat any
 non-zero exit as a failure: Phase 2 logs the failed route, exit code,
@@ -59,13 +60,18 @@ and the exact command, then aborts setup (`Write-Error` + `return`,
 matching Phase 0's precedent for a setup-blocking condition).
 
 **Routes never switch after Phase 2 starts**, on either route's
-failure. A failure partway through `winget configure` is either a bad
-package ID or a transient single-package error; both fail identically
-under `winget import` too, so re-routing would only waste the time
-already spent, not fix anything. Re-routing after a partial apply
-would also layer a second, differently-scoped install operation on top
-of whatever the first one already changed. `Test-ConfigurationStrategy`
-runs once, before Phase 2, and its result is not re-evaluated.
+failure. Re-routing risks a *partial apply* on top of whatever the
+first attempt already changed, and the two routes cover different
+resource scopes -- a `PSDscResources/Registry` or `OsVersion` failure
+under `winget configure` would not even be attempted under
+`winget import`, so switching would not retry the same failure, it
+would silently drop it. (A bad package ID or a transient single-
+package error is the one failure class that genuinely repeats under
+either route, since both install the same packages -- but the policy
+is "never switch," not "switch only when it would help," precisely
+because Phase 2 cannot tell which failure class it hit from the exit
+code alone.) `Test-ConfigurationStrategy` runs once, before Phase 2,
+and its result is not re-evaluated.
 
 The import route passes `--ignore-unavailable` to `winget import`, so
 one package unavailable on the current machine/region does not abort

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -36,6 +36,45 @@ every push/PR and fails if the committed generated files don't match
 what regeneration produces, so a `dsc.yaml` edit that isn't followed
 by regeneration is caught before merge rather than silently drifting.
 
+## The import route is degraded mode, and routes never switch mid-run
+
+`boxstarter.ps1`'s Phase 2 picks one of two routes via
+`libs/strategy.ps1`'s `Test-ConfigurationStrategy`, before any package
+installation starts:
+
+- **`dsc`**: `winget configure` against `packages.dsc.yaml`. Applies
+  every resource -- packages, `PSDscResources/Registry` values, and the
+  `OsVersion` assertion.
+- **`import`**: `winget import` against `packages.import.json`,
+  **degraded mode**. `import.json` can only express `PackageIdentifier`s
+  (see `winget-packages.schema.2.0.json`), so the Registry resources
+  and the assertion are silently out of scope for this command --
+  Phase 2 reads `packages.unapplied.json` afterward and warns about
+  each one by name, so this is visible to the person running setup
+  instead of a silent gap.
+
+Both routes check `$LASTEXITCODE` after the winget call and treat any
+non-zero exit as a failure: Phase 2 logs the failed route, exit code,
+and the exact command, then aborts setup (`Write-Error` + `return`,
+matching Phase 0's precedent for a setup-blocking condition).
+
+**Routes never switch after Phase 2 starts**, on either route's
+failure. A failure partway through `winget configure` is either a bad
+package ID or a transient single-package error; both fail identically
+under `winget import` too, so re-routing would only waste the time
+already spent, not fix anything. Re-routing after a partial apply
+would also layer a second, differently-scoped install operation on top
+of whatever the first one already changed. `Test-ConfigurationStrategy`
+runs once, before Phase 2, and its result is not re-evaluated.
+
+The import route passes `--ignore-unavailable` to `winget import`, so
+one package unavailable on the current machine/region does not abort
+the whole import. This narrows what counts as a Phase 2 failure on
+this route to *installation* failures, not *availability* failures --
+an asymmetry with the dsc route's exit-code check, accepted because
+availability gaps are still visible in winget's own per-package output
+in the Boxstarter log.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |


### PR DESCRIPTION
## Summary

Closes #67.

`boxstarter.ps1`'s Phase 2 ran `winget configure` unconditionally and
never checked its exit code -- a failed configuration apply printed
"WinGet Configuration complete." exactly like a real success. It also
didn't act on `libs/strategy.ps1`'s route decision (issue #65): both
`dsc` and `import` verdicts ran `winget configure` regardless. This PR
wires the route decision into an actual branch, checks exit codes on
both routes, and surfaces what the degraded `import` route can't
apply.

## What changed

- **`boxstarter.ps1` Phase 2**:
  - **Profile consolidation**: a single `$ConfigProfile` variable
    (`'full'` default) derives `$dscFile` / `$importJsonFile` /
    `$unappliedResourcesFile` together. Previously only the DSC file
    reference was hand-edited for the min profile; now that three
    related generated files exist per profile (issue #66), editing
    only one of them would have pointed the DSC file at `min` while
    still importing/warning from `full`'s generated files.
  - **`dsc` route**: `winget configure --accept-configuration-agreements
    --disable-interactivity $dscFile`, unchanged command, now checked
    against `$LASTEXITCODE`.
  - **`import` route (degraded mode)**: `winget import
    --accept-package-agreements --accept-source-agreements
    --disable-interactivity --ignore-unavailable $importJsonFile`.
    After a successful import, reads `$unappliedResourcesFile`
    (`scripts/Build-Configurations.ps1`'s output, issue #66) and
    `Write-Warning`s each entry's resource type / id / description --
    not double-defined in `boxstarter.ps1`, just consumed.
  - **Exit-code handling, both routes**: non-zero → `Write-Error` with
    the failed route, exit code, and the exact command, then `return`
    (matching Phase 0's existing abort precedent, not `throw` --
    consistent construct within this script, correct under
    Boxstarter's `$ErrorActionPreference = 'Continue'`).
  - **No re-routing on failure, on either route** -- unchanged from
    `libs/strategy.ps1`'s issue #65 design: a mid-run failure (bad
    package ID, transient single-package error) fails identically
    under the other route, so switching would only waste the time
    already spent.
  - **`--ignore-unavailable` on the import route, with the asymmetry
    it creates spelled out in a code comment**: one package unavailable
    on this machine/region no longer aborts the whole import. This
    deliberately narrows what counts as an import-route failure to
    *installation* failures, not *availability* failures -- asymmetric
    with the dsc route's exit-code check, accepted because availability
    gaps still show up in winget's own per-package output in the log.
  - `@(...)`-wraps the unapplied-list `ConvertFrom-Json` result, since
    a single-element JSON array unrolls to a bare object otherwise and
    `.Count` would read `$null` under `Set-StrictMode -Version Latest`
    (today's real files have 4/33 entries, but the min profile is one
    Registry-resource deletion away from 1).
- **`README.md` / `README.ja.md`**: architecture diagram now shows both
  routes; "Minimal Install" section now says to flip `$ConfigProfile`
  instead of hand-editing the DSC file reference.
- **`docs/dsc-migration-notes.md`**: new section documenting the two
  routes, degraded-mode scope (what `import.json` can't express),
  exit-code failure detection, the no-reroute policy, and the
  `--ignore-unavailable` trade-off.

## Verification

- `[scriptblock]::Create(...)` parse-check on `boxstarter.ps1` --
  no syntax errors (can't execute Phase 2 end-to-end here: no `winget`
  on this Linux dev environment, same constraint issue #65 hit)
- `markdownlint-cli2 "**/*.md"` -- 0 issues
- `cspell lint "**" --no-progress` -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- 18/18 pass (no test
  file touched by this PR; confirms no regression)
- **No new Pester tests**: `boxstarter.ps1`'s Phase 2 now branches on
  live `winget` process exit codes, which isn't meaningfully unit-
  testable without mocking external process execution -- the same
  constraint `libs/strategy.ps1` (issue #65) hit, verified there by
  direct empirical invocation instead of a test suite. Issue #67's own
  acceptance criteria don't require tests either.

## Test plan

- [x] Phase 2 branches on the pre-判定 route between `winget configure`
      and `winget import`
- [x] Both routes run non-interactively with package/source agreement
      flags
- [x] Both routes check the exit code and treat non-zero as failure
- [x] On failure, the failed route, exit code, and executed command
      are logged
- [x] No route-switching occurs on failure (no such branch exists in
      the implementation)
- [x] `--ignore-unavailable`'s adoption and reasoning are recorded in
      a code comment
- [x] Abort-vs-continue-on-failure choice and reasoning are recorded
      in a code comment
- [x] After a successful `import` run, unapplied resources are listed
      with counts and descriptions
- [x] The unapplied-resources list is read from the generation track's
      output, not double-defined in `boxstarter.ps1`
- [x] Profile (full/min) selection is consolidated to one place,
      defaulting to full
- [x] The min-profile switch procedure is documented in `README.md`
      and `README.ja.md`
- [x] `docs/dsc-migration-notes.md` documents degraded mode, exit-code
      detection, and the no-reroute policy
- [x] PSScriptAnalyzer reports nothing for `boxstarter.ps1`
- [x] `pre-push-validate` exits 0 on a clean worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a full or minimal installation profile.
  * Phase 2 can now use WinGet configuration or a fallback import route.
  * Import mode reports resources that could not be applied and unavailable packages.

* **Bug Fixes**
  * Installation now stops when WinGet operations fail.

* **Documentation**
  * Updated English and Japanese setup instructions.
  * Documented configuration, fallback behavior, degraded mode, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->