### PR TITLE
feat(setup): install and pin the Unity CLI binary

### DIFF
--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -176,6 +176,12 @@ else {
 ###########################################################################
 ### Phase 5 — Post-install setup (fnm, cargo, Unity, mkcert, Docker)
 ###########################################################################
+# Unity CLI must be in place before post-install.ps1's own Unity Editor
+# install step (issue #76) -- installed here, ahead of that step, rather
+# than as its own numbered phase, to avoid renumbering every phase below.
+. (Join-Path $scriptRoot 'libs\unity-cli-installer.ps1')
+Sync-UnityCli -ConfigPath (Join-Path $scriptRoot 'configurations\runtime-versions.psd1')
+
 $postInstall = Join-Path $scriptRoot 'libs\post-install.ps1'
 if (Test-Path $postInstall) {
   Write-Host '[Phase 5] Running post-install setup...' -ForegroundColor Cyan

--- a/configurations/runtime-versions.psd1
+++ b/configurations/runtime-versions.psd1
@@ -45,4 +45,28 @@
       'https://services.api.unity.com/unity/editor/release/v1/releases?version=2022.3.22f1 (Unity, confirms download URL contains changeset 887be4894c44)'
     )
   }
+
+  # Unity CLI (`unity` binary, libs/unity-cli-installer.ps1) -- not the
+  # Unity Editor itself. Pinned because the CLI is still experimental
+  # (Unity's own docs: "The features and documentation might change in
+  # an upcoming release.").
+  #
+  # Target is passed to install.ps1's -Target; Channel is passed to
+  # -Channel / $env:UNITY_CLI_CHANNEL, though install.ps1's own source
+  # shows -Channel only affects "latest" resolution -- once Target is a
+  # pinned version (not "latest"), install.ps1 fetches that version's
+  # own manifest directly and Channel has no functional effect. Kept
+  # here anyway to record which channel this pinned version came from.
+  UnityCli  = @{
+    Target       = '1.0.0-beta.3'
+    Channel      = 'beta'
+    Reason       = 'CLI is experimental; the stable/GA manifest returns HTTP 404 (no stable release published yet) as of VerifiedDate -- beta is not merely preferred, it is the only channel with any build.'
+    VerifiedDate = '2026-08-02'
+    Sources      = @(
+      # The stable/GA manifest itself, confirming no build exists yet.
+      'https://public-cdn.cloud.unity3d.com/hub/prod/cli/latest.json (Unity CDN, HTTP 404 as of VerifiedDate)'
+      # The beta manifest, confirming the pinned version and its availability.
+      'https://public-cdn.cloud.unity3d.com/hub/prod/cli/latest-beta.json (Unity CDN, HTTP 200, version 1.0.0-beta.3 as of VerifiedDate)'
+    )
+  }
 }

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -364,6 +364,114 @@ can't silently change which version `fnm default` selects.
   returns that exact changeset for `2022.3.22f1`'s Windows x86_64
   download.
 
