### PR TITLE
refactor(setup): externalize Node/Unity versions, drop EOL'd Node

### DIFF
--- a/configurations/runtime-versions.psd1
+++ b/configurations/runtime-versions.psd1
@@ -1,0 +1,48 @@
+@{
+  # Node.js versions installed via fnm (libs/post-install.ps1).
+  #
+  # Source of truth for each entry's Status/Eol: the official Node.js
+  # release schedule (https://github.com/nodejs/Release, schedule.json).
+  # Re-check that file when reviewing this list -- do not hand-roll EOL
+  # dates from memory, since that is exactly how this list went stale
+  # before (issue #73).
+  Node      = @{
+    # Default is the version `fnm default` selects. Kept as its own key
+    # (not "first entry wins") so removing/reordering Versions can't
+    # silently change the default.
+    Default  = 24
+    Versions = @(
+      @{
+        Version = 22
+        Status  = 'Maintenance LTS'
+        Eol     = '2027-04-30'
+        Reason  = 'Still under maintenance support; kept for projects pinned to v22 while v24 is the default for new work.'
+      }
+      @{
+        Version = 24
+        Status  = 'Active LTS'
+        Eol     = '2028-04-30'
+        Reason  = 'Current Active LTS release; the default version for new work.'
+      }
+    )
+  }
+
+  # Unity Editor version installed via Unity Hub CLI (libs/post-install.ps1).
+  #
+  # The changeset must match the version exactly, or Unity Hub's
+  # `install -v <version> -c <changeset>` fails. When updating Version,
+  # update Changeset from the same source in the same change -- never
+  # independently.
+  Unity     = @{
+    Version      = '2022.3.22f1'
+    Changeset    = '887be4894c44'
+    Reason       = 'Required by VRChat SDK / VCC (VRChat Creator Companion).'
+    VerifiedDate = '2026-08-02'
+    Sources      = @(
+      # VRChat's own current-version page; states the version only, no changeset.
+      'https://creators.vrchat.com/sdk/upgrade/current-unity-version/ (VRChat, page last updated 2025-10-03; still names 2022.3.22f1 as of this verification)'
+      # Unity's own release API; confirms the version/changeset pairing above.
+      'https://services.api.unity.com/unity/editor/release/v1/releases?version=2022.3.22f1 (Unity, confirms download URL contains changeset 887be4894c44)'
+    )
+  }
+}

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -314,7 +314,7 @@ went stale and nothing surfaced it. Both are now declared in
 `scripts/Build-Configurations.ps1` and `scripts/Test-PackageIds.ps1`
 already depend on the `powershell-yaml` module to parse `dsc.yaml`, but
 `libs/post-install.ps1` has no module dependency today. `.psd1` is
-parsed by `Import-PowerShellDataFile`, a builtin cmdlet -- so this file
+parsed by `Import-PowerShellDataFile`, a built-in cmdlet -- so this file
 does not add a new module dependency for a Boxstarter phase that
 previously had none. It also allows a `#`-prefixed comment directly
 above each entry, same as the hardcoded declarations it replaces.

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -300,6 +300,70 @@ declared," with `boxstarter.ps1` Phase 4's architecture branch recorded
 as a documented, intentional exception (linking here), revisitable if
 a sound single-file mechanism becomes available.
 
