### PR TITLE
fix(setup): Invoke-UnityCliInstaller の Invoke-WebRequest 失敗が未捕捉のまま伝播する

### DIFF
--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -513,6 +513,26 @@ documents Pester as pwsh-only (CI installs and runs it via
 `shell: pwsh`), so adding `#Requires` there would only restate an
 existing, already-enforced constraint.
 
+## Handling a failed Unity CLI installer download (issue #98)
+
+Found while verifying a `-UseBasicParsing` review comment during issue #76's
+own PR review: `Invoke-UnityCliInstaller`'s `Invoke-WebRequest` call,
+which downloads Unity's `install.ps1`, had no `catch` of its own --
+only the surrounding `try`/`finally` that cleans up the temp file.
+A network failure (DNS, connection refused, a non-2xx status) throws a
+terminating error there that would have propagated uncaught through
+`Sync-UnityCli` and into `boxstarter.ps1`'s Phase 5, aborting the rest
+of setup instead of being reported as a clear, contained Unity CLI
+installer failure.
+
+Fixed by wrapping the `Invoke-WebRequest` call in its own try/catch
+and returning a non-zero exit code on failure, instead of adding a
+second, parallel error-handling path: `Sync-UnityCli` already treats
+any non-zero `Invoke-UnityCliInstaller` return value (e.g. a failed
+`install.ps1` run) as a failure and reports it via `Write-Error`. A
+failed download now flows through that same path rather than needing
+its own.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/libs/unity-cli-installer.ps1
+++ b/libs/unity-cli-installer.ps1
@@ -121,10 +121,13 @@ function Invoke-UnityCliInstaller {
   for both causes rather than two.
 
   .OUTPUTS
-  The child process's exit code, or 1 if the installer script itself
-  could not be downloaded. install.ps1 does not call `exit 0` on its
-  success path, so a clean run's exit code is whatever a script falling
-  off the end returns (0).
+  The child process's exit code, or a non-zero value (currently 1) if
+  the installer script itself could not be downloaded. Callers cannot
+  distinguish a download failure from an install.ps1 failure by exit
+  code value alone -- install.ps1 can itself legitimately exit 1 on
+  its own failure paths -- only by whether it's zero. install.ps1 does
+  not call `exit 0` on its success path, so a clean run's exit code is
+  whatever a script falling off the end returns (0).
   #>
 }
 