+## Installing the Unity CLI (issue #76)
+
+Unity's CLI (`unity` binary) is a second, official way to manage Unity
+Editor installs, distinct from Unity Hub's unofficial `-- --headless`
+interface already used by `libs/post-install.ps1`. This issue installs
+only the CLI binary itself, via Unity's own installer script
+(`https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.ps1`), from
+`libs/unity-cli-installer.ps1`. Switching Editor installation from Hub
+to CLI is a separate, later issue's scope.
+
+### The stable channel does not exist yet (verified 2026-08-02)
+
+The Unity CLI's own docs list `beta` in every Windows example, without
+saying whether that's a preference or a necessity. Checked directly
+against the CDN itself:
+
+| Manifest | URL | HTTP status |
+| --- | --- | --- |
+| stable/GA | `.../cli/latest.json` | **404** |
+| beta | `.../cli/latest-beta.json` | 200 (`1.0.0-beta.3`) |
+| alpha | `.../cli/latest-alpha.json` | 404 |
+
+Beta is not merely recommended -- as of this verification, it is the
+*only* channel with a published build. `configurations/runtime-versions.psd1`'s
+`UnityCli.Channel` records this as `beta` with the reason and the date
+checked, per the review-cadence pattern issue #73 established. Re-check
+these three URLs when reviewing this entry; a `latest.json` 200 would
+mean a stable release has shipped.
+
+### `-Target` pins the version; `-Channel` only matters unpinned
+
+Reading `install.ps1`'s own source (not just its docs) matters here:
+when `-Target` is a concrete version (not `"latest"`), the script
+fetches that version's own manifest directly
+(`.../cli/<version>/latest.json`) and never consults `-Channel` /
+`$env:UNITY_CLI_CHANNEL` at all -- channel selection only resolves what
+`"latest"` means. `runtime-versions.psd1` pins `Target` to
+`1.0.0-beta.3` (the exact version confirmed available above), so
+`Channel: beta` is recorded for traceability only; it has no effect on
+this pinned install. If `Target` is ever changed back to `"latest"`,
+`Channel` starts mattering again.
+
+### Never invoke `install.ps1`'s downloaded content as an in-process scriptblock
+
+`install.ps1` calls `exit 1` on several of its own failure paths. This
+matters more than it looks: invoking downloaded script content
+in-process (e.g. `& [scriptblock]::Create($content) -Target ...`, or
+the official `irm ... | iex` one-liner with parameters spliced into the
+string) runs that `exit` in the *caller's own process*. Confirmed
+empirically with a minimal repro (a scriptblock containing `exit 1`
+invoked via `& $sb`, followed by a line that never printed) -- `exit`
+inside an in-process-invoked scriptblock terminates the entire
+PowerShell host, not just the scriptblock, silently aborting whatever
+of `boxstarter.ps1` was still queued behind it. `Invoke-UnityCliInstaller`
+in `libs/unity-cli-installer.ps1` downloads `install.ps1` to a temp file
+and runs it via `Start-Process -Wait -PassThru` in a **separate**
+process instead, so its exit code can be inspected and handled without
+risk to the calling process.
+
+### `install.ps1` itself is not pinned
+
+Unlike the binary it downloads (SHA-256 verified by the script itself),
+`install.ps1` is fetched fresh on every run and is not pinned by hash
+or version. This is the same trust model as any curl-pipe-to-shell
+bootstrap (Chocolatey's own installer, Scoop's) -- a compromise of
+Unity's CDN could serve a different script. Recorded here as a known,
+accepted risk rather than left implicit; mitigating it (e.g. pinning
+and re-verifying a hash of `install.ps1` itself) is out of this issue's
+scope.
+
+### PATH is not live in the current process after install
+
+`install.ps1` updates the persistent User-scope PATH
+(`[System.Environment]::SetEnvironmentVariable(..., "User")`) and
+broadcasts `WM_SETTINGCHANGE` so new shells and Explorer pick it up --
+but never touches `$env:Path` in its own process, let alone the
+calling one. `Sync-UnityCli` calls `Add-UnityCliToProcessPath` both
+before checking whether the CLI is already installed (so an existing
+install from a prior run is found) and after a fresh install (so
+`unity` is callable later in the same `boxstarter.ps1` run without a
+new shell).
+
+### Unity Hub stays installed; `com.unity.pipeline` is out of scope
+
+`configurations/packages.dsc.yaml` keeps `Unity.UnityHub`. VRChat
+Creator Companion may recognize installed Editors through Hub, and
+removing Hub without confirming that would risk breaking VCC; whether
+Hub can eventually be dropped is left to a future issue, not decided
+here. Separately, `com.unity.pipeline` (a beta Unity package that talks
+to a running Editor over local HTTP, requiring the CLI as a
+precondition) is installed into a Unity **project**, not this
+machine-setup repository -- out of scope here beyond this note.
+
+### Not verified on a real machine
+
+Like issue #68's package-id checker, this Windows-only script could not
+be run against a real `unity` binary or `install.ps1` invocation from
+this Linux development environment. `libs/post-install.ps1` and
+`boxstarter.ps1` are also never executed directly in this environment
+even for smoke-testing, since doing so risks running real installers
+present on the shared machine's PATH (learned the hard way during
+issue #73). What *is* verified: `install.ps1`'s actual source was read
+end to end (not assumed from its docs), the channel-manifest HTTP
+checks above were run for real, and `Sync-UnityCli`'s idempotency and
+error-handling logic is covered by Pester with
+`Get-InstalledUnityCliVersion` / `Invoke-UnityCliInstaller` mocked --
+see `tests/powershell/unity-cli-installer.Tests.ps1`.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -16,19 +16,13 @@ Set-StrictMode -Version Latest
 ### file for each version's EOL/verification info and the reason it is
 ### pinned, and docs/dsc-migration-notes.md for the review cadence.
 ###########################################################################
