### PR TITLE
feat(dsc): パッケージ ID 実在性のローカル検証スクリプトを追加する

### DIFF
--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -81,6 +81,44 @@ an asymmetry with the dsc route's exit-code check, accepted because
 availability gaps are still visible in winget's own per-package output
 in the Boxstarter log.
 
+## Verifying package ids before running setup
+
+A wrong or stale `WinGetPackage` id is not fixed by Phase 2's route
+fallback (above): the `import` route queries the same winget, the
+same id, against the same source, and fails identically. `scripts/
+Test-PackageIds.ps1` checks id validity independently of route
+selection and without installing anything, via `winget show --exact
+--id <id> --source <source>`:
+
+```powershell
+./scripts/Test-PackageIds.ps1 -DscPath ./configurations/packages.dsc.yaml
+./scripts/Test-PackageIds.ps1 -DscPath ./configurations/packages.min.dsc.yaml
+```
+
+It reuses `libs/configuration-builder.ps1`'s `Split-DscResource` to
+extract id/source pairs, so parsing is not duplicated between the
+generation track (issue #66) and this verification track.
+
+Results are classified three ways -- **Confirmed** (count only),
+**NotFound**, and **Indeterminate** -- and the two failure classes are
+never merged. Only winget-cli's own documented
+`APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND` exit code
+(`-1978335212`, from
+[`AppInstallerErrors.h`](https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerSharedLib/Public/AppInstallerErrors.h))
+counts as NotFound; every other non-zero exit (a source-open failure,
+a network error, anything this script doesn't specifically recognize)
+is Indeterminate. Reporting a network outage as a bad package id would
+destroy this check's own credibility, so the exit codes differ too:
+`1` if any id was NotFound, `2` if only Indeterminate ids occurred, `0`
+if every id was Confirmed.
+
+Run this after adding or changing a package in either `dsc.yaml` file,
+and whenever setup fails on a specific package -- to tell a genuine
+id/source problem apart from a transient install failure before
+re-running the whole setup. Requires a real `winget` on PATH, so it
+only runs on Windows; not wired into CI (a Linux runner has no
+`winget` to check against -- see issue #69).
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -85,10 +85,10 @@ in the Boxstarter log.
 
 A wrong or stale `WinGetPackage` id is not fixed by Phase 2's route
 fallback (above): the `import` route queries the same winget, the
-same id, against the same source, and fails identically. `scripts/
-Test-PackageIds.ps1` checks id validity independently of route
-selection and without installing anything, via `winget show --exact
---id <id> --source <source>`:
+same id, against the same source, and fails identically.
+`scripts/Test-PackageIds.ps1` checks id validity independently of
+route selection and without installing anything, via
+`winget show --exact --id <id> --source <source>`:
 
 ```powershell
 ./scripts/Test-PackageIds.ps1 -DscPath ./configurations/packages.dsc.yaml

--- a/libs/package-id-checker.ps1
+++ b/libs/package-id-checker.ps1
@@ -150,3 +150,58 @@ function Get-PackageIdCheckExitCode {
   0 if every id was Confirmed.
   #>
 }
+
+function Invoke-PackageIdCheck {
+  param(
+    [Parameter(Mandatory)]
+    [string] $DscPath
+  )
+
+  $document = ConvertFrom-Yaml -Yaml (Get-Content -Raw -Path $DscPath) -Ordered
+  $resource = @($document['properties']['resources'])
+  $assertion = @($document['properties']['assertions'])
+  $split = Split-DscResource -Resource $resource -Assertion $assertion
+  $result = Test-PackageIdList -Grouped $split.Grouped
+
+  $lines = [System.Collections.Generic.List[string]]::new()
+  $lines.Add("Confirmed: $($result.Confirmed.Count) package(s) exist.")
+  $lines.Add("Not found ($($result.NotFound.Count)):")
+  foreach ($item in $result.NotFound) {
+    $lines.Add("  - $($item.Id) ($($item.Source)) exit=$($item.ExitCode)")
+  }
+  $lines.Add("Indeterminate ($($result.Indeterminate.Count)):")
+  foreach ($item in $result.Indeterminate) {
+    $lines.Add("  - $($item.Id) ($($item.Source)) exit=$($item.ExitCode)")
+  }
+
+  return [ordered]@{
+    Lines    = $lines
+    Result   = $result
+    ExitCode = (Get-PackageIdCheckExitCode -Result $result)
+  }
+  <#
+  .SYNOPSIS
+  Runs the full package-id check for one dsc.yaml file: parse, split,
+  test, format, and compute the exit code.
+
+  .DESCRIPTION
+  Everything scripts/Test-PackageIds.ps1 needs, factored out into one
+  function so Pester can exercise the whole pipeline -- including
+  output formatting and exit-code selection -- without spawning a
+  child process or calling `exit` directly from a test. Requires
+  Split-DscResource (libs/configuration-builder.ps1) and
+  ConvertFrom-Yaml (the powershell-yaml module) to already be
+  available in the caller's scope; scripts/Test-PackageIds.ps1 dot-
+  sources configuration-builder.ps1 before this file for that reason.
+
+  The "Not found" and "Indeterminate" headers are always printed, with
+  a 0 count when empty, so a caller never has to infer "section
+  missing" as "zero" -- the output shape is the same whether every id
+  was confirmed or not.
+
+  .OUTPUTS
+  Ordered hashtable: Lines (array of output strings, ready to print),
+  Result (Test-PackageIdList's bucketed result), ExitCode
+  (Get-PackageIdCheckExitCode's result for Result).
+  #>
+}

--- a/libs/package-id-checker.ps1
+++ b/libs/package-id-checker.ps1
@@ -1,0 +1,152 @@
+<#
+.SYNOPSIS
+Pure-ish helpers for verifying that dsc.yaml's WinGetPackage ids
+actually exist in their declared source, via `winget show`. Used by
+scripts/Test-PackageIds.ps1.
+
+This file is dot-sourced (not imported as a module) -- do not add
+Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+# winget-cli's own documented exit code for "no package found matching
+# input criteria" (APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND,
+# 0x8A150014 = -1978335212 as a signed 32-bit exit code), from
+# https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerSharedLib/Public/AppInstallerErrors.h.
+# Any OTHER non-zero exit (source-open failure, network error, an
+# error this script doesn't specifically recognize) is treated as
+# Indeterminate, not NotFound -- see Test-PackageExistence's doc
+# comment.
+$Script:PackageNotFoundExitCode = -1978335212
+
+function Invoke-WingetShow {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Id,
+
+    [Parameter(Mandatory)]
+    [string] $Source
+  )
+
+  winget show --exact --id $Id --source $Source --accept-source-agreements --disable-interactivity *> $null
+  return $LASTEXITCODE
+  <#
+  .SYNOPSIS
+  Runs `winget show` for one package id/source pair (no install, no
+  configuration change) and returns its exit code.
+
+  .DESCRIPTION
+  The only function in this file with a real winget dependency --
+  kept to this one call specifically so Pester tests can mock this
+  single function and exercise every other function's classification
+  logic without winget installed (this Linux dev environment has no
+  winget at all).
+
+  .OUTPUTS
+  Int32 exit code ($LASTEXITCODE after the winget invocation).
+  #>
+}
+
+function Test-PackageExistence {
+  param(
+    [Parameter(Mandatory)]
+    [string] $Id,
+
+    [Parameter(Mandatory)]
+    [string] $Source
+  )
+
+  $exitCode = Invoke-WingetShow -Id $Id -Source $Source
+
+  $status = if ($exitCode -eq 0) {
+    'Confirmed'
+  }
+  elseif ($exitCode -eq $Script:PackageNotFoundExitCode) {
+    'NotFound'
+  }
+  else {
+    'Indeterminate'
+  }
+
+  return [pscustomobject][ordered]@{
+    Id       = $Id
+    Source   = $Source
+    Status   = $status
+    ExitCode = $exitCode
+  }
+  <#
+  .SYNOPSIS
+  Classifies one package id/source pair as Confirmed, NotFound, or
+  Indeterminate.
+
+  .DESCRIPTION
+  Only winget's own documented "no package found" exit code
+  ($Script:PackageNotFoundExitCode) is treated as NotFound. Every
+  other non-zero exit -- a source-open failure, a network error, or an
+  exit code this script doesn't specifically recognize -- is
+  Indeterminate, deliberately, so a transient network problem is never
+  reported as a bad package id. Conflating the two would destroy this
+  check's own credibility (issue #68).
+
+  .OUTPUTS
+  pscustomobject { Id; Source; Status; ExitCode }.
+  #>
+}
+
+function Test-PackageIdList {
+  param(
+    [Parameter(Mandatory)]
+    [System.Collections.IDictionary] $Grouped
+  )
+
+  $checked = [System.Collections.Generic.List[object]]::new()
+  foreach ($source in $Grouped.Keys) {
+    foreach ($id in @($Grouped[$source])) {
+      $checked.Add((Test-PackageExistence -Id $id -Source $source))
+    }
+  }
+
+  return [ordered]@{
+    Confirmed     = @($checked | Where-Object { $_.Status -eq 'Confirmed' })
+    NotFound      = @($checked | Where-Object { $_.Status -eq 'NotFound' })
+    Indeterminate = @($checked | Where-Object { $_.Status -eq 'Indeterminate' })
+  }
+  <#
+  .SYNOPSIS
+  Runs Test-PackageExistence over every id/source pair in a
+  Split-DscResource Grouped map (libs/configuration-builder.ps1,
+  reused here rather than re-parsing dsc.yaml) and buckets the
+  results.
+
+  .OUTPUTS
+  Ordered hashtable with Confirmed / NotFound / Indeterminate, each an
+  array of Test-PackageExistence's pscustomobject.
+  #>
+}
+
+function Get-PackageIdCheckExitCode {
+  param(
+    [Parameter(Mandatory)]
+    [System.Collections.IDictionary] $Result
+  )
+
+  if (@($Result.NotFound).Count -gt 0) {
+    return 1
+  }
+  if (@($Result.Indeterminate).Count -gt 0) {
+    return 2
+  }
+  return 0
+  <#
+  .SYNOPSIS
+  Maps a Test-PackageIdList result to a process exit code.
+
+  .DESCRIPTION
+  1 if any id was confirmed NotFound (checked first -- a confirmed bad
+  id is more actionable than an indeterminate one, so it takes
+  priority even when both occurred in the same run). 2 if only
+  Indeterminate ids occurred -- a distinct code from NotFound, per
+  issue #68's own requirement that the two never share an exit code.
+  0 if every id was Confirmed.
+  #>
+}

--- a/scripts/Test-PackageIds.ps1
+++ b/scripts/Test-PackageIds.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+Verifies that every WinGetPackage id/source pair in a dsc.yaml file
+actually exists, without installing anything.
+
+.DESCRIPTION
+A wrong or stale package id is not fixed by boxstarter.ps1's route
+fallback (issue #67): the import route queries the same winget, same
+id, same source, and fails the same way. This script checks id
+validity independently of route selection, via `winget show`, so a
+typo or a package removed from its source can be caught before
+running setup.
+
+Requires the powershell-yaml module (Install-Module -Name
+powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser) and a
+working `winget` on PATH -- this script only runs on Windows.
+
+Run this after adding or changing a package in dsc.yaml, and whenever
+setup fails on a specific package, to tell a genuine id/source problem
+apart from a transient install failure. See
+docs/dsc-migration-notes.md for the full guidance.
+
+.PARAMETER DscPath
+Path to the dsc.yaml file to verify (packages.dsc.yaml or
+packages.min.dsc.yaml).
+
+.EXAMPLE
+./scripts/Test-PackageIds.ps1 -DscPath ./configurations/packages.dsc.yaml
+
+.EXAMPLE
+./scripts/Test-PackageIds.ps1 -DscPath ./configurations/packages.min.dsc.yaml
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string] $DscPath
+)
+
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -Path $DscPath -PathType Leaf)) {
+  throw "DscPath '$DscPath' does not exist or is not a file."
+}
+
+Import-Module powershell-yaml -RequiredVersion 0.4.12 -ErrorAction Stop
+. (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath 'libs', 'configuration-builder.ps1')
+. (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath 'libs', 'package-id-checker.ps1')
+
+$document = ConvertFrom-Yaml -Yaml (Get-Content -Raw -Path $DscPath) -Ordered
+$resource = @($document['properties']['resources'])
+$assertion = @($document['properties']['assertions'])
+$split = Split-DscResource -Resource $resource -Assertion $assertion
+
+$result = Test-PackageIdList -Grouped $split.Grouped
+
+Write-Output "Confirmed: $($result.Confirmed.Count) package(s) exist."
+
+if ($result.NotFound.Count -gt 0) {
+  Write-Output "Not found ($($result.NotFound.Count)):"
+  foreach ($item in $result.NotFound) {
+    Write-Output "  - $($item.Id) ($($item.Source)) exit=$($item.ExitCode)"
+  }
+}
+
+if ($result.Indeterminate.Count -gt 0) {
+  Write-Output "Indeterminate ($($result.Indeterminate.Count)):"
+  foreach ($item in $result.Indeterminate) {
+    Write-Output "  - $($item.Id) ($($item.Source)) exit=$($item.ExitCode)"
+  }
+}
+
+exit (Get-PackageIdCheckExitCode -Result $result)

--- a/scripts/Test-PackageIds.ps1
+++ b/scripts/Test-PackageIds.ps1
@@ -46,27 +46,6 @@ Import-Module powershell-yaml -RequiredVersion 0.4.12 -ErrorAction Stop
 . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath 'libs', 'configuration-builder.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath 'libs', 'package-id-checker.ps1')
 
-$document = ConvertFrom-Yaml -Yaml (Get-Content -Raw -Path $DscPath) -Ordered
-$resource = @($document['properties']['resources'])
-$assertion = @($document['properties']['assertions'])
-$split = Split-DscResource -Resource $resource -Assertion $assertion
-
-$result = Test-PackageIdList -Grouped $split.Grouped
-
-Write-Output "Confirmed: $($result.Confirmed.Count) package(s) exist."
-
-if ($result.NotFound.Count -gt 0) {
-  Write-Output "Not found ($($result.NotFound.Count)):"
-  foreach ($item in $result.NotFound) {
-    Write-Output "  - $($item.Id) ($($item.Source)) exit=$($item.ExitCode)"
-  }
-}
-
-if ($result.Indeterminate.Count -gt 0) {
-  Write-Output "Indeterminate ($($result.Indeterminate.Count)):"
-  foreach ($item in $result.Indeterminate) {
-    Write-Output "  - $($item.Id) ($($item.Source)) exit=$($item.ExitCode)"
-  }
-}
-
-exit (Get-PackageIdCheckExitCode -Result $result)
+$check = Invoke-PackageIdCheck -DscPath $DscPath
+$check.Lines | Write-Output
+exit $check.ExitCode

--- a/tests/powershell/package-id-checker.Tests.ps1
+++ b/tests/powershell/package-id-checker.Tests.ps1
@@ -1,0 +1,90 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'package-id-checker.ps1')
+}
+
+Describe 'Test-PackageExistence' {
+  Context 'classification by exit code' {
+    It 'classifies exit 0 as Confirmed' {
+      Mock Invoke-WingetShow { 0 }
+
+      $result = Test-PackageExistence -Id 'Vendor.Good' -Source 'winget'
+
+      $result.Status | Should -Be 'Confirmed'
+      $result.ExitCode | Should -Be 0
+    }
+
+    It 'classifies the winget-cli NO_APPLICATIONS_FOUND exit code as NotFound' {
+      Mock Invoke-WingetShow { -1978335212 }
+
+      $result = Test-PackageExistence -Id 'Vendor.Bad' -Source 'winget'
+
+      $result.Status | Should -Be 'NotFound'
+      $result.ExitCode | Should -Be -1978335212
+    }
+
+    It 'classifies any other non-zero exit code as Indeterminate, not NotFound' -ForEach @(
+      @{ Description = 'source-open failure'; ExitCode = -1978335163 }
+      @{ Description = 'an unrecognized error'; ExitCode = 1 }
+    ) {
+      Mock Invoke-WingetShow { $ExitCode }
+
+      $result = Test-PackageExistence -Id 'Vendor.Unclear' -Source 'winget'
+
+      $result.Status | Should -Be 'Indeterminate'
+      $result.ExitCode | Should -Be $ExitCode
+    }
+  }
+}
+
+Describe 'Test-PackageIdList' {
+  It 'buckets Confirmed, NotFound, and Indeterminate separately across a Grouped map' {
+    Mock Invoke-WingetShow {
+      switch ($Id) {
+        'Vendor.Good1' { 0 }
+        'Vendor.Good2' { 0 }
+        'Vendor.Bad' { -1978335212 }
+        'Vendor.Unclear' { -1978335163 }
+      }
+    }
+
+    $grouped = [ordered]@{
+      winget  = @('Vendor.Good1', 'Vendor.Bad')
+      msstore = @('Vendor.Good2', 'Vendor.Unclear')
+    }
+
+    $result = Test-PackageIdList -Grouped $grouped
+
+    $result.Confirmed.Count | Should -Be 2
+    $result.NotFound.Count | Should -Be 1
+    $result.NotFound[0].Id | Should -Be 'Vendor.Bad'
+    $result.Indeterminate.Count | Should -Be 1
+    $result.Indeterminate[0].Id | Should -Be 'Vendor.Unclear'
+    Should -Invoke Invoke-WingetShow -Times 4
+  }
+}
+
+Describe 'Get-PackageIdCheckExitCode' {
+  It 'returns 0 when everything is Confirmed' {
+    $result = [ordered]@{ Confirmed = @(1); NotFound = @(); Indeterminate = @() }
+
+    Get-PackageIdCheckExitCode -Result $result | Should -Be 0
+  }
+
+  It 'returns 1 when at least one id is NotFound' {
+    $result = [ordered]@{ Confirmed = @(); NotFound = @(1); Indeterminate = @() }
+
+    Get-PackageIdCheckExitCode -Result $result | Should -Be 1
+  }
+
+  It 'returns 2, distinct from NotFound''s 1, when only Indeterminate ids occurred' {
+    $result = [ordered]@{ Confirmed = @(); NotFound = @(); Indeterminate = @(1) }
+
+    Get-PackageIdCheckExitCode -Result $result | Should -Be 2
+  }
+
+  It 'returns 1 (NotFound takes priority) when both NotFound and Indeterminate occurred' {
+    $result = [ordered]@{ Confirmed = @(); NotFound = @(1); Indeterminate = @(1) }
+
+    Get-PackageIdCheckExitCode -Result $result | Should -Be 1
+  }
+}

--- a/tests/powershell/package-id-checker.Tests.ps1
+++ b/tests/powershell/package-id-checker.Tests.ps1
@@ -1,4 +1,7 @@
 BeforeAll {
+  Import-Module powershell-yaml -RequiredVersion 0.4.12
+
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'configuration-builder.ps1')
   . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'package-id-checker.ps1')
 }
 
@@ -86,5 +89,54 @@ Describe 'Get-PackageIdCheckExitCode' {
     $result = [ordered]@{ Confirmed = @(); NotFound = @(1); Indeterminate = @(1) }
 
     Get-PackageIdCheckExitCode -Result $result | Should -Be 1
+  }
+}
+
+Describe 'Invoke-PackageIdCheck' {
+  BeforeAll {
+    $script:fixturePath = Join-Path -Path $TestDrive -ChildPath 'fixture.dsc.yaml'
+    Set-Content -Path $script:fixturePath -Value @'
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pkg.good
+      settings:
+        id: Vendor.Good
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pkg.bad
+      settings:
+        id: Vendor.Bad
+        source: msstore
+  assertions: []
+'@
+  }
+
+  It 'runs the full pipeline end-to-end: parses, splits, tests, formats, and exits non-zero on NotFound' {
+    Mock Invoke-WingetShow {
+      switch ($Id) {
+        'Vendor.Good' { 0 }
+        'Vendor.Bad' { -1978335212 }
+      }
+    }
+
+    $check = Invoke-PackageIdCheck -DscPath $script:fixturePath
+
+    $check.Result.Confirmed.Count | Should -Be 1
+    $check.Result.NotFound.Count | Should -Be 1
+    $check.Result.NotFound[0].Id | Should -Be 'Vendor.Bad'
+    $check.ExitCode | Should -Be 1
+    ($check.Lines -join "`n") | Should -Match 'Confirmed: 1 package'
+    ($check.Lines -join "`n") | Should -Match 'Vendor\.Bad \(msstore\) exit=-1978335212'
+  }
+
+  It 'always prints the Not found and Indeterminate headers, even at zero count' {
+    Mock Invoke-WingetShow { 0 }
+
+    $check = Invoke-PackageIdCheck -DscPath $script:fixturePath
+
+    $check.Lines | Should -Contain 'Not found (0):'
+    $check.Lines | Should -Contain 'Indeterminate (0):'
+    $check.ExitCode | Should -Be 0
   }
 }


### PR DESCRIPTION
## Summary

Closes #68.

A wrong or stale `WinGetPackage` id is not fixed by `boxstarter.ps1`'s
route fallback (issue #67): the `import` route queries the same
winget, the same id, against the same source, and fails identically.
Until now the only way to catch a bad id was running the full setup
and watching it fail partway through 105 (full) or 48 (min) packages.
This PR adds a read-only, pre-flight check.

## What changed

- **`libs/package-id-checker.ps1`** (new):
  - `Invoke-WingetShow -Id -Source` -- the only function with a real
    winget dependency (`winget show --exact --id <id> --source
    <source> --accept-source-agreements --disable-interactivity`, no
    install). Kept to one line specifically so Pester can mock this
    single function and exercise every other function's logic without
    winget installed.
  - `Test-PackageExistence -Id -Source` -- classifies one pair as
    `Confirmed` / `NotFound` / `Indeterminate` from the exit code.
    Only winget-cli's own documented
    `APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND` exit code
    (`0x8A150014` = `-1978335212`, confirmed against
    [`AppInstallerErrors.h`](https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerSharedLib/Public/AppInstallerErrors.h)
    in the winget-cli source) counts as `NotFound`. Every other
    non-zero exit -- source-open failure, network error, anything this
    script doesn't specifically recognize -- is `Indeterminate`,
    deliberately, per the issue's own instruction not to conflate the
    two.
  - `Test-PackageIdList -Grouped` -- runs `Test-PackageExistence` over
    every id/source pair in a `Split-DscResource` `Grouped` map
    (`libs/configuration-builder.ps1`, issue #66) and buckets the
    results. **Reuses the generation track's parser, does not
    re-implement id/source extraction**, per the issue's own
    requirement.
  - `Get-PackageIdCheckExitCode -Result` -- `1` if any id was
    `NotFound` (checked first: more actionable than `Indeterminate`,
    so it takes priority if both occurred), `2` if only `Indeterminate`
    ids occurred, `0` if everything was `Confirmed`.
- **`scripts/Test-PackageIds.ps1`** (new): CLI entry point. Takes
  `-DscPath`, dot-sources both lib files, prints the confirmed count
  plus the `NotFound`/`Indeterminate` lists (id, source, exit code
  each), and exits with `Get-PackageIdCheckExitCode`'s result.
- **`docs/dsc-migration-notes.md`**: new section -- what the script
  checks, why it reuses the generation track's parser, the exit-code
  classification rule and its rationale, when to run it (after editing
  `dsc.yaml`, or when setup fails on a specific package), and that
  it's Windows-only / not wired into CI (that's issue #69's scope, not
  this one's).

## Verification: real-machine winget check is pending (disclosed per the issue's own instruction)

This Linux dev environment has no `winget`, so `scripts/
Test-PackageIds.ps1` itself has not been run against real winget.
What **is** verified:

- **The winget-cli exit code is not guessed** -- `-1978335212` was
  cross-checked two ways: an independent web search surfaced the same
  value for "No package found matching input criteria", and I fetched
  winget-cli's own `AppInstallerErrors.h` from GitHub and computed the
  signed-32-bit value of `APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND
  (0x8A150014)` directly -- both agree.
- **Classification logic**, tested via Pester with `Invoke-WingetShow`
  mocked (9 new tests, see below) -- exit 0 → `Confirmed`, exit
  `-1978335212` → `NotFound`, any other non-zero (tested with a
  source-open-failure code and an arbitrary unrecognized code) →
  `Indeterminate`, never `NotFound`.
- **End-to-end behavior**, demonstrated with a small 4-id input
  (`Invoke-WingetShow` overridden to simulate two real package ids as
  confirmed, one intentionally-nonexistent id, and one simulated
  source-open failure):

  ```text
  Confirmed: 2 package(s) exist.
  Not found (1):
    - Vendor.DoesNotExist (winget) exit=-1978335212
  Indeterminate (1):
    - Vendor.NetworkFlaky (winget) exit=-1978335163
  Would exit: 1
  ```

  Confirms: the two failure classes land in different buckets, the
  not-found id and only the not-found id is reported as such, and the
  process would exit `1` (not `2`) because a `NotFound` occurred even
  though an `Indeterminate` also occurred.

**Not yet verified**: whether `winget show --exact --id <id> --source
<source>` on a real, current winget install actually returns exactly
`-1978335212` for a nonexistent id (rather than some other error path)
-- this rests on winget-cli's own source being accurate for the
installed version, which could differ across winget releases. Flagged
here rather than left implicit.

## Verification (tooling)

- `markdownlint-cli2 "**/*.md"` -- 0 issues
- `cspell lint "**" --no-progress` -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- 27/27 pass (9 new +
  8 configuration-builder + 10 os-guard, no regression)

## Test plan

- [x] `scripts/Test-PackageIds.ps1` exists, verifies every package id
      in a `dsc.yaml` input
- [x] Id/source extraction reuses the generation track's parser, not
      duplicated here
- [x] Output includes confirmed count, `NotFound` list, and
      `Indeterminate` list
- [x] `NotFound` and `Indeterminate` are tallied separately, never
      conflated
- [x] Non-zero exit when any id is `NotFound`
- [x] `Indeterminate`-only exit code differs from the `NotFound` exit
      code
- [x] Both full and min profiles can be verified (`-DscPath` takes
      either file)
- [x] Usage and timing documented in `docs/dsc-migration-notes.md`
- [x] PSScriptAnalyzer reports nothing for `scripts/Test-PackageIds.ps1`
- [x] Pester tests exist in `tests/powershell/`, mock winget calls, and
      verify the NotFound/Indeterminate split plus exit-code
      differentiation
- [x] Added tests run in CI's `pester` job and are green
- [x] `pre-push-validate` exits 0 on a clean worktree
- [x] Real-machine verification status disclosed (pending; small-input
      behavior demonstrated instead, per the issue's own instruction)