--- a/libs/unity-cli-installer.ps1
+++ b/libs/unity-cli-installer.ps1
@@ -72,7 +72,13 @@ function Invoke-UnityCliInstaller {
   )
   $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) "unity-cli-install-$([guid]::NewGuid().ToString('N')).ps1"
   try {
-    Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $tempScript -UseBasicParsing
+    try {
+      Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $tempScript -UseBasicParsing -ErrorAction Stop
+    }
+    catch {
+      Write-Error "Failed to download the Unity CLI installer from ${InstallScriptUrl}: $_"
+      return 1
+    }
     $shell = (Get-Process -Id $PID).Path
     $process = Start-Process -FilePath $shell -ArgumentList @(
       '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $tempScript,
@@ -104,10 +110,21 @@ function Invoke-UnityCliInstaller {
   is the same trust model as any curl-pipe-to-shell bootstrap (Chocolatey,
   Scoop); see docs/dsc-migration-notes.md for the recorded risk.
 
+  The download itself is wrapped in its own try/catch (issue #98): a
+  network failure (DNS, connection refused, non-2xx status) throws a
+  terminating error from Invoke-WebRequest that would otherwise
+  propagate uncaught past this function, past Sync-UnityCli, and into
+  boxstarter.ps1's Phase 5. Caught here and turned into a non-zero
+  return instead, so it flows through the same
+  "$exitCode -ne 0 -> Write-Error, return" handling in Sync-UnityCli
+  that an install.ps1 failure already goes through -- one failure path
+  for both causes rather than two.
+
   .OUTPUTS
-  The child process's exit code. install.ps1 does not call `exit 0` on
-  its success path, so a clean run's exit code is whatever a script
-  falling off the end returns (0).
+  The child process's exit code, or 1 if the installer script itself
+  could not be downloaded. install.ps1 does not call `exit 0` on its
+  success path, so a clean run's exit code is whatever a script falling
+  off the end returns (0).
   #>
 }
 

--- a/tests/powershell/unity-cli-installer.Tests.ps1
+++ b/tests/powershell/unity-cli-installer.Tests.ps1
@@ -62,6 +62,28 @@ Describe 'Add-UnityCliToProcessPath' {
   }
 }
 
+Describe 'Invoke-UnityCliInstaller' {
+  It 'returns a non-zero exit code instead of throwing when the download fails' {
+    Mock Invoke-WebRequest { throw [System.Net.WebException]::new('Name or service not known') }
+    Mock Start-Process { }
+
+    $exitCode = Invoke-UnityCliInstaller -Target '1.0.0-beta.3' -Channel 'beta' -ErrorAction SilentlyContinue
+    $exitCode | Should -Not -Be 0
+
+    Should -Invoke Start-Process -Times 0
+  }
+
+  It 'removes the temp script even when the download fails' {
+    Mock Invoke-WebRequest { throw [System.Net.WebException]::new('Name or service not known') }
+    Mock Start-Process { }
+    Mock Remove-Item { }
+
+    Invoke-UnityCliInstaller -Target '1.0.0-beta.3' -Channel 'beta' -ErrorAction SilentlyContinue | Out-Null
+
+    Should -Invoke Remove-Item -Times 1
+  }
+}
+
 Describe 'Sync-UnityCli' {
   BeforeAll {
     $script:configPath = Join-Path -Path $TestDrive -ChildPath 'runtime-versions.psd1'

--- a/tests/powershell/unity-cli-installer.Tests.ps1
+++ b/tests/powershell/unity-cli-installer.Tests.ps1
@@ -68,7 +68,7 @@ Describe 'Invoke-UnityCliInstaller' {
     Mock Start-Process { }
 
     $exitCode = Invoke-UnityCliInstaller -Target '1.0.0-beta.3' -Channel 'beta' -ErrorAction SilentlyContinue
-    $exitCode | Should -Not -Be 0
+    $exitCode | Should -Be 1
 
     Should -Invoke Start-Process -Times 0
   }


### PR DESCRIPTION
## Summary

Closes #98.

`Invoke-UnityCliInstaller`'s `Invoke-WebRequest` call (downloading
Unity's own `install.ps1`) had no `catch` of its own -- only the
surrounding `try`/`finally` that cleans up the temp file. Found this
while empirically verifying a `-UseBasicParsing` review comment on
issue #76's own PR, not as a review finding on that PR itself, so it
was filed and fixed as its own follow-up rather than folded in
after-the-fact.

## The bug

A network failure (DNS resolution, connection refused, a non-2xx
response) makes `Invoke-WebRequest` throw a terminating error. With no
`catch`, that exception propagated straight out of
`Invoke-UnityCliInstaller`, out of `Sync-UnityCli` (which also had no
`try`/`catch` around the call), and into `boxstarter.ps1`'s Phase 5 --
aborting the rest of setup on a transient network blip instead of
failing that one step cleanly and reporting it.

## What changed

- **`libs/unity-cli-installer.ps1`**: the `Invoke-WebRequest` call is
  now wrapped in its own `try`/`catch`. On failure it `Write-Error`s
  and returns `1` instead of letting the exception propagate.
  `Sync-UnityCli` already treats any non-zero
  `Invoke-UnityCliInstaller` return value as a failure (this was
  already how a failed `install.ps1` run itself was handled) -- a
  failed download now flows through that same existing path instead
  of needing a second one.
- **`tests/powershell/unity-cli-installer.Tests.ps1`**: two new tests
  under `Describe 'Invoke-UnityCliInstaller'` -- a mocked
  `Invoke-WebRequest` failure returns non-zero without throwing and
  never reaches `Start-Process`, and the temp-file cleanup in
  `finally` still runs on that failure path.
- **`docs/dsc-migration-notes.md`**: short section recording what was
  found and why the fix reuses `Sync-UnityCli`'s existing
  non-zero-exit handling instead of adding a parallel one.

## A bug in my own first draft of the test

The first version of the new `Invoke-UnityCliInstaller` test wrapped
the call in `{ $exitCode = Invoke-UnityCliInstaller ... } | Should -Not
-Throw`. That scriptblock runs in its own scope, so the assignment
inside it never reached the outer `$exitCode` -- the assertion below
it would have silently passed against a stale `$null` rather than the
real return value. PSScriptAnalyzer's
`PSUseDeclaredVarsMoreThanAssignment` caught the now-orphaned outer
assignment; fixed by calling the function directly (it doesn't throw
after this fix, so the wrapper added nothing) and asserting on its
actual return value.

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` on the
  changed `.ps1` file -- no syntax errors
- `markdownlint-cli2 "**/*.md"` -- 0 issues
- `cspell lint "**" --no-progress` -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- 47/47 pass (2 new,
  45 pre-existing, no regression)

## Test plan

- [x] A mocked `Invoke-WebRequest` failure does not propagate as an
      uncaught exception out of `Invoke-UnityCliInstaller`
- [x] On that failure path, `Start-Process` (running the downloaded
      installer) is never invoked
- [x] The temp file is still cleaned up (`finally`) when the download
      fails
- [x] `Sync-UnityCli`'s existing non-zero-exit-code handling is reused
      rather than duplicated (recorded in `docs/dsc-migration-notes.md`)
- [x] PSScriptAnalyzer reports nothing for the changed files
- [x] `pre-push-validate` exits 0 on a clean worktree