+. (Join-Path -Path $PSScriptRoot -ChildPath 'runtime-versions.ps1')
 $runtimeVersionsFile = $PSScriptRoot `
   | Join-Path -ChildPath '..' `
   | Join-Path -ChildPath 'configurations' `
   | Join-Path -ChildPath 'runtime-versions.psd1'
-if (-not (Test-Path -Path $runtimeVersionsFile -PathType Leaf)) {
-  Write-Error "Runtime versions config not found: $runtimeVersionsFile"
-  return
-}
-try {
-  $runtimeVersions = Import-PowerShellDataFile -Path $runtimeVersionsFile -ErrorAction Stop
-}
-catch {
-  Write-Error "Failed to read runtime versions config ${runtimeVersionsFile}: $_"
+$runtimeVersions = Get-RuntimeVersionsConfig -Path $runtimeVersionsFile
+if ($null -eq $runtimeVersions) {
   return
 }
 

--- a/libs/runtime-versions.ps1
+++ b/libs/runtime-versions.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Shared reader for configurations/runtime-versions.psd1 -- the single
+source of truth for pinned Node, Unity Editor, and Unity CLI versions.
+
+This file is dot-sourced (not imported as a module) from post-install.ps1
+and unity-cli-installer.ps1 -- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+function Get-RuntimeVersionsConfig {
+  param (
+    [Parameter(Mandatory)][string]$Path
+  )
+  if (-not (Test-Path -Path $Path -PathType Leaf)) {
+    Write-Error "Runtime versions config not found: $Path"
+    return $null
+  }
+  try {
+    return Import-PowerShellDataFile -Path $Path -ErrorAction Stop
+  }
+  catch {
+    Write-Error "Failed to read runtime versions config ${Path}: $_"
+    return $null
+  }
+  <#
+  .SYNOPSIS
+  Reads and parses configurations/runtime-versions.psd1, returning $null
+  (after Write-Error) on a missing or unreadable file instead of letting
+  Import-PowerShellDataFile's own error surface, so every caller fails
+  the same way regardless of which failure mode occurred.
+
+  .OUTPUTS
+  The parsed hashtable, or $null if the file is missing or malformed.
+  Callers must check for $null and return/abort -- this function does
+  not throw, matching Set-StrictMode callers that run under Boxstarter's
+  Write-Error + return convention.
+  #>
+}

--- a/libs/unity-cli-installer.ps1
+++ b/libs/unity-cli-installer.ps1
@@ -1,0 +1,175 @@
+<#
+.SYNOPSIS
+Installs and pins the Unity CLI (`unity` binary), idempotently, per
+configurations/runtime-versions.psd1's UnityCli entry.
+
+This file is dot-sourced (not imported as a module) from boxstarter.ps1
+-- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'runtime-versions.ps1')
+
+$Script:UnityCliInstallScriptUrl = 'https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.ps1'
+# $env:LOCALAPPDATA is Windows-only and absent on the Linux CI runner
+# that runs this file's Pester tests -- guarded so dot-sourcing this
+# file doesn't fail there. Every real caller passes -InstallDir
+# explicitly or runs on Windows, where LOCALAPPDATA is always set.
+$Script:UnityCliInstallDir = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'Unity\bin' } else { $null }
+
+function Get-InstalledUnityCliVersion {
+  if (-not (Get-Command unity -CommandType Application -ErrorAction SilentlyContinue)) {
+    return @{ Found = $false; Output = ''; ExitCode = $null }
+  }
+  $output = (& unity --version 2>&1 | Out-String).Trim()
+  return @{ Found = $true; Output = $output; ExitCode = $LASTEXITCODE }
+  <#
+  .SYNOPSIS
+  Runs `unity --version` if the binary is on PATH. This is the only
+  function in this file with a real dependency on the installed CLI,
+  kept to a few lines specifically so Pester can mock this single
+  function and exercise every other function's logic without a real
+  Unity CLI installed.
+
+  .OUTPUTS
+  Hashtable: Found ($false if `unity` isn't on PATH at all), Output (raw
+  trimmed stdout+stderr text), ExitCode ($null when Found is $false).
+  #>
+}
+
+function Test-UnityCliCurrent {
+  param (
+    [Parameter(Mandatory)][hashtable]$Installed,
+    [Parameter(Mandatory)][string]$Target
+  )
+  if (-not $Installed.Found -or $Installed.ExitCode -ne 0) {
+    return $false
+  }
+  return $Installed.Output -match [regex]::Escape($Target)
+  <#
+  .SYNOPSIS
+  Decides whether an already-installed Unity CLI already matches the
+  declared Target version.
+
+  .DESCRIPTION
+  `unity --version`'s exact output format isn't documented anywhere
+  found during this issue's research (Unity's own CLI reference page
+  covers every other command's output but not this one) and could not
+  be verified on a real Windows machine either -- see the "Not verified
+  on a real machine" note in this PR. A substring match against the
+  declared Target is deliberately used instead of parsing an assumed
+  exact format, so this stays correct even if the real output turns out
+  to look different than expected (e.g. "unity-cli 1.0.0-beta.3" or
+  just "1.0.0-beta.3" both match).
+  #>
+}
+
+function Invoke-UnityCliInstaller {
+  param (
+    [Parameter(Mandatory)][string]$Target,
+    [Parameter(Mandatory)][string]$Channel,
+    [string]$InstallScriptUrl = $Script:UnityCliInstallScriptUrl
+  )
+  $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) "unity-cli-install-$([guid]::NewGuid().ToString('N')).ps1"
+  try {
+    Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $tempScript -UseBasicParsing
+    $shell = (Get-Process -Id $PID).Path
+    $process = Start-Process -FilePath $shell -ArgumentList @(
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $tempScript,
+      '-Target', $Target, '-Channel', $Channel
+    ) -NoNewWindow -Wait -PassThru
+    return $process.ExitCode
+  }
+  finally {
+    Remove-Item -Path $tempScript -Force -ErrorAction SilentlyContinue
+  }
+  <#
+  .SYNOPSIS
+  Downloads Unity's own install.ps1 and runs it to install the pinned
+  Target version.
+
+  .DESCRIPTION
+  Runs install.ps1 in a SEPARATE process via Start-Process, never
+  in-process (e.g. never `& [scriptblock]::Create($downloadedContent)`).
+  install.ps1 itself calls `exit 1` on several failure paths -- an
+  in-process scriptblock invocation confirmed empirically to terminate
+  the *entire calling PowerShell process* on `exit`, not just return
+  from the scriptblock, which would silently abort the rest of
+  boxstarter.ps1's phases on any Unity CLI installer failure. A
+  separate process confines that `exit` to the child, so its exit code
+  can be inspected and handled by the caller instead.
+
+  install.ps1's own script is not pinned by hash or version -- only the
+  binary it downloads is (SHA-256, verified by install.ps1 itself). This
+  is the same trust model as any curl-pipe-to-shell bootstrap (Chocolatey,
+  Scoop); see docs/dsc-migration-notes.md for the recorded risk.
+
+  .OUTPUTS
+  The child process's exit code. install.ps1 does not call `exit 0` on
+  its success path, so a clean run's exit code is whatever a script
+  falling off the end returns (0).
+  #>
+}
+
+function Add-UnityCliToProcessPath {
+  param (
+    [string]$InstallDir = $Script:UnityCliInstallDir
+  )
+  $current = @($env:Path -split ';' | Where-Object { $_ -ne '' })
+  $target = $InstallDir.TrimEnd('\', '/')
+  $alreadyPresent = $current | Where-Object {
+    [string]::Equals($_.TrimEnd('\', '/'), $target, [System.StringComparison]::OrdinalIgnoreCase)
+  }
+  if (-not $alreadyPresent) {
+    $env:Path = (@($current) + $InstallDir) -join ';'
+  }
+  <#
+  .SYNOPSIS
+  Adds the Unity CLI install directory to the *current process's*
+  $env:Path.
+
+  .DESCRIPTION
+  install.ps1 updates the persistent User-scope PATH (via
+  [System.Environment]::SetEnvironmentVariable(..., "User")) and
+  broadcasts WM_SETTINGCHANGE, but neither reaches the environment of
+  the already-running boxstarter.ps1 process -- confirmed by reading
+  install.ps1's own source, which never touches $env:Path. Without
+  this, a `unity` call later in the same setup run would fail even
+  immediately after a successful install.
+  #>
+}
+
+function Sync-UnityCli {
+  param (
+    [Parameter(Mandatory)][string]$ConfigPath
+  )
+  $config = Get-RuntimeVersionsConfig -Path $ConfigPath
+  if ($null -eq $config) {
+    return
+  }
+  $unityCli = $config.UnityCli
+
+  Add-UnityCliToProcessPath
+
+  $installed = Get-InstalledUnityCliVersion
+  if (Test-UnityCliCurrent -Installed $installed -Target $unityCli.Target) {
+    Write-Host "[unity-cli] Unity CLI $($unityCli.Target) already installed -- skipping." -ForegroundColor Gray
+    return
+  }
+
+  Write-Host "[unity-cli] Installing Unity CLI $($unityCli.Target) (channel: $($unityCli.Channel))..." -ForegroundColor Cyan
+  $exitCode = Invoke-UnityCliInstaller -Target $unityCli.Target -Channel $unityCli.Channel
+  if ($exitCode -ne 0) {
+    Write-Error "Unity CLI installer exited with code ${exitCode}."
+    return
+  }
+
+  Add-UnityCliToProcessPath
+  Write-Host '[unity-cli] Unity CLI installation complete.' -ForegroundColor Green
+  <#
+  .SYNOPSIS
+  Idempotent entry point: installs the Unity CLI only if it isn't
+  already at the declared Target version, per
+  configurations/runtime-versions.psd1's UnityCli entry.
+  #>
+}

--- a/libs/unity-cli-installer.ps1
+++ b/libs/unity-cli-installer.ps1
@@ -115,6 +115,9 @@ function Add-UnityCliToProcessPath {
   param (
     [string]$InstallDir = $Script:UnityCliInstallDir
   )
+  if ([string]::IsNullOrEmpty($InstallDir)) {
+    return
+  }
   $current = @($env:Path -split ';' | Where-Object { $_ -ne '' })
   $target = $InstallDir.TrimEnd('\', '/')
   $alreadyPresent = $current | Where-Object {
@@ -136,6 +139,10 @@ function Add-UnityCliToProcessPath {
   install.ps1's own source, which never touches $env:Path. Without
   this, a `unity` call later in the same setup run would fail even
   immediately after a successful install.
+
+  A null/empty InstallDir (e.g. the default on a machine without
+  $env:LOCALAPPDATA, such as this file's own Linux Pester run) is a
+  no-op rather than an error -- there is nothing to add.
   #>
 }
 
@@ -145,6 +152,11 @@ function Sync-UnityCli {
   )
   $config = Get-RuntimeVersionsConfig -Path $ConfigPath
   if ($null -eq $config) {
+    return
+  }
+  if (-not $config.Contains('UnityCli') -or
+    -not $config.UnityCli.Contains('Target') -or -not $config.UnityCli.Contains('Channel')) {
+    Write-Error "Runtime versions config ${ConfigPath} is missing a UnityCli.Target/UnityCli.Channel entry."
     return
   }
   $unityCli = $config.UnityCli

--- a/tests/powershell/runtime-versions.Tests.ps1
+++ b/tests/powershell/runtime-versions.Tests.ps1
@@ -1,0 +1,31 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'runtime-versions.ps1')
+}
+
+Describe 'Get-RuntimeVersionsConfig' {
+  It 'returns the parsed hashtable for a valid file' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'valid.psd1'
+    Set-Content -Path $path -Value "@{ Foo = 'bar' }"
+
+    $result = Get-RuntimeVersionsConfig -Path $path
+
+    $result.Foo | Should -Be 'bar'
+  }
+
+  It 'returns $null, not a thrown error, when the file does not exist' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'missing.psd1'
+
+    $result = Get-RuntimeVersionsConfig -Path $path -ErrorAction SilentlyContinue
+
+    $result | Should -BeNullOrEmpty
+  }
+
+  It 'returns $null, not a thrown error, when the file is not valid PowerShell data' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'malformed.psd1'
+    Set-Content -Path $path -Value 'this is not { valid psd1 syntax'
+
+    $result = Get-RuntimeVersionsConfig -Path $path -ErrorAction SilentlyContinue
+
+    $result | Should -BeNullOrEmpty
+  }
+}

--- a/tests/powershell/unity-cli-installer.Tests.ps1
+++ b/tests/powershell/unity-cli-installer.Tests.ps1
@@ -52,6 +52,14 @@ Describe 'Add-UnityCliToProcessPath' {
 
     ($env:Path -split ';' | Where-Object { $_ -ne '' }).Count | Should -Be 2
   }
+
+  It 'no-ops instead of throwing when InstallDir is null or empty' {
+    $env:Path = '/existing/one'
+
+    { Add-UnityCliToProcessPath -InstallDir $null } | Should -Not -Throw
+    { Add-UnityCliToProcessPath -InstallDir '' } | Should -Not -Throw
+    $env:Path | Should -Be '/existing/one'
+  }
 }
 
 Describe 'Sync-UnityCli' {
@@ -108,5 +116,19 @@ Describe 'Sync-UnityCli' {
 
   It 'writes a non-terminating error and does not throw when the config file is missing' {
     { Sync-UnityCli -ConfigPath (Join-Path $TestDrive 'does-not-exist.psd1') -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'writes a non-terminating error and does not throw when the UnityCli entry is missing' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'no-unity-cli.psd1'
+    Set-Content -Path $path -Value "@{ Node = @{} }"
+
+    { Sync-UnityCli -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'writes a non-terminating error and does not throw when UnityCli is missing Target/Channel' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'incomplete-unity-cli.psd1'
+    Set-Content -Path $path -Value "@{ UnityCli = @{ Target = '1.0.0-beta.3' } }"
+
+    { Sync-UnityCli -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
   }
 }

--- a/tests/powershell/unity-cli-installer.Tests.ps1
+++ b/tests/powershell/unity-cli-installer.Tests.ps1
@@ -1,0 +1,112 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'unity-cli-installer.ps1')
+}
+
+Describe 'Test-UnityCliCurrent' {
+  It 'returns $false when the CLI is not on PATH' {
+    $installed = @{ Found = $false; Output = ''; ExitCode = $null }
+
+    Test-UnityCliCurrent -Installed $installed -Target '1.0.0-beta.3' | Should -Be $false
+  }
+
+  It 'returns $false when `unity --version` exited non-zero' {
+    $installed = @{ Found = $true; Output = '1.0.0-beta.3'; ExitCode = 1 }
+
+    Test-UnityCliCurrent -Installed $installed -Target '1.0.0-beta.3' | Should -Be $false
+  }
+
+  It 'returns $true when the declared Target appears in the output' {
+    $installed = @{ Found = $true; Output = 'unity-cli 1.0.0-beta.3'; ExitCode = 0 }
+
+    Test-UnityCliCurrent -Installed $installed -Target '1.0.0-beta.3' | Should -Be $true
+  }
+
+  It 'returns $false when the output names a different version' {
+    $installed = @{ Found = $true; Output = 'unity-cli 1.0.0-beta.2'; ExitCode = 0 }
+
+    Test-UnityCliCurrent -Installed $installed -Target '1.0.0-beta.3' | Should -Be $false
+  }
+}
+
+Describe 'Add-UnityCliToProcessPath' {
+  BeforeEach {
+    $script:originalPath = $env:Path
+  }
+
+  AfterEach {
+    $env:Path = $script:originalPath
+  }
+
+  It 'appends the install dir when not already present' {
+    $env:Path = '/existing/one;/existing/two'
+
+    Add-UnityCliToProcessPath -InstallDir '/unity/bin'
+
+    $env:Path | Should -Match ([regex]::Escape('/unity/bin'))
+  }
+
+  It 'does not duplicate an entry that only differs by case or a trailing slash' {
+    $env:Path = '/Existing/UNITY/BIN/;/existing/two'
+
+    Add-UnityCliToProcessPath -InstallDir '/existing/unity/bin'
+
+    ($env:Path -split ';' | Where-Object { $_ -ne '' }).Count | Should -Be 2
+  }
+}
+
+Describe 'Sync-UnityCli' {
+  BeforeAll {
+    $script:configPath = Join-Path -Path $TestDrive -ChildPath 'runtime-versions.psd1'
+    Set-Content -Path $script:configPath -Value @'
+@{
+  UnityCli = @{
+    Target  = '1.0.0-beta.3'
+    Channel = 'beta'
+  }
+}
+'@
+  }
+
+  It 'skips installation when the CLI already matches Target' {
+    Mock Get-InstalledUnityCliVersion { @{ Found = $true; Output = '1.0.0-beta.3'; ExitCode = 0 } }
+    Mock Invoke-UnityCliInstaller { 0 }
+    Mock Add-UnityCliToProcessPath { }
+
+    Sync-UnityCli -ConfigPath $script:configPath
+
+    Should -Invoke Invoke-UnityCliInstaller -Times 0
+  }
+
+  It 'installs when the CLI is missing, then does not reinstall on a second run (idempotent)' {
+    $script:installed = $false
+    Mock Get-InstalledUnityCliVersion {
+      if ($script:installed) {
+        return @{ Found = $true; Output = '1.0.0-beta.3'; ExitCode = 0 }
+      }
+      return @{ Found = $false; Output = ''; ExitCode = $null }
+    }
+    Mock Invoke-UnityCliInstaller {
+      $script:installed = $true
+      return 0
+    }
+    Mock Add-UnityCliToProcessPath { }
+
+    Sync-UnityCli -ConfigPath $script:configPath
+    Should -Invoke Invoke-UnityCliInstaller -Times 1
+
+    Sync-UnityCli -ConfigPath $script:configPath
+    Should -Invoke Invoke-UnityCliInstaller -Times 1
+  }
+
+  It 'writes a non-terminating error and does not throw when the installer exits non-zero' {
+    Mock Get-InstalledUnityCliVersion { @{ Found = $false; Output = ''; ExitCode = $null } }
+    Mock Invoke-UnityCliInstaller { 1 }
+    Mock Add-UnityCliToProcessPath { }
+
+    { Sync-UnityCli -ConfigPath $script:configPath -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'writes a non-terminating error and does not throw when the config file is missing' {
+    { Sync-UnityCli -ConfigPath (Join-Path $TestDrive 'does-not-exist.psd1') -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+}


### PR DESCRIPTION
## Summary

Closes #76.

Unity shipped an official CLI (`unity` binary) with a documented
exit-code contract, structured (`json`/`tsv`) output, and a `-Target`
flag for pinning versions -- unlike Unity Hub's unofficial
`-- --headless` interface `libs/post-install.ps1` already drives. This
PR installs and pins the CLI binary itself. Switching Editor
installation from Hub to the CLI is a separate, later issue's scope
(per this issue's own "この issue のスコープ" section).

## What changed

- **`configurations/runtime-versions.psd1`**: new `UnityCli` entry
  (`Target`, `Channel`, `Reason`, `VerifiedDate`, `Sources`), following
  the same format issue #73 established for Node/Unity Editor.
- **`libs/runtime-versions.ps1`** (new): `Get-RuntimeVersionsConfig`,
  factored out of `libs/post-install.ps1`'s existing read-and-parse
  logic so both it and the new installer share one error-handling path
  instead of duplicating it.
- **`libs/unity-cli-installer.ps1`** (new): `Sync-UnityCli`, an
  idempotent installer --
  - `Get-InstalledUnityCliVersion` (the one function with a real
    dependency on an installed `unity`, kept mockable like
    `Invoke-WingetShow` in issue #68's checker)
  - `Test-UnityCliCurrent` (pure decision: does the installed CLI
    already match the declared `Target`)
  - `Invoke-UnityCliInstaller` (downloads Unity's own `install.ps1` and
    runs it -- see "Why a separate process" below)
  - `Add-UnityCliToProcessPath` (install.ps1 updates the persistent
    User PATH but not the current process's `$env:Path`)
- **`libs/post-install.ps1`**: now reads `configurations/runtime-versions.psd1`
  via the shared `Get-RuntimeVersionsConfig` instead of its own inline
  copy of the same logic. No behavior change.
- **`boxstarter.ps1`**: Phase 5 now calls `Sync-UnityCli` before
  invoking `post-install.ps1` (which does the actual Unity Editor
  install). Kept inside the existing Phase 5 rather than as a new
  numbered phase, to satisfy "before the Editor-install phase" without
  renumbering every phase after it.
- **`docs/dsc-migration-notes.md`**: new section covering the channel
  finding, the `-Target`/`-Channel` interaction, the in-process-`exit`
  finding, `install.ps1`'s own unpinned-script risk, PATH handling,
  Hub retention, and `com.unity.pipeline`'s out-of-scope relationship.

## Findings from reading the real sources (not just the docs)

- **The stable channel doesn't exist yet.** Checked the CDN manifests
  directly: `.../cli/latest.json` (stable/GA) is **HTTP 404**;
  `.../cli/latest-beta.json` is **HTTP 200**, version `1.0.0-beta.3`;
  `.../cli/latest-alpha.json` is 404. Beta isn't merely the documented
  example -- it's the only channel with any build, as of this
  verification (2026-08-02). Recorded in `runtime-versions.psd1` with
  the URLs and dates checked.
- **`-Target` makes `-Channel` a no-op once pinned.** Read
  `install.ps1`'s own source: when `-Target` isn't `"latest"`, it
  fetches that version's manifest directly and never consults
  `-Channel`/`$env:UNITY_CLI_CHANNEL`. `Channel: beta` is recorded in
  the config for traceability, not because it has any effect on this
  pinned install.
- **A real, non-hypothetical risk caught by testing an assumption, not
  the docs:** the "official" invocation pattern is `irm URL | iex`,
  and adding `-Target` to that would mean invoking the downloaded
  content in-process (e.g. `& [scriptblock]::Create($content) -Target ...`).
  `install.ps1` calls `exit 1` on several of its own failure paths. I
  reproduced this with a minimal script: a scriptblock containing
  `exit 1`, invoked via `& $sb` -- a line placed immediately after
  never printed. `exit` inside an in-process-invoked scriptblock kills
  the *entire calling PowerShell process*, not just the scriptblock,
  which would have silently aborted the rest of `boxstarter.ps1` on
  any Unity CLI installer failure. `Invoke-UnityCliInstaller` instead
  downloads `install.ps1` to a temp file and runs it via
  `Start-Process -Wait -PassThru` in a genuinely separate process.

## Not verified on a real machine

Per this issue's own instructions for exactly this case: Windows-only,
could not run `unity` or `install.ps1` for real from this Linux
environment. `libs/post-install.ps1` / `boxstarter.ps1` are also never
executed directly in this environment even to smoke-test, regardless
of OS -- doing exactly that during issue #73 caused real installs
(`git-vrc`, `vrchat.vpm.cli`) on the shared dev machine, since `git`/
`cargo`/`dotnet` happened to be on PATH there.

What **is** verified:
- `install.ps1`'s actual source was read end to end, not inferred from
  its docs (this is how the `-Target`/`-Channel` interaction and the
  `exit` risk above were found).
- The channel-manifest HTTP checks above were run for real against the
  CDN.
- `unity --version`'s exact output format is undocumented anywhere
  found (Unity's own CLI reference covers every other command's output
  but not this one) and could not be confirmed on a real machine
  either -- `Test-UnityCliCurrent` uses a substring match against the
  declared `Target` rather than assuming an exact format, so it stays
  correct regardless of the real formatting.
- `Sync-UnityCli`'s idempotency and error-handling logic is covered by
  Pester with `Get-InstalledUnityCliVersion` / `Invoke-UnityCliInstaller`
  mocked -- including running it twice with the second run's mock
  reporting the CLI as already installed, confirming the installer is
  not invoked again.

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` on every
  changed/new `.ps1` file -- no syntax errors