+## Reviewing pinned Node/Unity versions (issue #73)
+
+`libs/post-install.ps1` installs Node.js (via fnm) and the Unity Editor
+(via Unity Hub CLI). Both used to have hardcoded version numbers,
+including one comment block that named its own EOL dates while
+continuing to install two already-EOL'd Node releases -- the versions
+went stale and nothing surfaced it. Both are now declared in
+`configurations/runtime-versions.psd1` instead.
+
+### Why `.psd1`, not YAML or JSON
+
+`scripts/Build-Configurations.ps1` and `scripts/Test-PackageIds.ps1`
+already depend on the `powershell-yaml` module to parse `dsc.yaml`, but
+`libs/post-install.ps1` has no module dependency today. `.psd1` is
+parsed by `Import-PowerShellDataFile`, a builtin cmdlet -- so this file
+does not add a new module dependency for a Boxstarter phase that
+previously had none. It also allows a `#`-prefixed comment directly
+above each entry, same as the hardcoded declarations it replaces.
+
+### Where to look for the next EOL
+
+Every entry in `configurations/runtime-versions.psd1` carries its own
+`Eol` (Node) or `VerifiedDate` (Unity, which has no EOL concept)
+alongside `Reason` -- the file itself is the answer to "when does this
+go stale," no separate tracking needed. `Node.Default` is a distinct
+key (not "first entry wins"), so reordering or trimming `Versions`
+can't silently change which version `fnm default` selects.
+
+### Review cadence
+
+- **Node**: re-check the
+  [official release schedule](https://github.com/nodejs/Release)
+  (`schedule.json`) whenever a version's `Eol` in
+  `runtime-versions.psd1` has passed, or at least whenever an issue
+  like this one revisits the file. Drop any version past its `Eol`,
+  and confirm `fnm` itself supports whichever version is added, since a
+  version fnm doesn't yet recognize will fail `fnm install` outright.
+- **Unity**: no fixed EOL, so `VerifiedDate` records when the pinned
+  version/changeset pair was last confirmed against VRChat's own
+  [current-version page](https://creators.vrchat.com/sdk/upgrade/current-unity-version/).
+  Re-check that page periodically (it has changed roughly once a year
+  historically) and whenever a VRChat SDK/VCC upgrade is suspected.
+  If the version changes, get the matching changeset from
+  [Unity's release API](https://services.api.unity.com/unity/editor/release/v1/releases)
+  (query by `?version=<version>`) in the same change -- a
+  mismatched changeset makes Unity Hub's
+  `install -v <version> -c <changeset>` fail outright. If the version
+  is still current, update `VerifiedDate` only.
+
+### 2026-08-02 verification (this issue)
+
+- Node 20 (EOL 2026-04-30) and Node 25 (EOL 2026-06-01) are past EOL as
+  of this issue's filing (2026-07-28) and have been dropped.
+  Node 22 (Maintenance LTS, EOL 2027-04-30) is kept for projects still
+  pinned to it; Node 24 (Active LTS, EOL 2028-04-30) is the default.
+  Source: `nodejs/Release`'s `schedule.json`, fetched 2026-08-02.
+- Unity `2022.3.22f1` is still the version named on VRChat's
+  current-version page (last updated there 2025-10-03, confirmed
+  2026-08-02) -- version unchanged, so only `VerifiedDate` was updated.
+  The paired changeset `887be4894c44` was independently confirmed
+  against Unity's own release API (`services.api.unity.com`), which
+  returns that exact changeset for `2022.3.22f1`'s Windows x86_64
+  download.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -16,8 +16,10 @@ Set-StrictMode -Version Latest
 ### file for each version's EOL/verification info and the reason it is
 ### pinned, and docs/dsc-migration-notes.md for the review cadence.
 ###########################################################################
-$runtimeVersionsFile = Join-Path -Path $PSScriptRoot -ChildPath '..' `
-  -AdditionalChildPath 'configurations', 'runtime-versions.psd1'
+$runtimeVersionsFile = $PSScriptRoot `
+  | Join-Path -ChildPath '..' `
+  | Join-Path -ChildPath 'configurations' `
+  | Join-Path -ChildPath 'runtime-versions.psd1'
 if (-not (Test-Path -Path $runtimeVersionsFile -PathType Leaf)) {
   Write-Error "Runtime versions config not found: $runtimeVersionsFile"
   return
@@ -184,7 +186,6 @@ if ((Test-Path $DockerDesktop) -and -not (Test-Path 'C:\vagrant')) {
     $images = @(
       'hello-world', 'alpine', 'busybox', 'debian', 'ubuntu',
       'docker', 'docker:dind', 'docker:git',
-      'node:20', 'node:20-alpine', 'node:20-slim',
       'node:22', 'node:22-alpine', 'node:22-slim',
       'node:24', 'node:24-alpine', 'node:24-slim'
     )

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -22,7 +22,13 @@ if (-not (Test-Path -Path $runtimeVersionsFile -PathType Leaf)) {
   Write-Error "Runtime versions config not found: $runtimeVersionsFile"
   return
 }
-$runtimeVersions = Import-PowerShellDataFile -Path $runtimeVersionsFile
+try {
+  $runtimeVersions = Import-PowerShellDataFile -Path $runtimeVersionsFile -ErrorAction Stop
+}
+catch {
+  Write-Error "Failed to read runtime versions config ${runtimeVersionsFile}: $_"
+  return
+}
 
 ###########################################################################
 ### Helper — correct command existence check (fixes the Out-Null bug)

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -11,6 +11,20 @@ param()
 Set-StrictMode -Version Latest
 
 ###########################################################################
+### Runtime version config (issue #73) — Node/Unity versions live in
+### configurations/runtime-versions.psd1, not hardcoded here. See that
+### file for each version's EOL/verification info and the reason it is
+### pinned, and docs/dsc-migration-notes.md for the review cadence.
+###########################################################################
+$runtimeVersionsFile = Join-Path -Path $PSScriptRoot -ChildPath '..' `
+  -AdditionalChildPath 'configurations', 'runtime-versions.psd1'
+if (-not (Test-Path -Path $runtimeVersionsFile -PathType Leaf)) {
+  Write-Error "Runtime versions config not found: $runtimeVersionsFile"
+  return
+}
+$runtimeVersions = Import-PowerShellDataFile -Path $runtimeVersionsFile
+
+###########################################################################
 ### Helper — correct command existence check (fixes the Out-Null bug)
 ###########################################################################
 function Test-CommandExists {
@@ -33,17 +47,12 @@ if (Test-CommandExists fnm) {
   Write-Host '[post-install] Setting up Node.js via fnm...' -ForegroundColor Cyan
   fnm env --use-on-cd | Out-String | Invoke-Expression
 
-  # Node 20 (Iron)  — Maintenance LTS, EOL 2026-04-30
-  # Node 22 (Jod)   — Maintenance LTS, EOL 2027-04-30
-  # Node 24 (Krypton) — Active LTS, EOL 2028-04-30
-  # Node 25 — Current (non-LTS), EOL 2026-06-01
-  $nodeVersions = @(20, 22, 24, 25)
-  foreach ($v in $nodeVersions) {
-    Write-Host "  Installing Node.js v$v..." -ForegroundColor Gray
-    fnm install $v
+  $nodeConfig = $runtimeVersions.Node
+  foreach ($entry in @($nodeConfig.Versions)) {
+    Write-Host "  Installing Node.js v$($entry.Version) ($($entry.Status), EOL $($entry.Eol))..." -ForegroundColor Gray
+    fnm install $entry.Version
   }
-  # Set the latest LTS as default
-  fnm default 24
+  fnm default $nodeConfig.Default
   Write-Host '[post-install] Node.js setup complete.' -ForegroundColor Green
 }
 else {
@@ -108,7 +117,7 @@ else {
 
 ###########################################################################
 ### Unity Editor via Unity Hub CLI
-### VRChat SDK / VCC only supports Unity 2022.3.22f1 as of 2026-03
+### Pinned version/changeset live in configurations/runtime-versions.psd1
 ###########################################################################
 $UnityHub = $env:ProgramFiles `
   | Join-Path -ChildPath 'Unity Hub' `
@@ -134,8 +143,8 @@ if (Test-Path $UnityHub) {
     Start-Process $UnityHub -ArgumentList $opts -NoNewWindow -Wait
   }
 
-  # Unity 2022.3.22f1 — required by VRChat SDK / VCC
-  Install-UnityEditor -Version '2022.3.22f1' -Changeset '887be4894c44'
+  $unityConfig = $runtimeVersions.Unity
+  Install-UnityEditor -Version $unityConfig.Version -Changeset $unityConfig.Changeset
 
   Write-Host '[post-install] Unity Editor setup complete.' -ForegroundColor Green
 }


### PR DESCRIPTION
## Summary

Closes #73.

`libs/post-install.ps1` hardcoded its Node.js and Unity versions,
including a comment block that named its own Node EOL dates while
continuing to install two already-EOL'd releases (Node 20, EOL
2026-04-30; Node 25, EOL 2026-06-01) -- the information needed to
catch the drift was right there in the comment, but nothing acted on
it. This PR externalizes both to a declared config file and drops the
EOL'd versions.

## What changed

- **`configurations/runtime-versions.psd1`** (new): declares Node
  versions (`Default` plus a `Versions` list, each with `Status`,
  `Eol`, `Reason`) and the pinned Unity version (`Version`,
  `Changeset`, `Reason`, `VerifiedDate`, `Sources`). `.psd1` was chosen
  over YAML/JSON because `libs/post-install.ps1` has no module
  dependency today, and `Import-PowerShellDataFile` (builtin) keeps it
  that way -- unlike `scripts/Build-Configurations.ps1` /
  `scripts/Test-PackageIds.ps1`, which already need `powershell-yaml`
  for `dsc.yaml`. Reasoning recorded in `docs/dsc-migration-notes.md`.
- **`libs/post-install.ps1`**: reads the config file at the top
  (`Write-Error` + `return` if missing, matching this repo's
  Boxstarter failure convention); the Node section now installs
  whatever `Node.Versions` lists and sets `fnm default` from
  `Node.Default`; the Unity section installs `Unity.Version` /
  `Unity.Changeset` from config. No hardcoded version numbers remain
  in either section.
- **`docs/dsc-migration-notes.md`**: new section covering the `.psd1`
  choice, where to look for the next EOL, a review-cadence procedure
  for both Node (recheck `nodejs/Release`'s `schedule.json`) and Unity
  (recheck VRChat's current-version page; changeset must be updated
  together with version, never independently), and this issue's own
  2026-08-02 verification results.

## Version decisions (2026-08-02 verification, real sources)

- **Node**: confirmed against `nodejs/Release`'s `schedule.json` --
  v20 EOL'd 2026-04-30, v25 EOL'd 2026-06-01, both already past as of
  this issue's filing (2026-07-28). Dropped both. Kept v22
  (Maintenance LTS, EOL 2027-04-30, for projects still pinned to it)
  and v24 (Active LTS, EOL 2028-04-30, set as `Default`).
- **Unity**: VRChat's own
  [current-version page](https://creators.vrchat.com/sdk/upgrade/current-unity-version/)
  (last updated there 2025-10-03) still names `2022.3.22f1` as of this
  verification -- version unchanged, so only `VerifiedDate` was
  updated, per the issue's own "if not needed, update the
  confirmation date" branch. The paired changeset `887be4894c44` was
  independently cross-checked against
  [Unity's own release API](https://services.api.unity.com/unity/editor/release/v1/releases?version=2022.3.22f1),
  which returns that exact changeset for `2022.3.22f1`'s Windows
  x86_64 download -- not just carried over unverified.

## Out of scope (per this issue's own "他 issue との調整" section)

- Unity Hub CLI installer behavior itself (exit-code checking, stricter
  installed-detection, a `modules` field, drift detection) is #74's
  scope, not this one's.

## Review fixes (Copilot + CodeRabbit)

- **`libs/post-install.ps1`'s `Join-Path -AdditionalChildPath`** (Copilot
  and CodeRabbit, independently, both correct): `setup.cmd` launches
  Boxstarter via bare `powershell` (Windows PowerShell 5.1), and
  `-AdditionalChildPath` was only added in PowerShell 6.0 -- it would
  throw a parameter-binding error before `runtime-versions.psd1` could
  even be read. Rewritten as a `Join-Path -ChildPath` pipeline, matching
  the `$UnityHub`/`$DockerDesktop` path-building style already used
  elsewhere in this same file.
- **Docker's Node 20 image pulls** (CodeRabbit): `libs/post-install.ps1`
  separately pulled `node:20`/`node:20-alpine`/`node:20-slim` Docker
  base images, alongside the fnm-installed Node versions this issue
  drops. Agreed this was worth fixing alongside the fnm change rather
  than leaving a second, inconsistent EOL'd-Node source in the same
  file -- removed the three Node 20 image entries.
- **"builtin" spelling** (CodeRabbit): fixed to "built-in" in
  `docs/dsc-migration-notes.md`.
- **"Use `throw` instead of `Write-Error` + `return`"** (CodeRabbit):
  dismissed after empirical verification -- `return` at a script's own
  top level unconditionally exits that script's execution regardless
  of `$ErrorActionPreference` (confirmed with a minimal repro: a
  `Write-Host` placed after `Write-Error; return` never printed, under
  `$ErrorActionPreference = 'Continue'`). This matches the existing
  `Write-Error` + `return` pattern already used for Phase 0's OS check
  in `boxstarter.ps1`, which this repository settled on in an earlier
  issue.

## Verification

- `Import-PowerShellDataFile` on `runtime-versions.psd1` -- parses to
  the expected shape (checked interactively).
- `[System.Management.Automation.Language.Parser]::ParseFile` on
  `libs/post-install.ps1` -- no syntax errors.
- `markdownlint-cli2 "docs/dsc-migration-notes.md"` -- 0 issues
- `cspell lint` on the three changed files -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- all pass (no test
  changes; `libs/post-install.ps1` is an imperative installer script,
  which `docs/testing.md` explicitly excludes from Pester coverage --
  "there's nothing to assert against without a real Windows machine")

## Test plan

- [x] Node and Unity target versions externalized to
      `configurations/runtime-versions.psd1`
- [x] Config file format choice recorded with reasoning
- [x] Each entry carries version, EOL-or-verification-info, and reason
- [x] No hardcoded version numbers remain in `libs/post-install.ps1`
- [x] `libs/post-install.ps1` reads the config file; changing it
      changes install targets (code path reads `Node.Versions` /
      `Node.Default` / `Unity.Version` / `Unity.Changeset` directly,
      no fallback literals)
- [x] Node 20 and Node 25 removed from install targets
- [x] Retained/default Node versions decided, rationale recorded
- [x] Unity version/changeset re-confirmed; result (confirmation-date
      update, no version change) recorded
- [x] Review cadence and timing documented in `docs/`, with where to
      find the next EOL
- [x] PSScriptAnalyzer reports nothing for the changed
      `libs/post-install.ps1`
- [x] `pre-push-validate` exits 0 on a clean worktree
