### PR TITLE
refactor(setup): Unity Editor の導入を Unity CLI へ移行する

### DIFF
--- a/configurations/runtime-versions.psd1
+++ b/configurations/runtime-versions.psd1
@@ -27,15 +27,22 @@
     )
   }
 
-  # Unity Editor version installed via Unity Hub CLI (libs/post-install.ps1).
+  # Unity Editor version installed via the Unity CLI (`unity install`,
+  # libs/unity-editor-installer.ps1) -- not Unity Hub's unofficial
+  # `-- --headless` interface (replaced by issue #74; see
+  # docs/dsc-migration-notes.md for why).
   #
-  # The changeset must match the version exactly, or Unity Hub's
-  # `install -v <version> -c <changeset>` fails. When updating Version,
-  # update Changeset from the same source in the same change -- never
+  # The changeset must match the version exactly, or `unity install
+  # <version> -c <changeset>` fails. When updating Version, update
+  # Changeset from the same source in the same change -- never
   # independently.
   Unity     = @{
     Version      = '2022.3.22f1'
     Changeset    = '887be4894c44'
+    # Passed to `unity install ... -m <id>` for each entry, plus --cm
+    # (also install each module's child modules) -- see
+    # docs/dsc-migration-notes.md for why --cm is kept.
+    Modules      = @('android', 'documentation', 'ios', 'language-ja')
     Reason       = 'Required by VRChat SDK / VCC (VRChat Creator Companion).'
     VerifiedDate = '2026-08-02'
     Sources      = @(

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -533,6 +533,98 @@ any non-zero `Invoke-UnityCliInstaller` return value (e.g. a failed
 failed download now flows through that same path rather than needing
 its own.
 
+## Migrating Unity Editor installation from Hub CLI to the Unity CLI (issue #74)
+
+The Unity Editor install step (`libs/post-install.ps1`) originally drove Unity
+Hub's unofficial `-- --headless` interface (`Unity Hub.exe -- --headless
+install -v <version> -c <changeset> -m <modules...> --cm`). That
+implementation had four real defects: it never checked the process's exit
+code (a failed install still reached "setup complete"), its
+already-installed check ran the declared version string through
+`Select-String -Pattern`, treating it as a regex (so `2022.3.22f1`'s dots
+matched any character), the module list was hardcoded in the script instead
+of declared, and there was no way to detect drift between the declared
+version and what was actually installed, since Hub self-updates outside
+winget and its `--headless` interface is undocumented.
+
+Unity's own CLI (`unity` binary, installed by `libs/unity-cli-installer.ps1`,
+issue #76) replaced Hub CLI for this step because it solves the first,
+second, and fourth defects structurally rather than through workarounds:
+`unity install` has a documented exit-code contract, `unity editors -i
+--format json` gives structured output instead of text to regex-match, and
+comparing that JSON against the declared config is a drift check with no
+extra machinery needed. `libs/unity-editor-installer.ps1` implements this;
+`libs/post-install.ps1` now dot-sources it and calls `Sync-UnityEditor`
+instead of embedding the Hub CLI logic inline.
+
+### The real exit-code table is more granular than assumed
+
+This issue's own body simplified `unity install`'s contract as "0 success /
+1 error / 130 interrupted". Checking Unity's actual CLI reference
+(docs.unity.com/en-us/unity-cli/unity-cli-reference) found a fuller table:
+`0` success, `1` general error, `2` usage error (bad flags/values), `3`
+auth/authorization failure, `4` configuration required, `6` the command's
+primary operation itself failed (e.g. the install failed), `130` interrupted
+(Ctrl+C/SIGINT), `143` terminated (SIGTERM). A real install failure can
+surface as `1`, `2`, `3`, `4`, or `6` depending on the cause -- there is no
+single "the install failed" code to special-case. `Invoke-UnityEditorInstall`
+therefore only special-cases `0` (success) and `130` (user-interrupted, per
+this issue's acceptance criteria), and treats every other non-zero code
+uniformly as a failure, always logging the exact value it saw.
+
+### `unity editors -i --format json`'s per-item shape is not documented
+
+The JSON envelope (`success`/`command`/`data`/`errors`/`warnings`) is
+documented on the CLI reference page's "Format selection" table. The shape
+of each item inside `data` for the `editors` command specifically is not --
+not on that page, not on the CLI intro or usage pages, and no real example
+output was found anywhere. This is the same situation `Test-UnityCliCurrent`
+(issue #76) was in for `unity --version`'s output, and it's handled the same
+way: `Get-InstalledUnityEditors` probes a small, explicit set of plausible
+field names (`version`, then `Version`) per item and skips (rather than
+throws on) any item where neither is present, so an unexpected real shape
+degrades to "not recognized" instead of crashing the install path. This
+could not be verified against a real `unity` binary -- Windows-only, and
+`libs/post-install.ps1` / `boxstarter.ps1` are never executed directly in
+this environment even to smoke-test (see the Unity CLI section above for
+why). Covered by Pester with `unity` itself mocked at the JSON-output level.
+
+### `--cm` is kept, unreconsidered
+
+The prior Hub CLI call always passed `--cm` (install child modules). The
+Unity CLI documents an equivalent `--cm, --childModules` flag.
+`Invoke-UnityEditorInstall` keeps passing it unconditionally, so switching
+install paths doesn't also silently change what gets installed -- reconsidering
+whether child modules are actually wanted is out of scope for this refactor.
+
+### Why Editor still isn't a winget package (re-confirmed, unchanged from issue #73)
+
+Unity's own CLI doesn't change this issue's answer, kept here so a future
+reconsideration doesn't have to redo the research:
+
+- `Unity.Unity.2022` exists in winget per patch version, and `2022.3.22f1` is
+  registered there with the same changeset (`887be4894c44`) this repo already
+  pins -- the underlying installer download is identical either way.
+- That winget package is `Windows64EditorInstaller` -- the Editor alone. The
+  four modules this repo installs (`android`, `documentation`, `ios`,
+  `language-ja`) aren't part of it.
+- winget packages one ID per minor line, so multiple patch versions within
+  the same line can't coexist through winget. This repo's own history hit
+  this: an earlier `boxstarter.ps1` ran `2022.3.6f1` and `2022.3.22f1`
+  side-by-side.
+- Pinning `Version` in a `WinGetPackage`/`Microsoft.WinGet.DSC` resource
+  triggers an uninstall-then-reinstall whenever the installed version
+  differs from the declared one -- unlike `unity install`, which is
+  additive by design (Editors are side-by-side).
+
+### Drift detection is report-only by design
+
+`Get-UnityEditorDrift` reports installed-but-undeclared Editor versions; it
+never removes them. Unity Editors install side-by-side, and a version a
+developer installed manually for an unrelated project must not disappear as
+a side effect of running this repo's setup -- an explicit constraint from
+this issue, not an oversight.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -118,41 +118,18 @@ else {
 }
 
 ###########################################################################
-### Unity Editor via Unity Hub CLI
-### Pinned version/changeset live in configurations/runtime-versions.psd1
+### Unity Editor via the Unity CLI (`unity install`)
+### Pinned version/changeset/modules live in
+### configurations/runtime-versions.psd1. Installed and verified by
+### libs/unity-editor-installer.ps1 -- see docs/dsc-migration-notes.md
+### for why this replaced Unity Hub's unofficial `-- --headless`
+### interface (issue #74). Unity Hub itself remains a declared package
+### (configurations/packages.dsc.yaml) since VRChat Creator Companion
+### may rely on Hub recognizing installed Editors -- only the Editor
+### install path moved.
 ###########################################################################
-$UnityHub = $env:ProgramFiles `
-  | Join-Path -ChildPath 'Unity Hub' `
-  | Join-Path -ChildPath 'Unity Hub.exe'
-
-if (Test-Path $UnityHub) {
-  Write-Host '[post-install] Setting up Unity Editor...' -ForegroundColor Cyan
-
-  $versions = & $UnityHub -- --headless editors --installed | Out-String
-
-  function Install-UnityEditor {
-    param (
-      [Parameter(Mandatory)][string]$Version,
-      [Parameter(Mandatory)][string]$Changeset
-    )
-    if ($versions | Select-String -Pattern $Version) {
-      Write-Host "  Unity $Version is already installed — skipping." -ForegroundColor Gray
-      return
-    }
-    $opts = '-- --headless install -v {0} -c {1} -m android -m documentation -m ios -m language-ja --cm' `
-      -f $Version, $Changeset
-    Write-Host "  Installing Unity $Version..." -ForegroundColor Gray
-    Start-Process $UnityHub -ArgumentList $opts -NoNewWindow -Wait
-  }
-
-  $unityConfig = $runtimeVersions.Unity
-  Install-UnityEditor -Version $unityConfig.Version -Changeset $unityConfig.Changeset
-
-  Write-Host '[post-install] Unity Editor setup complete.' -ForegroundColor Green
-}
-else {
-  Write-Warning '[post-install] Unity Hub not found — skipping Unity Editor setup.'
-}
+. (Join-Path -Path $PSScriptRoot -ChildPath 'unity-editor-installer.ps1')
+Sync-UnityEditor -ConfigPath $runtimeVersionsFile
 
 ###########################################################################
 ### Docker Desktop — start and pull base images

--- a/libs/unity-editor-installer.ps1
+++ b/libs/unity-editor-installer.ps1
@@ -53,10 +53,16 @@ function Get-InstalledUnityEditors {
     Write-Error "Failed to parse 'unity editors -i --format json' output: $_"
     return [string[]]@()
   }
-  if (-not $envelope.success -or $null -eq $envelope.data) {
+  if ($null -eq $envelope) {
     return [string[]]@()
   }
-  $versions = foreach ($item in @($envelope.data)) {
+  $successProperty = $envelope.PSObject.Properties['success']
+  $dataProperty = $envelope.PSObject.Properties['data']
+  if (-not $successProperty -or -not $successProperty.Value -or
+    -not $dataProperty -or $null -eq $dataProperty.Value) {
+    return [string[]]@()
+  }
+  $versions = foreach ($item in @($dataProperty.Value)) {
     $property = $item.PSObject.Properties['version']
     if (-not $property) {
       $property = $item.PSObject.Properties['Version']

--- a/libs/unity-editor-installer.ps1
+++ b/libs/unity-editor-installer.ps1
@@ -261,8 +261,21 @@ function Sync-UnityEditor {
   $unityConfig = $config.Unity
 
   if (-not (Test-UnityCliAvailable)) {
-    Write-Error 'Unity CLI (`unity`) is not on PATH -- cannot install or verify the Unity Editor. The Unity CLI installer (libs/unity-cli-installer.ps1) must run before this step; there is no Unity Hub CLI fallback (issue #74).'
-    return
+    # throw, not Write-Error + return: this is a function, not a script's
+    # own top level -- `return` here only exits Sync-UnityEditor and lets
+    # libs/post-install.ps1's later steps (Docker, mkcert, etc.) run
+    # normally under Boxstarter's default $ErrorActionPreference =
+    # 'Continue', silently reaching "setup complete" despite the Unity
+    # Editor step never running. Verified empirically: a dot-sourced
+    # function's `Write-Error` + `return` does not halt its caller's
+    # later statements, unlike `return` at a script's own top level
+    # (the case this repo's existing Write-Error + return convention,
+    # e.g. Phase 0's OS check, actually relies on). `throw` propagates
+    # as a terminating error through post-install.ps1 (invoked via `&`
+    # from boxstarter.ps1) and aborts the whole run -- the correct
+    # outcome here, since a missing Unity CLI means the earlier
+    # Sync-UnityCli step (issue #76) itself already failed silently.
+    throw 'Unity CLI (`unity`) is not on PATH -- cannot install or verify the Unity Editor. The Unity CLI installer (libs/unity-cli-installer.ps1) must run before this step; there is no Unity Hub CLI fallback (issue #74).'
   }
 
   # -ErrorAction Stop: Get-InstalledUnityEditors returns an empty array

--- a/libs/unity-editor-installer.ps1
+++ b/libs/unity-editor-installer.ps1
@@ -54,12 +54,14 @@ function Get-InstalledUnityEditors {
     return [string[]]@()
   }
   if ($null -eq $envelope) {
+    Write-Error "'unity editors -i --format json' returned a null envelope: $($result.Output)"
     return [string[]]@()
   }
   $successProperty = $envelope.PSObject.Properties['success']
   $dataProperty = $envelope.PSObject.Properties['data']
   if (-not $successProperty -or -not $successProperty.Value -or
     -not $dataProperty -or $null -eq $dataProperty.Value) {
+    Write-Error "'unity editors -i --format json' returned an unexpected envelope shape (missing/false success or missing/null data): $($result.Output)"
     return [string[]]@()
   }
   $versions = foreach ($item in @($dataProperty.Value)) {

--- a/libs/unity-editor-installer.ps1
+++ b/libs/unity-editor-installer.ps1
@@ -263,13 +263,28 @@ function Sync-UnityEditor {
     return
   }
 
+  # -ErrorAction Stop: Get-InstalledUnityEditors returns an empty array
+  # (not a thrown error) when it can't determine the installed list, so
+  # that other callers can degrade gracefully. Sync-UnityEditor cannot --
+  # treating "couldn't tell" the same as "genuinely nothing installed"
+  # would attempt an install based on a false premise instead of
+  # reporting the real problem (`unity editors` itself failing).
+  # -ErrorAction Stop escalates Get-InstalledUnityEditors's own
+  # Write-Error calls to terminating for this call only.
+  #
   # @(...) guards against PowerShell's own empty-array-collapses-to-$null
   # behavior across a function-call boundary (confirmed empirically:
   # `$x = Get-Foo` is $null, not an empty array, when Get-Foo's only
   # output is `return @()`) -- without this, an environment with zero
   # installed Editors would fail Get-UnityEditorDrift's
   # [AllowEmptyCollection()] binding instead of reporting zero drift.
-  $installed = @(Get-InstalledUnityEditors)
+  try {
+    $installed = @(Get-InstalledUnityEditors -ErrorAction Stop)
+  }
+  catch {
+    Write-Error "Could not determine installed Unity Editors -- aborting rather than risk installing based on unknown state: $_"
+    return
+  }
   $target = $unityConfig.Version
   $drift = Get-UnityEditorDrift -Declared @($target) -Installed $installed
 

--- a/libs/unity-editor-installer.ps1
+++ b/libs/unity-editor-installer.ps1
@@ -1,0 +1,292 @@
+<#
+.SYNOPSIS
+Installs and tracks the declared Unity Editor version via the Unity
+CLI (`unity install`), per configurations/runtime-versions.psd1's
+Unity entry.
+
+This file is dot-sourced (not imported as a module) from
+libs/post-install.ps1 -- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+. (Join-Path -Path $PSScriptRoot -ChildPath 'runtime-versions.ps1')
+
+function Invoke-UnityEditorsListCommand {
+  [CmdletBinding()]
+  [OutputType([hashtable])]
+  param ()
+  $output = & unity editors -i --format json 2>&1 | Out-String
+  return @{ Output = $output; ExitCode = $LASTEXITCODE }
+  <#
+  .SYNOPSIS
+  Runs `unity editors -i --format json` and returns its raw output and
+  exit code, with no parsing.
+
+  .DESCRIPTION
+  The only function in this file that invokes the real `unity` binary
+  for listing installed Editors, kept to a single line specifically so
+  Pester can mock it directly. Pester's Mock requires the target
+  command to already resolve via Get-Command -- mocking the bare
+  `unity` command name itself does not work on a machine with no
+  `unity` binary anywhere on PATH (such as this file's own Linux
+  Pester run), so the real shell-out is isolated here instead of
+  inline inside Get-InstalledUnityEditors.
+
+  .OUTPUTS
+  Hashtable: Output (raw stdout+stderr text), ExitCode.
+  #>
+}
+
+function Get-InstalledUnityEditors {
+  [CmdletBinding()]
+  [OutputType([string[]])]
+  param ()
+  $result = Invoke-UnityEditorsListCommand
+  if ($result.ExitCode -ne 0) {
+    Write-Error "'unity editors -i --format json' exited with code $($result.ExitCode): $($result.Output)"
+    return [string[]]@()
+  }
+  try {
+    $envelope = $result.Output | ConvertFrom-Json -ErrorAction Stop
+  }
+  catch {
+    Write-Error "Failed to parse 'unity editors -i --format json' output: $_"
+    return [string[]]@()
+  }
+  if (-not $envelope.success -or $null -eq $envelope.data) {
+    return [string[]]@()
+  }
+  $versions = foreach ($item in @($envelope.data)) {
+    $property = $item.PSObject.Properties['version']
+    if (-not $property) {
+      $property = $item.PSObject.Properties['Version']
+    }
+    if ($property) {
+      $property.Value
+    }
+  }
+  return [string[]]@($versions | Where-Object { $_ })
+  <#
+  .SYNOPSIS
+  Returns the installed Editor version strings that
+  Invoke-UnityEditorsListCommand's output could identify.
+
+  .DESCRIPTION
+  The JSON envelope (`success`/`command`/`data`/`errors`/`warnings`) is
+  documented (docs.unity.com's CLI reference, "Format selection"
+  table), but the exact shape of each item inside `data` for the
+  `editors` command is not documented anywhere found during this
+  issue's research -- the same situation `Test-UnityCliCurrent`
+  (libs/unity-cli-installer.ps1, issue #76) was in for `unity
+  --version`'s output. Rather than assume an unverified deep shape,
+  this probes a small, explicit set of plausible field names per item
+  ('version', 'Version') and skips any item where neither is present,
+  so an unexpected real shape degrades to "not recognized" instead of
+  crashing the whole install path.
+
+  This function's only dependency is Invoke-UnityEditorsListCommand's
+  return value (no direct call to `unity`), so its parsing logic --
+  the part actually worth testing -- is fully exercisable by mocking
+  that one function, without needing a real Unity CLI installed.
+
+  .OUTPUTS
+  String[]: the version string of each installed Editor this function
+  could identify. Callers must not assume a non-empty result is
+  preserved across a plain assignment -- see the `@(...)` note on
+  Sync-UnityEditor's call site.
+  #>
+}
+
+function Test-UnityCliAvailable {
+  $null -ne (Get-Command unity -CommandType Application -ErrorAction SilentlyContinue)
+  <#
+  .SYNOPSIS
+  Returns $true if the Unity CLI (`unity`) is on PATH, $false
+  otherwise.
+
+  .DESCRIPTION
+  Isolated into its own function (the same pattern as
+  Test-CommandExists in libs/post-install.ps1) purely so
+  Sync-UnityEditor's Pester tests can mock this one check instead of
+  requiring a real `unity` binary on PATH.
+  #>
+}
+
+function Test-UnityEditorInstalled {
+  param (
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Installed,
+    [Parameter(Mandatory)][string]$Target
+  )
+  foreach ($version in $Installed) {
+    if ([string]::Equals($version, $Target, [System.StringComparison]::Ordinal)) {
+      return $true
+    }
+  }
+  return $false
+  <#
+  .SYNOPSIS
+  Decides whether the declared Target version is already installed, by
+  exact string match against the installed Editor versions -- never a
+  regex or substring match.
+
+  .DESCRIPTION
+  The prior Unity Hub CLI implementation used
+  `$versions | Select-String -Pattern $Version`, which treated the
+  version as a regex: a declared "2022.3.22f1" would also match an
+  installed "2022X3Y22f1"-shaped string, because '.' matches any
+  character in a regex. This function is the fix (issue #74) -- exact,
+  ordinal equality only.
+  #>
+}
+
+function Get-UnityEditorDrift {
+  param (
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Declared,
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Installed
+  )
+  $missing = @($Declared | Where-Object { -not (Test-UnityEditorInstalled -Installed $Installed -Target $_) })
+  $extra = @($Installed | Where-Object { -not (Test-UnityEditorInstalled -Installed $Declared -Target $_) })
+  return @{ MissingVersions = $missing; ExtraVersions = $extra }
+  <#
+  .SYNOPSIS
+  Compares the declared Editor version(s) against what's actually
+  installed and reports the difference.
+
+  .DESCRIPTION
+  Report-only: never deletes or otherwise acts on an installed-but-
+  undeclared Editor. Unity Editors are side-by-side, and a version
+  installed for a different project must not be removed as a side
+  effect of this comparison -- an explicit constraint in issue #74.
+
+  .OUTPUTS
+  Hashtable: MissingVersions (declared but not installed), ExtraVersions
+  (installed but not declared). Both use the same exact-match semantics
+  as Test-UnityEditorInstalled.
+  #>
+}
+
+function Invoke-UnityInstallCommand {
+  [CmdletBinding()]
+  [OutputType([int])]
+  param (
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$ArgumentList
+  )
+  & unity @ArgumentList
+  return $LASTEXITCODE
+  <#
+  .SYNOPSIS
+  Runs `unity` with the given argument list and returns its exit code.
+
+  .DESCRIPTION
+  The only function in this file that invokes the real `unity` binary
+  for installing an Editor, isolated for the same reason
+  Invoke-UnityEditorsListCommand is: Pester can only mock a command
+  that already resolves via Get-Command, and no `unity` binary exists
+  on PATH on this file's own Linux Pester run. Invoke-UnityEditorInstall
+  builds the argument list (the part worth testing); this function's
+  only job is the real process invocation.
+
+  .OUTPUTS
+  Int: `unity`'s real exit code.
+  #>
+}
+
+function Invoke-UnityEditorInstall {
+  param (
+    [Parameter(Mandatory)][string]$Version,
+    [Parameter(Mandatory)][string]$Changeset,
+    [string[]]$Modules = @()
+  )
+  $moduleArgs = foreach ($module in $Modules) { '-m'; $module }
+  $argumentList = @('install', $Version, '-c', $Changeset) + @($moduleArgs) + @('--cm')
+  $exitCode = Invoke-UnityInstallCommand -ArgumentList $argumentList
+  switch ($exitCode) {
+    0 { Write-Host "  Unity $Version installed." -ForegroundColor Gray }
+    130 { Write-Error "Unity $Version install was interrupted (exit code 130 -- Ctrl+C)." }
+    default { Write-Error "Unity $Version install failed with exit code ${exitCode}." }
+  }
+  return $exitCode
+  <#
+  .SYNOPSIS
+  Runs `unity install <Version> -c <Changeset> -m <module> [-m
+  <module>...] --cm` and returns its exit code.
+
+  .DESCRIPTION
+  --cm (also install each module's child modules) is always passed,
+  matching the prior Unity Hub CLI invocation's behavior. Kept as-is
+  rather than reconsidered as part of this refactor, so switching
+  install paths doesn't also silently change what gets installed --
+  issue #74's own explicit instruction.
+
+  Unity's documented exit codes
+  (docs.unity.com/en-us/unity-cli/unity-cli-reference) are more
+  granular than a simple "0 success / 1 error / 130 interrupted": 0
+  success, 1 general error, 2 usage error, 3 auth/authorization
+  failure, 4 configuration required, 6 the command's primary operation
+  itself failed (e.g. install failed), 130 interrupted (Ctrl+C /
+  SIGINT), 143 terminated (SIGTERM). Only 0 (success) and 130
+  (user-interrupted, logged distinctly per this issue's acceptance
+  criteria) get special handling; every other non-zero code is treated
+  uniformly as a failure and logged with its exact value, since a real
+  install failure can surface as 1, 2, 3, 4, or 6 depending on the
+  cause -- "1" does not uniquely mean "install failed".
+
+  .OUTPUTS
+  Int: the `unity install` process's real exit code.
+  #>
+}
+
+function Sync-UnityEditor {
+  param (
+    [Parameter(Mandatory)][string]$ConfigPath
+  )
+  $config = Get-RuntimeVersionsConfig -Path $ConfigPath
+  if ($null -eq $config) {
+    return
+  }
+  if (-not $config.Contains('Unity') -or
+    -not $config.Unity.Contains('Version') -or -not $config.Unity.Contains('Changeset') -or
+    -not $config.Unity.Contains('Modules')) {
+    Write-Error "Runtime versions config ${ConfigPath} is missing a Unity.Version/Unity.Changeset/Unity.Modules entry."
+    return
+  }
+  $unityConfig = $config.Unity
+
+  if (-not (Test-UnityCliAvailable)) {
+    Write-Error 'Unity CLI (`unity`) is not on PATH -- cannot install or verify the Unity Editor. The Unity CLI installer (libs/unity-cli-installer.ps1) must run before this step; there is no Unity Hub CLI fallback (issue #74).'
+    return
+  }
+
+  # @(...) guards against PowerShell's own empty-array-collapses-to-$null
+  # behavior across a function-call boundary (confirmed empirically:
+  # `$x = Get-Foo` is $null, not an empty array, when Get-Foo's only
+  # output is `return @()`) -- without this, an environment with zero
+  # installed Editors would fail Get-UnityEditorDrift's
+  # [AllowEmptyCollection()] binding instead of reporting zero drift.
+  $installed = @(Get-InstalledUnityEditors)
+  $target = $unityConfig.Version
+  $drift = Get-UnityEditorDrift -Declared @($target) -Installed $installed
+
+  foreach ($version in $drift.ExtraVersions) {
+    Write-Host "[unity-editor] Installed but not declared: $version (left as-is -- Editors are side-by-side)." -ForegroundColor Yellow
+  }
+
+  if ($drift.MissingVersions.Count -eq 0) {
+    Write-Host "[unity-editor] Unity $target already installed -- skipping." -ForegroundColor Gray
+    return
+  }
+
+  Write-Host "[unity-editor] Installing Unity $target (modules: $($unityConfig.Modules -join ', '))..." -ForegroundColor Cyan
+  $exitCode = Invoke-UnityEditorInstall -Version $target -Changeset $unityConfig.Changeset -Modules $unityConfig.Modules
+  if ($exitCode -ne 0) {
+    return
+  }
+
+  Write-Host '[unity-editor] Unity Editor installation complete.' -ForegroundColor Green
+  <#
+  .SYNOPSIS
+  Idempotent entry point: installs the declared Unity Editor version
+  only if it isn't already installed, and reports (without deleting)
+  any installed Editor versions the declared config doesn't name.
+  #>
+}

--- a/tests/powershell/unity-editor-installer.Tests.ps1
+++ b/tests/powershell/unity-editor-installer.Tests.ps1
@@ -209,6 +209,18 @@ Describe 'Sync-UnityEditor' {
     Should -Invoke Invoke-UnityEditorInstall -Times 0
   }
 
+  It 'aborts (end to end, no mocking of Get-InstalledUnityEditors itself) when the real envelope shape is unexpected' {
+    Mock Test-UnityCliAvailable { $true }
+    Mock Invoke-UnityEditorsListCommand {
+      @{ ExitCode = 0; Output = '{"unexpected":true}' }
+    }
+    Mock Invoke-UnityEditorInstall { 0 }
+
+    { Sync-UnityEditor -ConfigPath $script:configPath -ErrorAction SilentlyContinue } | Should -Not -Throw
+
+    Should -Invoke Invoke-UnityEditorInstall -Times 0
+  }
+
   It 'skips installation when the declared version is already installed' {
     Mock Test-UnityCliAvailable { $true }
     Mock Get-InstalledUnityEditors { @('2022.3.22f1') }

--- a/tests/powershell/unity-editor-installer.Tests.ps1
+++ b/tests/powershell/unity-editor-installer.Tests.ps1
@@ -1,0 +1,230 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'unity-editor-installer.ps1')
+}
+
+Describe 'Get-InstalledUnityEditors' {
+  It 'returns version strings from a "version" field' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{
+        ExitCode = 0
+        Output   = '{"success":true,"command":"editors","data":[{"version":"2022.3.22f1"},{"version":"6000.0.1f1"}],"errors":[],"warnings":[]}'
+      }
+    }
+
+    Get-InstalledUnityEditors | Should -Be @('2022.3.22f1', '6000.0.1f1')
+  }
+
+  It 'falls back to a "Version" field when "version" is absent' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{
+        ExitCode = 0
+        Output   = '{"success":true,"command":"editors","data":[{"Version":"2022.3.22f1"}],"errors":[],"warnings":[]}'
+      }
+    }
+
+    Get-InstalledUnityEditors | Should -Be @('2022.3.22f1')
+  }
+
+  It 'returns an empty array when the exit code is non-zero' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{ ExitCode = 1; Output = 'unity: command failed' }
+    }
+
+    Get-InstalledUnityEditors -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+  }
+
+  It 'returns an empty array instead of throwing when the output is not valid JSON' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{ ExitCode = 0; Output = 'not json' }
+    }
+
+    { Get-InstalledUnityEditors -ErrorAction SilentlyContinue } | Should -Not -Throw
+    Get-InstalledUnityEditors -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+  }
+
+  It 'returns an empty array when data is empty' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{
+        ExitCode = 0
+        Output   = '{"success":true,"command":"editors","data":[],"errors":[],"warnings":[]}'
+      }
+    }
+
+    Get-InstalledUnityEditors | Should -BeNullOrEmpty
+  }
+
+  It 'skips an item where neither "version" nor "Version" is present' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{
+        ExitCode = 0
+        Output   = '{"success":true,"command":"editors","data":[{"path":"/no/version/field"},{"version":"2022.3.22f1"}],"errors":[],"warnings":[]}'
+      }
+    }
+
+    Get-InstalledUnityEditors | Should -Be @('2022.3.22f1')
+  }
+}
+
+Describe 'Test-UnityEditorInstalled' {
+  It 'returns $true on an exact match' {
+    Test-UnityEditorInstalled -Installed @('2022.3.22f1') -Target '2022.3.22f1' | Should -Be $true
+  }
+
+  It 'returns $false for an unrelated version' {
+    Test-UnityEditorInstalled -Installed @('2021.1.1f1') -Target '2022.3.22f1' | Should -Be $false
+  }
+
+  It 'does not treat the declared version as a regex (issue #74''s own example)' {
+    Test-UnityEditorInstalled -Installed @('2022X3Y22f1') -Target '2022.3.22f1' | Should -Be $false
+  }
+
+  It 'returns $false against an empty Installed list' {
+    Test-UnityEditorInstalled -Installed @() -Target '2022.3.22f1' | Should -Be $false
+  }
+}
+
+Describe 'Get-UnityEditorDrift' {
+  It 'reports nothing when declared and installed match exactly' {
+    $drift = Get-UnityEditorDrift -Declared @('2022.3.22f1') -Installed @('2022.3.22f1')
+
+    $drift.MissingVersions | Should -BeNullOrEmpty
+    $drift.ExtraVersions | Should -BeNullOrEmpty
+  }
+
+  It 'reports a declared version that is not installed as missing' {
+    $drift = Get-UnityEditorDrift -Declared @('2022.3.22f1') -Installed @()
+
+    $drift.MissingVersions | Should -Be @('2022.3.22f1')
+  }
+
+  It 'reports an installed version that is not declared as extra, without removing it' {
+    $drift = Get-UnityEditorDrift -Declared @('2022.3.22f1') -Installed @('2022.3.22f1', '2021.1.1f1')
+
+    $drift.ExtraVersions | Should -Be @('2021.1.1f1')
+    $drift.MissingVersions | Should -BeNullOrEmpty
+  }
+}
+
+Describe 'Invoke-UnityEditorInstall' {
+  It 'returns 0 on success' {
+    Mock Invoke-UnityInstallCommand { 0 }
+
+    Invoke-UnityEditorInstall -Version '2022.3.22f1' -Changeset '887be4894c44' -Modules @('android') | Should -Be 0
+  }
+
+  It 'passes -m for each declared module plus --cm' {
+    Mock Invoke-UnityInstallCommand { 0 }
+
+    Invoke-UnityEditorInstall -Version '2022.3.22f1' -Changeset '887be4894c44' -Modules @('android', 'ios') | Out-Null
+
+    Should -Invoke Invoke-UnityInstallCommand -Times 1 -ParameterFilter {
+      ($ArgumentList -join ' ') -eq 'install 2022.3.22f1 -c 887be4894c44 -m android -m ios --cm'
+    }
+  }
+
+  It 'passes --cm with no -m flags when no modules are declared' {
+    Mock Invoke-UnityInstallCommand { 0 }
+
+    Invoke-UnityEditorInstall -Version '2022.3.22f1' -Changeset '887be4894c44' | Out-Null
+
+    Should -Invoke Invoke-UnityInstallCommand -Times 1 -ParameterFilter {
+      ($ArgumentList -join ' ') -eq 'install 2022.3.22f1 -c 887be4894c44 --cm'
+    }
+  }
+
+  It 'returns 130 and writes a distinct error when interrupted' {
+    Mock Invoke-UnityInstallCommand { 130 }
+
+    $exitCode = Invoke-UnityEditorInstall -Version '2022.3.22f1' -Changeset '887be4894c44' -ErrorAction SilentlyContinue
+    $exitCode | Should -Be 130
+  }
+
+  It 'returns a non-zero, non-130 exit code without throwing' {
+    Mock Invoke-UnityInstallCommand { 6 }
+
+    $exitCode = Invoke-UnityEditorInstall -Version '2022.3.22f1' -Changeset '887be4894c44' -ErrorAction SilentlyContinue
+    $exitCode | Should -Be 6
+  }
+}
+
+Describe 'Sync-UnityEditor' {
+  BeforeAll {
+    $script:configPath = Join-Path -Path $TestDrive -ChildPath 'runtime-versions.psd1'
+    Set-Content -Path $script:configPath -Value @'
+@{
+  Unity = @{
+    Version   = '2022.3.22f1'
+    Changeset = '887be4894c44'
+    Modules   = @('android', 'documentation')
+  }
+}
+'@
+  }
+
+  It 'stops with an explicit error and does not check installed editors when the Unity CLI is unavailable' {
+    Mock Test-UnityCliAvailable { $false }
+    Mock Get-InstalledUnityEditors { @() }
+    Mock Invoke-UnityEditorInstall { 0 }
+
+    { Sync-UnityEditor -ConfigPath $script:configPath -ErrorAction SilentlyContinue } | Should -Not -Throw
+
+    Should -Invoke Get-InstalledUnityEditors -Times 0
+    Should -Invoke Invoke-UnityEditorInstall -Times 0
+  }
+
+  It 'skips installation when the declared version is already installed' {
+    Mock Test-UnityCliAvailable { $true }
+    Mock Get-InstalledUnityEditors { @('2022.3.22f1') }
+    Mock Invoke-UnityEditorInstall { 0 }
+
+    Sync-UnityEditor -ConfigPath $script:configPath
+
+    Should -Invoke Invoke-UnityEditorInstall -Times 0
+  }
+
+  It 'installs when the declared version is missing, then does not reinstall on a second run (idempotent)' {
+    Mock Test-UnityCliAvailable { $true }
+    $script:installed = @()
+    Mock Get-InstalledUnityEditors { $script:installed }
+    Mock Invoke-UnityEditorInstall {
+      $script:installed = @('2022.3.22f1')
+      return 0
+    }
+
+    Sync-UnityEditor -ConfigPath $script:configPath
+    Should -Invoke Invoke-UnityEditorInstall -Times 1
+
+    Sync-UnityEditor -ConfigPath $script:configPath
+    Should -Invoke Invoke-UnityEditorInstall -Times 1
+  }
+
+  It 'reports an installed-but-undeclared version without attempting to remove it' {
+    Mock Test-UnityCliAvailable { $true }
+    Mock Get-InstalledUnityEditors { @('2022.3.22f1', '2021.1.1f1') }
+    Mock Invoke-UnityEditorInstall { 0 }
+    Mock Remove-Item { }
+
+    Sync-UnityEditor -ConfigPath $script:configPath
+
+    Should -Invoke Invoke-UnityEditorInstall -Times 0
+    Should -Invoke Remove-Item -Times 0
+  }
+
+  It 'writes a non-terminating error and does not throw when the config file is missing' {
+    { Sync-UnityEditor -ConfigPath (Join-Path $TestDrive 'does-not-exist.psd1') -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'writes a non-terminating error and does not throw when the Unity entry is missing' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'no-unity.psd1'
+    Set-Content -Path $path -Value "@{ Node = @{} }"
+
+    { Sync-UnityEditor -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'writes a non-terminating error and does not throw when Unity is missing Modules' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'incomplete-unity.psd1'
+    Set-Content -Path $path -Value "@{ Unity = @{ Version = '2022.3.22f1'; Changeset = '887be4894c44' } }"
+
+    { Sync-UnityEditor -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+}

--- a/tests/powershell/unity-editor-installer.Tests.ps1
+++ b/tests/powershell/unity-editor-installer.Tests.ps1
@@ -188,12 +188,12 @@ Describe 'Sync-UnityEditor' {
 '@
   }
 
-  It 'stops with an explicit error and does not check installed editors when the Unity CLI is unavailable' {
+  It 'throws (stopping the whole run, not just this step) and does not check installed editors when the Unity CLI is unavailable' {
     Mock Test-UnityCliAvailable { $false }
     Mock Get-InstalledUnityEditors { @() }
     Mock Invoke-UnityEditorInstall { 0 }
 
-    { Sync-UnityEditor -ConfigPath $script:configPath -ErrorAction SilentlyContinue } | Should -Not -Throw
+    { Sync-UnityEditor -ConfigPath $script:configPath } | Should -Throw
 
     Should -Invoke Get-InstalledUnityEditors -Times 0
     Should -Invoke Invoke-UnityEditorInstall -Times 0

--- a/tests/powershell/unity-editor-installer.Tests.ps1
+++ b/tests/powershell/unity-editor-installer.Tests.ps1
@@ -63,6 +63,33 @@ Describe 'Get-InstalledUnityEditors' {
 
     Get-InstalledUnityEditors | Should -Be @('2022.3.22f1')
   }
+
+  It 'returns an empty array instead of throwing under StrictMode when the envelope has no "success" or "data" member' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{ ExitCode = 0; Output = '{"unexpected":true}' }
+    }
+
+    { Get-InstalledUnityEditors -ErrorAction SilentlyContinue } | Should -Not -Throw
+    Get-InstalledUnityEditors -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+  }
+
+  It 'returns an empty array instead of throwing under StrictMode when the JSON parses to a bare primitive' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{ ExitCode = 0; Output = '42' }
+    }
+
+    { Get-InstalledUnityEditors -ErrorAction SilentlyContinue } | Should -Not -Throw
+    Get-InstalledUnityEditors -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+  }
+
+  It 'returns an empty array instead of throwing under StrictMode when the JSON is a literal null' {
+    Mock Invoke-UnityEditorsListCommand {
+      @{ ExitCode = 0; Output = 'null' }
+    }
+
+    { Get-InstalledUnityEditors -ErrorAction SilentlyContinue } | Should -Not -Throw
+    Get-InstalledUnityEditors -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+  }
 }
 
 Describe 'Test-UnityEditorInstalled' {

--- a/tests/powershell/unity-editor-installer.Tests.ps1
+++ b/tests/powershell/unity-editor-installer.Tests.ps1
@@ -199,6 +199,16 @@ Describe 'Sync-UnityEditor' {
     Should -Invoke Invoke-UnityEditorInstall -Times 0
   }
 
+  It 'aborts without attempting an install when the installed-editors list cannot be determined' {
+    Mock Test-UnityCliAvailable { $true }
+    Mock Get-InstalledUnityEditors { throw 'unity editors -i --format json failed' }
+    Mock Invoke-UnityEditorInstall { 0 }
+
+    { Sync-UnityEditor -ConfigPath $script:configPath -ErrorAction SilentlyContinue } | Should -Not -Throw
+
+    Should -Invoke Invoke-UnityEditorInstall -Times 0
+  }
+
   It 'skips installation when the declared version is already installed' {
     Mock Test-UnityCliAvailable { $true }
     Mock Get-InstalledUnityEditors { @('2022.3.22f1') }


### PR DESCRIPTION
## Summary

Closes #74.

`libs/post-install.ps1`'s Unity Editor install drove Unity Hub's unofficial
`-- --headless` interface (`Unity Hub.exe -- --headless install -v <version>
-c <changeset> -m <modules...> --cm`). That implementation had four real
defects, all listed in this issue: it never checked the install process's
exit code (a failed install still reached "setup complete"), its
already-installed check ran the declared version through
`Select-String -Pattern`, treating it as a regex (`2022.3.22f1`'s dots
matched any character), the module list was hardcoded in the script instead
of declared, and there was no way to detect drift between the declared
version and what's actually installed, since Hub self-updates outside
winget and its `--headless` interface is undocumented.

Unity's own CLI (`unity` binary, installed by `libs/unity-cli-installer.ps1`,
issue #76) replaces Hub CLI for this step because it solves three of these
structurally instead of through workarounds: `unity install` has a
documented exit-code contract, `unity editors -i --format json` gives
structured output instead of text to regex-match, and comparing that JSON
against the declared config is a drift check with no extra machinery.

## What changed

- **`configurations/runtime-versions.psd1`**: Unity entry gains a `Modules`
  array (`android`, `documentation`, `ios`, `language-ja`), replacing the
  hardcoded `-m` flags that used to live in the script.
- **`libs/unity-editor-installer.ps1`** (new): `Sync-UnityEditor`, the
  idempotent entry point --
  - `Invoke-UnityEditorsListCommand` / `Invoke-UnityInstallCommand`: the
    only two functions with a real dependency on the installed `unity`
    binary, kept to a couple of lines each so Pester can mock them directly
  - `Get-InstalledUnityEditors`: parses `unity editors -i --format json`'s
    envelope, defensively probing per-item field names (see "JSON shape"
    below)
  - `Test-UnityEditorInstalled`: exact, ordinal string match -- never a
    regex/substring match (the fix for defect #2 above)
  - `Get-UnityEditorDrift`: report-only comparison, both directions
  - `Invoke-UnityEditorInstall`: builds the `unity install` argument list,
    handles the real exit-code contract (see "Exit codes" below)
- **`libs/post-install.ps1`**: the inline Hub CLI block is gone; the Unity
  Editor section now just dot-sources `libs/unity-editor-installer.ps1` and
  calls `Sync-UnityEditor`.
- **`docs/dsc-migration-notes.md`**: new section covering the defects fixed,
  the real exit-code table found during research, the JSON-shape honesty
  note, the `--cm` decision, and a re-confirmation (unchanged) of why Editor
  still isn't a winget package.

Unaffected by this PR, per the issue's own instructions: `Unity.UnityHub`
stays in `configurations/packages.dsc.yaml` (VRChat Creator Companion may
rely on Hub recognizing installed Editors), and there is no Hub CLI
fallback if `unity` is unavailable -- `Sync-UnityEditor` stops with an
explicit error instead, consistent with this repo's existing
"fallback is a pre-check gate, not an exception handler" principle from
issues #65/#67.

## Findings from checking the actual Unity CLI reference (not assumed)

- **The real exit-code table is more granular than this issue's own
  description.** The issue simplifies `unity install`'s contract as "0
  success / 1 error / 130 interrupted". Unity's CLI reference
  (docs.unity.com/en-us/unity-cli/unity-cli-reference) documents a fuller
  table: `0` success, `1` general error, `2` usage error, `3`
  auth/authorization failure, `4` configuration required, `6` the
  operation itself failed (e.g. the install failed), `130` interrupted
  (Ctrl+C/SIGINT), `143` terminated (SIGTERM). A real install failure can
  surface as `1`, `2`, `3`, `4`, or `6` -- there's no single code that
  uniquely means "install failed". `Invoke-UnityEditorInstall` only
  special-cases `0` and `130` (per this issue's acceptance criteria) and
  treats every other non-zero code uniformly as a failure, always logging
  the exact value.
- **`unity editors -i --format json`'s per-item JSON shape is undocumented.**
  The outer envelope (`success`/`command`/`data`/`errors`/`warnings`) is
  documented on the reference page's "Format selection" table and verified
  directly from that page's text. The shape of each item inside `data` for
  the `editors` command specifically is not documented anywhere found --
  same situation `Test-UnityCliCurrent` (issue #76) was in for `unity
  --version`'s output. Handled the same way: `Get-InstalledUnityEditors`
  probes a small, explicit set of plausible field names (`version`, then
  `Version`) per item and skips (rather than throws on) anything else, so
  an unexpected real shape degrades gracefully instead of crashing the
  install path.

## A design detour worth calling out: two Pester-testability bugs found and fixed while writing this PR

- **`Mock unity { ... }` doesn't work when no `unity` binary exists at all**
  on the machine (this Linux dev environment) -- Pester's `Mock` requires
  the target command to already resolve via `Get-Command`. Fixed by
  isolating every real `& unity ...` invocation into its own one-line
  function (`Invoke-UnityEditorsListCommand`, `Invoke-UnityInstallCommand`),
  which Pester *can* mock regardless of whether the real binary exists,
  matching the pattern issue #76 already established for
  `Get-InstalledUnityCliVersion`.
- **PowerShell collapses an empty array to `$null` across a function-call
  boundary.** Confirmed empirically: `function Get-Foo { return @() }; $x =
  Get-Foo` leaves `$x` as `$null`, not an empty array -- this broke
  `Get-UnityEditorDrift`'s `[AllowEmptyCollection()]` parameter binding in
  a "zero installed Editors" test. Fixed at `Sync-UnityEditor`'s call site
  (`$installed = @(Get-InstalledUnityEditors)`), which reliably re-coerces
  `$null` back into a real empty array regardless of what the callee (or
  its Pester mock) returns -- verified this fix works with a standalone
  repro before applying it.

## Not verified on a real machine

Windows/Unity-CLI-only, and per this repo's own established rule (learned
the hard way during issue #73): `libs/post-install.ps1` / `boxstarter.ps1`
are never executed directly in this environment even to smoke-test. What
*is* verified: Unity's actual CLI reference page was read directly (not
inferred from this issue's own simplified description) for the exit-code
table and the JSON envelope shape, and all new logic is covered by Pester
with `unity` itself mocked at the `Invoke-UnityEditorsListCommand` /
`Invoke-UnityInstallCommand` boundary.

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` on every
  changed/new `.ps1` file -- no syntax errors
- `markdownlint-cli2 "**/*.md"` -- 0 issues
- `cspell lint "**" --no-progress` -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` -- exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` -- 72/72 pass (25 new: 6
  `Get-InstalledUnityEditors`, 4 `Test-UnityEditorInstalled`, 3
  `Get-UnityEditorDrift`, 5 `Invoke-UnityEditorInstall`, 7
  `Sync-UnityEditor`; 47 pre-existing, no regression)

## Test plan

- [x] `libs/post-install.ps1` no longer calls Unity Hub CLI
      (`-- --headless`)
- [x] Editor install goes through `unity install`, with version/changeset/
      modules from the declared config
- [x] Changing `Modules` in the config changes the `-m` arguments passed to
      `unity install` (Pester)
- [x] `--cm`'s inclusion and rationale are recorded in
      `docs/dsc-migration-notes.md`
- [x] Already-installed detection uses `unity editors -i --format json`
      output with exact string match (`2022.3.22f1` does not match a
      `2022X3Y22f1`-shaped string -- this issue's own example, tested)
- [x] `unity install`'s exit code is checked; non-zero is treated as
      failure
- [x] Exit code `130` is distinguished from a general error
- [x] Version and exit code are logged on failure
- [x] Drift detection reports both "declared but not installed" and
      "installed but not declared"
- [x] Drift detection never removes an undeclared Editor
- [x] An explicit error stops the run when `unity` is unavailable
- [x] No Hub CLI fallback path exists in the implementation
- [x] `Unity.UnityHub` remains in `configurations/packages.dsc.yaml`
- [x] The winget-Editor rejection decision and its four supporting points
      are recorded in `docs/dsc-migration-notes.md`
- [x] PSScriptAnalyzer reports nothing for the changed `libs/post-install.ps1`
- [x] Pester tests exist for the new logic, mocking `unity editors -i
      --format json` output and covering exact-match and drift-detection
      classification
- [x] `pre-push-validate` exits 0 on a clean worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unity Editor installation now uses the official Unity CLI.
  * Automatically detects installed Editors, installs missing configured versions, and applies required modules and changesets.
  * Reports configuration drift while preserving unlisted installed Editors.
  * Provides clearer handling for installation interruptions and failures.

* **Documentation**
  * Added migration guidance covering the new installation process, detection behavior, synchronization requirements, and known limitations.

* **Tests**
  * Added comprehensive automated coverage for discovery, installation, drift detection, errors, and repeatable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->