- `Import-PowerShellDataFile` on `runtime-versions.psd1` -- parses to
  the expected shape
- `markdownlint-cli2 "docs/dsc-migration-notes.md"` -- 0 issues
- `cspell lint` on all changed files -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- 42/42 pass (10 new:
  4 `Test-UnityCliCurrent`, 2 `Add-UnityCliToProcessPath`, 4
  `Sync-UnityCli` including the idempotency test; 3 new
  `Get-RuntimeVersionsConfig`; 29 pre-existing, no regression)

## Test plan

- [x] Unity CLI target version, channel, pin reason, and verification
      date recorded in `configurations/runtime-versions.psd1`
- [x] Stable-channel-availability check performed and recorded, with
      the reason for choosing beta
- [x] Idempotent installer exists; does not reinstall when the
      declared version is already present (Pester, mocked)
- [x] Installer run twice in sequence produces no second install on
      the second run (Pester, mocked)
- [x] Installer runs `install.ps1` with `-Target` set to the declared
      version
- [x] `unity --version` would be callable in the same process after
      install (`$env:Path` updated; verified via `Add-UnityCliToProcessPath`
      unit tests, not a real invocation -- see "Not verified" above)
- [x] `boxstarter.ps1` calls the installer before the Editor-install
      phase
- [x] `Unity.UnityHub` remains in `configurations/packages.dsc.yaml`
      (untouched by this PR)
- [x] Hub-removal-decision-is-out-of-scope recorded in `docs/`
- [x] `install.ps1`'s own unpinned-script risk recorded in `docs/`
- [x] `com.unity.pipeline` relationship and out-of-scope note recorded
      in `docs/`
- [x] PSScriptAnalyzer reports nothing for the added scripts
- [x] `pre-push-validate` exits 0 on a clean worktree
