### PR TITLE
fix(dsc): PowerShell 5.1 で -AdditionalChildPath が使えない箇所を修正する

### DIFF
--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -472,6 +472,47 @@ error-handling logic is covered by Pester with
 `Get-InstalledUnityCliVersion` / `Invoke-UnityCliInstaller` mocked --
 see `tests/powershell/unity-cli-installer.Tests.ps1`.
 
+## PowerShell 7+ requirement for `scripts/*.ps1` (issue #96)
+
+`libs/post-install.ps1` had a `Join-Path -Path ... -AdditionalChildPath
+...` call that failed on Windows PowerShell 5.1 -- `-AdditionalChildPath`
+was added in PowerShell 6.0, and `setup.cmd` launches Boxstarter via the
+bare `powershell` command, which resolves to 5.1 on a stock Windows
+machine. That was fixed during issue #73's review by rewriting it as a
+`Join-Path -ChildPath` pipeline chain, since `libs/post-install.ps1`
+must work before a newer PowerShell is guaranteed to be installed.
+
+The same `-AdditionalChildPath` pattern also existed in
+`scripts/Build-Configurations.ps1` and `scripts/Test-PackageIds.ps1`,
+which are developer-run CLI tools, not part of the Boxstarter bootstrap
+path. Rather than rewrite them the same way, this issue declares them
+PowerShell 7+-only via `#Requires -Version 7.0`, because the evidence
+shows they already are:
+
+- `.github/workflows/lint.yml`'s `configuration-drift` job runs
+  `Build-Configurations.ps1` exclusively via `shell: pwsh` on
+  `ubuntu-latest` -- it has never been exercised under 5.1 in this
+  repository's own automation.
+- `Test-PackageIds.ps1` isn't run in CI at all (it needs a real
+  `winget`, so it only runs on Windows), but it shares
+  `libs/configuration-builder.ps1` and the same `-AdditionalChildPath`
+  pattern with `Build-Configurations.ps1`; keeping both scripts under
+  the same requirement avoids a silent inconsistency where one enforces
+  PowerShell 7+ and the other fails opaquely if a developer runs it
+  under the default `powershell` command instead of `pwsh`.
+
+`#Requires -Version 7.0` was chosen over a doc-comment-only note
+because PowerShell enforces it natively at parse time, before the
+script body (and its 5.1-incompatible `Join-Path` call) ever runs --
+this produces PowerShell's own clear "cannot be run" message instead of
+a parameter-binding error several lines into execution.
+
+`tests/powershell/*.Tests.ps1` use the same `-AdditionalChildPath`
+pattern and were deliberately left untouched: `docs/testing.md` already
+documents Pester as pwsh-only (CI installs and runs it via
+`shell: pwsh`), so adding `#Requires` there would only restate an
+existing, already-enforced constraint.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/scripts/Build-Configurations.ps1
+++ b/scripts/Build-Configurations.ps1
@@ -9,7 +9,12 @@ and configurations/*.unapplied.json are generated from it by this
 script and must never be hand-edited. See docs/dsc-migration-notes.md.
 
 Requires the powershell-yaml module (Install-Module -Name
-powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser).
+powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser) and
+PowerShell 7+ (see the #Requires statement below) -- this script uses
+Join-Path's -AdditionalChildPath parameter, added in PowerShell 6.0
+and unavailable in Windows PowerShell 5.1. .github/workflows/lint.yml
+already runs it exclusively via `shell: pwsh`, so this only makes the
+existing constraint explicit; see docs/dsc-migration-notes.md.
 
 .PARAMETER DscPath
 Path to the source dsc.yaml file.
@@ -28,6 +33,7 @@ $DscPath with its trailing ".dsc.yaml" replaced by ".unapplied.json".
 .EXAMPLE
 ./scripts/Build-Configurations.ps1 -DscPath ./configurations/packages.min.dsc.yaml
 #>
+#Requires -Version 7.0
 [CmdletBinding()]
 param(
   [Parameter(Mandatory)]

--- a/scripts/Test-PackageIds.ps1
+++ b/scripts/Test-PackageIds.ps1
@@ -12,8 +12,12 @@ typo or a package removed from its source can be caught before
 running setup.
 
 Requires the powershell-yaml module (Install-Module -Name
-powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser) and a
-working `winget` on PATH -- this script only runs on Windows.
+powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser), a
+working `winget` on PATH -- this script only runs on Windows -- and
+PowerShell 7+ (see the #Requires statement below). This script uses
+Join-Path's -AdditionalChildPath parameter, added in PowerShell 6.0
+and unavailable in Windows PowerShell 5.1's default `powershell`
+command; see docs/dsc-migration-notes.md.
 
 Run this after adding or changing a package in dsc.yaml, and whenever
 setup fails on a specific package, to tell a genuine id/source problem
@@ -30,6 +34,7 @@ packages.min.dsc.yaml).
 .EXAMPLE
 ./scripts/Test-PackageIds.ps1 -DscPath ./configurations/packages.min.dsc.yaml
 #>
+#Requires -Version 7.0
 [CmdletBinding()]
 param(
   [Parameter(Mandatory)]


### PR DESCRIPTION
## Summary

Closes #96.

`scripts/Build-Configurations.ps1` and `scripts/Test-PackageIds.ps1`
used `Join-Path -Path ... -AdditionalChildPath ...`, a parameter added
in PowerShell 6.0 and unavailable under Windows PowerShell 5.1's
default `powershell` command. The same pattern was already fixed in
`libs/post-install.ps1` during issue #73's review, but these two
developer-run CLI scripts were left as-is, out of scope for that PR.

## Decision: `#Requires -Version 7.0`, not a `Join-Path` rewrite

The issue left the choice open ("5.1互換化 or pwsh 7+専用明記, 実装者の
判断"). Checked the actual evidence before picking:

- `libs/post-install.ps1` must tolerate 5.1 because Boxstarter launches
  it via `setup.cmd`'s bare `powershell` command, before a newer
  PowerShell is guaranteed to exist on the target machine. That's why
  it was rewritten as a `Join-Path -ChildPath` pipeline chain.
- `scripts/Build-Configurations.ps1` and `scripts/Test-PackageIds.ps1`
  are different: they're developer-run CLI tools, not part of the
  Boxstarter bootstrap path.
  - `.github/workflows/lint.yml`'s `configuration-drift` job already
    runs `Build-Configurations.ps1` exclusively via `shell: pwsh` on
    `ubuntu-latest` -- it has never been exercised under 5.1 in this
    repo's own CI.
  - `Test-PackageIds.ps1` isn't run in CI at all (it needs a real
    `winget`, Windows-only), but shares the same
    `libs/configuration-builder.ps1` dependency and
    `-AdditionalChildPath` pattern as `Build-Configurations.ps1`.
    Declaring both PowerShell 7+ keeps them consistent instead of one
    enforcing the requirement and the other failing opaquely.

Given that, declaring the existing constraint explicitly is the
smaller, more honest change than rewriting working `Join-Path` calls
to work around a version they're not actually run under.
`#Requires -Version 7.0` was chosen over a doc-comment-only note
because PowerShell enforces it natively at parse time, before the
5.1-incompatible `Join-Path` call ever runs -- producing PowerShell's
own clear "cannot be run" message instead of a parameter-binding
error partway through execution.

`tests/powershell/*.Tests.ps1` use the same `-AdditionalChildPath`
pattern and were deliberately left untouched, per the issue's own
scope note -- `docs/testing.md` already documents Pester as pwsh-only
(CI installs and runs it via `shell: pwsh`), so a `#Requires` there
would only restate an already-enforced constraint.

## What changed

- **`scripts/Build-Configurations.ps1`**: added `#Requires -Version
  7.0`; `.DESCRIPTION` now states the PowerShell 7+ requirement and
  why.
- **`scripts/Test-PackageIds.ps1`**: same `#Requires -Version 7.0`
  addition and `.DESCRIPTION` update.
- **`docs/dsc-migration-notes.md`**: new section recording the
  decision and the evidence behind it (see "Decision" above).

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` on both
  changed `.ps1` files -- no syntax errors
- `markdownlint-cli2 "**/*.md"` -- 0 issues
- `cspell lint "**" --no-progress` -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- 45/45 pass, no
  regression (pre-existing suite; this change adds no new test file
  since there's nothing new to unit-test -- `#Requires` is enforced by
  the PowerShell host itself, not application logic)

## Test plan

- [x] Both `-AdditionalChildPath` call sites addressed (via `#Requires
      -Version 7.0`, not a rewrite -- see "Decision" above)
- [x] Decision rationale recorded in `docs/dsc-migration-notes.md`
- [x] `tests/powershell/*.Tests.ps1` deliberately left untouched (out
      of this issue's scope; already pwsh-only per `docs/testing.md`)
- [x] PSScriptAnalyzer reports nothing for the changed scripts
- [x] `Invoke-Pester -Path ./tests/powershell -CI` passes cleanly
- [x] `pre-push-validate` exits 0 on a clean worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the PowerShell 7+ requirement for configuration and package validation scripts.
  * Added guidance explaining the PowerShell compatibility constraint.

* **Bug Fixes**
  * Scripts now explicitly prevent execution in unsupported PowerShell versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->