### PR TITLE
feat(setup): declare winget pins and apply them idempotently

### DIFF
--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -189,6 +189,16 @@ if (Test-Path $postInstall) {
   Write-Host '[Phase 5] Post-install setup complete.' -ForegroundColor Green
 }
 
+# Applied after every package-install phase above (winget configure/import in
+# Phase 2, the architecture-conditional winget installs in Phase 4, and
+# post-install.ps1's own package-adjacent work just above) so every pin
+# target actually exists on the machine before winget pin add runs against
+# it -- see docs/dsc-migration-notes.md's "Declaring winget pins (issue #75)"
+# section. Kept in Phase 5 rather than its own numbered phase for the same
+# reason Sync-UnityCli is, above: avoids renumbering every phase below.
+. (Join-Path $scriptRoot 'libs\winget-pin-sync.ps1')
+Sync-WinGetPins -ConfigPath (Join-Path $scriptRoot 'configurations\pinned-packages.psd1')
+
 ###########################################################################
 ### Phase 6 — Remote Desktop
 ###########################################################################

--- a/configurations/pinned-packages.psd1
+++ b/configurations/pinned-packages.psd1
@@ -1,0 +1,44 @@
+@{
+  # Packages pinned via `winget pin add` (libs/winget-pin-sync.ps1,
+  # applied by boxstarter.ps1 after package installation) so a manual
+  # `winget upgrade --all` -- or any other bulk-upgrade path that goes
+  # through winget itself -- does not silently move a version-sensitive
+  # package out from under this repo's other declared state. Pinning is
+  # machine-local winget state, not part of the DSC/import files
+  # themselves, which is exactly why it needs its own declaration here:
+  # see docs/dsc-migration-notes.md's "Declaring winget pins (issue #75)"
+  # section for the full rationale, the pin-type decision, and this
+  # mechanism's documented limits (Unity Hub's own self-update, and
+  # msstore-sourced packages).
+  #
+  # Each entry:
+  #   Id      - winget package identifier (must match its
+  #             configurations/packages*.dsc.yaml entry)
+  #   Source  - winget source name (almost always 'winget'; msstore
+  #             packages can be listed too, but pin coverage there is
+  #             unverified -- see docs/dsc-migration-notes.md)
+  #   PinType - one of 'Pinning' | 'Blocking' | 'Gating', matching
+  #             winget's own three pin types exactly (case-sensitive).
+  #             'Gating' entries must also set VersionRange.
+  #   Reason  - why this package is pinned, i.e. what breaks if it
+  #             silently upgrades. A pin with no reason can't later be
+  #             judged safe to remove.
+  Pins = @(
+    @{
+      Id      = 'Unity.UnityHub'
+      Source  = 'winget'
+      PinType = 'Blocking'
+      Reason  = @'
+Unity Hub drives Unity Editor installation (libs/unity-editor-installer.ps1)
+and VRChat Creator Companion depends on it recognizing the installed Editor
+(configurations/runtime-versions.psd1's Unity entry). An unplanned Hub
+upgrade risks changing that recognition behavior or the Hub CLI surface
+underneath a pinned Editor version, so this uses Blocking (not the default
+Pinning) -- an operator typing `winget upgrade Unity.UnityHub` by name
+should not silently succeed either. This still only closes the
+winget-upgrade path: Hub self-updates outside winget entirely, which no pin
+type can stop -- see docs/dsc-migration-notes.md.
+'@
+    }
+  )
+}

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -625,6 +625,136 @@ developer installed manually for an unrelated project must not disappear as
 a side effect of running this repo's setup -- an explicit constraint from
 this issue, not an oversight.
 
+## Declaring winget pins (issue #75)
+
+Declaring a package in `configurations/packages.dsc.yaml` only controls
+whether it gets installed, not whether it silently upgrades later.
+`Microsoft.WinGet.DSC`'s `WinGetPackage` resource defaults `UseLatest` to
+`$false`, and with no `Version` pinned either, its check is "installed at
+all" -- re-running `winget configure` never upgrades anything. That is not
+the exposure this issue is about: the two real upgrade paths are a human
+running `winget upgrade --all`, and UniGetUI (`MartiCliment.UniGetUI`, this
+repo's own declared package) doing a bulk update. `winget pin` is winget's
+own answer to both, but it is machine-local state -- it does not live in
+`packages.dsc.yaml`, so a clone or a new machine starts with no pins at all
+and silently loses this protection. `configurations/pinned-packages.psd1`
+(declaration) and `libs/winget-pin-sync.ps1` (idempotent apply, called from
+`boxstarter.ps1` Phase 5) exist to make that state reproducible again.
+
+### The three pin types, and which one is used
+
+winget has three pin types (`winget pin add`'s own reference page), and
+they are not interchangeable:
+
+- **Pinning** (the default, no extra flag): excluded from `winget upgrade
+  --all`, but `winget upgrade <package>` by name still goes through.
+- **Blocking** (`--blocking`): rejected by both `winget upgrade --all` and
+  an explicit `winget upgrade <package>`, until unpinned (or `--force`).
+- **Gating** (`--version <range>`, wildcard `*` allowed as the last version
+  part): locks to a specific version or range, independent of the other two.
+
+`configurations/pinned-packages.psd1`'s one entry so far, `Unity.UnityHub`,
+uses **Blocking**. Reasoning (also recorded next to the entry itself, since
+a pin with no reason can't later be judged safe to remove): Unity Hub drives
+Unity Editor installation (`libs/unity-editor-installer.ps1`) and VRChat
+Creator Companion depends on Hub recognizing the installed Editor
+(`configurations/runtime-versions.psd1`'s `Unity` entry) -- a Hub upgrade
+changing that recognition behavior, or the Hub CLI surface underneath a
+pinned Editor version, is exactly the kind of breakage this issue exists to
+prevent. The plain **Pinning** default was rejected specifically because it
+would still let `winget upgrade Unity.UnityHub` (by name) through -- an
+operator typing that should not silently succeed either. **Gating** was not
+used here: it would require tracking and re-verifying a specific target Hub
+version, which nothing in this repo currently does (unlike the Unity Editor
+itself, whose `Version`/`Changeset` are already tracked in
+`runtime-versions.psd1`) -- introducing that tracking was out of scope.
+`Docker.DockerDesktop`, cited alongside Unity Hub as an example in this
+issue's own background, is not pinned: it is intentionally kept out of
+`packages.dsc.yaml` already (installed conditionally in `boxstarter.ps1`
+Phase 4) and has no currently-documented version-compatibility constraint
+in this repo to point to as a reason -- adding a pin without one would
+violate this same section's own "no reason, can't be judged removable"
+principle.
+
+### Undeclared and mismatched pins are reported, never touched
+
+`libs/winget-pin-sync.ps1`'s `Get-WinGetPinDrift` classifies every current
+pin against the declaration into four buckets: `ToAdd` (declared, missing --
+the only bucket `Sync-WinGetPins` acts on), `Matching`, `Mismatched`
+(present, but pinned with a different type or version range than declared),
+and `Undeclared` (present, not declared at all). Mismatched and Undeclared
+are both surfaced via `Write-Warning` and never modified. This is a
+deliberate choice, not an oversight: an operator may have pinned or
+re-pinned a package by hand for a reason this repo doesn't know about, and
+auto-correcting or removing that pin risks silently discarding it -- the
+same "report drift, never remove what the declaration doesn't know about"
+posture `Get-UnityEditorDrift` already uses for installed-but-undeclared
+Unity Editors (issue #74). Whether to eventually add an opt-in
+auto-remove/auto-correct mode is left for a future issue if it turns out to
+matter in practice.
+
+### `winget pin list` has no machine-readable output
+
+Unlike `unity editors -i --format json` (issue #74), `winget pin list` has
+no `--format json` or any other structured-output option -- confirmed
+against winget-cli's own `pin` reference page, which lists only the
+console/logging options (`--verbose`, `--nowarn`, etc.), no output-format
+flag. `microsoft/winget-cli#3051` ("add machine-parseable output") was
+closed as a duplicate of #1753 and redirects scripting use to the
+`Microsoft.WinGet.Client` PowerShell module instead -- but that module has
+no pin cmdlet at all as of this writing (no `Add-WinGetPin`/`Get-WinGetPin`
+exists anywhere in its `Cmdlets` source on GitHub). `ConvertFrom-
+WinGetPinListOutput` therefore parses the human-readable table directly,
+deriving each column's start offset from the header row itself (`Id`,
+`Source`, `Version`, `Pin type`) rather than hardcoding a width, since
+winget pads each column to its widest cell and that width isn't documented
+or guaranteed stable. A known related bug (`microsoft/winget-cli#3013`,
+`Version`/`Pin type` columns swapped for Gating pins) was already fixed
+upstream by the time of that issue's later comments, but is exactly the
+kind of shift this header-driven approach tolerates without a code change.
+Not verified against a real `winget pin list` invocation -- Windows-only,
+and per this repo's established rule, `boxstarter.ps1` is never executed
+directly in this environment even to smoke-test. Covered by Pester with
+`winget` mocked at the `Invoke-WinGetPinListCommand` boundary, using
+fixture tables generated to match winget's documented column layout.
+
+### UniGetUI does not respect winget pin
+
+UniGetUI's own issue tracker documents an "ignored updates" feature
+(`marticliment/UniGetUI#418`, `Devolutions/UniGetUI#1008`) that its own UI
+labels internally as a "blacklist" -- entirely separate app-managed state,
+not a read of winget's pin database. No evidence of UniGetUI reading or
+writing winget pin state was found anywhere in its issue tracker, release
+notes (through the 2026.2.x series), or documentation. **Conclusion: winget
+pin declared here is not respected by UniGetUI's bulk-update feature.** The
+avoidance path this issue's acceptance criteria asks for does exist, just
+not through winget pin: UniGetUI's own per-package "ignore updates" /
+"Manage ignored updates" feature (its Settings screen) can independently
+exclude a package from UniGetUI's own update pass. That is a manual,
+UniGetUI-side step -- it has no equivalent in `configurations/
+pinned-packages.psd1` and is not automated by `libs/winget-pin-sync.ps1`,
+since it is a different application's own local state, not winget's.
+Anyone relying on UniGetUI for updates should mirror this repo's pinned
+packages there by hand; that gap is a documented limitation, not something
+this issue's mechanism can close.
+
+### What pin cannot close
+
+- **Unity Hub self-updates outside winget entirely.** Its own
+  auto-updater is not a winget-mediated upgrade, so no pin type --
+  Blocking included -- stops it. Pinning `Unity.UnityHub` here still closes
+  the *winget*-mediated path (`winget upgrade --all`, or an explicit
+  `winget upgrade Unity.UnityHub`); it just doesn't close Hub's own
+  self-update mechanism, which is undocumented and outside this repo's
+  control.
+- **Microsoft Store-sourced packages (`source: msstore`, 29 in
+  `configurations/packages.dsc.yaml` as of this writing) are not guaranteed
+  to respect winget pin.** They are also subject to the Microsoft Store's
+  own automatic-update mechanism, independent of winget. `winget pin add`
+  does not reject an `msstore`-sourced target, so declaring one here is not
+  blocked, but its effectiveness against Store's own update path is
+  unverified.
+
 ## Removed files and their relocation
 
 | Removed file | Disposition |

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -704,19 +704,62 @@ closed as a duplicate of #1753 and redirects scripting use to the
 `Microsoft.WinGet.Client` PowerShell module instead -- but that module has
 no pin cmdlet at all as of this writing (no `Add-WinGetPin`/`Get-WinGetPin`
 exists anywhere in its `Cmdlets` source on GitHub). `ConvertFrom-
-WinGetPinListOutput` therefore parses the human-readable table directly,
-deriving each column's start offset from the header row itself (`Id`,
-`Source`, `Version`, `Pin type`) rather than hardcoding a width, since
-winget pads each column to its widest cell and that width isn't documented
-or guaranteed stable. A known related bug (`microsoft/winget-cli#3013`,
-`Version`/`Pin type` columns swapped for Gating pins) was already fixed
-upstream by the time of that issue's later comments, but is exactly the
-kind of shift this header-driven approach tolerates without a code change.
-Not verified against a real `winget pin list` invocation -- Windows-only,
-and per this repo's established rule, `boxstarter.ps1` is never executed
-directly in this environment even to smoke-test. Covered by Pester with
-`winget` mocked at the `Invoke-WinGetPinListCommand` boundary, using
-fixture tables generated to match winget's documented column layout.
+WinGetPinListOutput` therefore parses the human-readable table directly.
+
+The real, current column set -- confirmed from two independent, real
+terminal-output reproductions pasted into actual `microsoft/winget-cli`
+issues, `#4340` (2024-04, winget v1.7.10861) and `#5244` (2025-02, a
+different winget install) -- is **`Name | Id | Version | Source | Pin
+type`**, five columns with `Name` first. This corrected an initial mistake
+in this PR: the first implementation was modeled on `microsoft/winget-
+cli#3013` (2023-02, winget v1.5.441-preview -- the very first preview
+build with pinning at all), whose reproduction shows a *four*-column `Id |
+Source | Version | Pin type` table with no `Name` column at all. That
+issue's own fix (`microsoft/winget-cli#3016`, "Fix order of pin labels")
+only reordered which value landed in which of *its* four columns; it did
+not add the `Name` column seen in the later issues, which must have
+happened separately. A CodeRabbit review comment on this PR caught the
+mismatch, backed by its own citations to the current documentation --
+verified independently against the two issues above (primary terminal
+output, not the docs page, since the docs page itself doesn't show an
+example row) before accepting the correction.
+
+Column start offsets are still derived from the header row rather than
+hardcoded (winget pads each column to its widest cell, an undocumented and
+non-guaranteed width), but are now looked up by name and sorted by
+discovered position instead of assumed to be in a fixed sequence --
+specifically because `#3013` already proves this table's column order has
+shifted across winget-cli versions once before, and could again. Only
+`Id`/`Version`/`Source`/`Pin type` are parsed (`Name` is human-readable
+only, not needed for drift matching), which also means the four-column,
+`Name`-less shape from the older `#3013`-era winget still parses correctly
+without any special-casing -- one fewer column to find is not an error
+condition for this lookup. A related, very recent finding
+(`microsoft/winget-cli#6325`, 2026-06): when no pins are set, the command
+prints the literal message "There are no pins configured." -- consistent
+with this parser's existing design of treating "no recognized header
+found" as zero pins rather than an error, and tolerant of that exact
+wording changing again without a code change here.
+
+One correctness consequence of the real format: both `#4340` and `#5244`
+show a concrete, non-blank installed-version string in the `Version`
+column for every pin type, not just `Gating` -- contradicting this PR's
+original assumption that `Version` would be blank for `Pinning`/`Blocking`
+pins. `Get-WinGetPinDrift` was corrected accordingly: it only compares
+`Version` against the declared `VersionRange` for `Gating` entries;
+`Pinning`/`Blocking` pins are classified as `Matching` by `PinType` alone,
+since there is no "must be blank" value left to check and comparing one
+would misclassify a correctly applied pin as `Mismatched`.
+
+Not verified against a real `winget pin list` invocation on this repo's
+own machine -- Windows-only, and per this repo's established rule,
+`boxstarter.ps1` is never executed directly in this environment even to
+smoke-test. What *is* verified: the column layout and the empty-state
+message both come from real terminal output pasted into the actual
+winget-cli issue tracker, not inferred from a docs page or assumed stable
+across versions. Covered by Pester with `winget` mocked at the
+`Invoke-WinGetPinListCommand` boundary, using fixture tables matching both
+the current five-column shape and the older four-column one.
 
 ### UniGetUI does not respect winget pin
 

--- a/libs/winget-pin-sync.ps1
+++ b/libs/winget-pin-sync.ps1
@@ -63,62 +63,97 @@ function ConvertFrom-WinGetPinListOutput {
     [Parameter(Mandatory)][AllowEmptyString()][string]$Output
   )
   $lines = $Output -split "`r?`n"
+  $requiredColumns = @('Id', 'Version', 'Source', 'Pin type')
   $headerIndex = -1
+  $offsets = $null
   for ($i = 0; $i -lt $lines.Count; $i++) {
-    if ($lines[$i] -match '^Id\s+Source\s+Version\s+Pin type\s*$') {
+    $candidateOffsets = @{}
+    foreach ($name in $requiredColumns) {
+      $candidateOffsets[$name] = $lines[$i].IndexOf($name)
+    }
+    if (@($candidateOffsets.Values | Where-Object { $_ -lt 0 }).Count -eq 0) {
       $headerIndex = $i
+      $offsets = $candidateOffsets
       break
     }
   }
   if ($headerIndex -lt 0) {
     return [hashtable[]]@()
   }
-  $header = $lines[$headerIndex]
-  $sourceStart = $header.IndexOf('Source')
-  $versionStart = $header.IndexOf('Version')
-  $pinTypeStart = $header.IndexOf('Pin type')
+  $orderedColumns = @($requiredColumns | Sort-Object { $offsets[$_] })
   $firstDataLine = $headerIndex + 2
   $lastDataLine = $lines.Count - 1
   if ($firstDataLine -gt $lastDataLine) {
     return [hashtable[]]@()
   }
+  $lastColumnStart = $offsets[$orderedColumns[-1]]
   $pins = foreach ($line in $lines[$firstDataLine..$lastDataLine]) {
-    if ([string]::IsNullOrWhiteSpace($line) -or $line.Length -lt $pinTypeStart) {
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.Length -lt $lastColumnStart) {
       continue
     }
+    $values = @{}
+    for ($c = 0; $c -lt $orderedColumns.Count; $c++) {
+      $columnName = $orderedColumns[$c]
+      $start = $offsets[$columnName]
+      if ($c -lt $orderedColumns.Count - 1) {
+        $end = $offsets[$orderedColumns[$c + 1]]
+        $values[$columnName] = $line.Substring($start, $end - $start).Trim()
+      }
+      else {
+        $values[$columnName] = $line.Substring($start).Trim()
+      }
+    }
     @{
-      Id      = $line.Substring(0, $sourceStart).Trim()
-      Source  = $line.Substring($sourceStart, $versionStart - $sourceStart).Trim()
-      Version = $line.Substring($versionStart, $pinTypeStart - $versionStart).Trim()
-      PinType = $line.Substring($pinTypeStart).Trim()
+      Id      = $values['Id']
+      Source  = $values['Source']
+      Version = $values['Version']
+      PinType = $values['Pin type']
     }
   }
   return [hashtable[]]@($pins)
   <#
   .SYNOPSIS
-  Parses `winget pin list`'s human-readable table (Id / Source / Version
-  / Pin type columns). There is no --format json (or any other
-  machine-readable output) for this command: confirmed against
-  microsoft/winget-cli#3051, which was closed as a duplicate of #1753
-  and redirected scripting use to the PowerShell module (Microsoft.
-  WinGet.Client) -- but that module has no pin cmdlet at all as of this
-  writing (no Add-WinGetPin/Get-WinGetPin exists in its Cmdlets source).
-  Column start offsets are read from the header row itself rather than
-  hardcoded, since winget pads each column to fit its widest cell and
-  that width is not documented or guaranteed stable -- this mirrors the
-  header-driven parsing already used nowhere else in this repo, but the
-  same "derive structure from the live output, don't hardcode it"
-  posture as Get-InstalledUnityEditors's per-item field probing.
+  Parses `winget pin list`'s human-readable table. There is no --format
+  json (or any other machine-readable output) for this command:
+  confirmed against microsoft/winget-cli#3051, which was closed as a
+  duplicate of #1753 and redirected scripting use to the PowerShell
+  module (Microsoft.WinGet.Client) -- but that module has no pin
+  cmdlet at all as of this writing (no Add-WinGetPin/Get-WinGetPin
+  exists in its Cmdlets source).
 
-  A missing header row (no pins currently set, or an output shape this
-  parser doesn't recognize) degrades to an empty array rather than an
-  error -- winget pin list itself is not known to fail via exit code
-  merely for having zero pins, so treating "no header found" as "zero
-  pins" is the correct default for the common case.
+  The real, current column set is `Name | Id | Version | Source | Pin
+  type` (five columns, Name first) -- confirmed from two independent,
+  real terminal-output reproductions pasted into microsoft/winget-cli
+  issues: #4340 (2024-04, winget v1.7.10861) and #5244 (2025-02, a
+  different winget install). This is NOT what an earlier issue,
+  #3013 (2023-02, winget v1.5.441-preview -- the first preview build
+  with pinning at all), showed: a four-column `Id | Source | Version |
+  Pin type` table with no Name column. #3013's own fix
+  (microsoft/winget-cli#3016, "Fix order of pin labels") only
+  reordered which value landed in which of ITS FOUR columns; #4340 and
+  #5244 show a materially different, five-column shape that must have
+  been added later. Only Id/Version/Source/Pin type are parsed here
+  (Name is human-readable-only, not needed for drift matching) --
+  their offsets are read from the header row and sorted by discovered
+  position, not assumed to be in a fixed order, specifically because
+  #3013 already proves this table's column order has shifted across
+  winget-cli versions once before.
+
+  A missing header row (no pins currently set -- e.g.
+  microsoft/winget-cli#6325 (2026-06) shows the literal message "There
+  are no pins configured." -- or an output shape this parser doesn't
+  recognize) degrades to an empty array rather than an error: winget
+  pin list itself is not known to fail via exit code merely for having
+  zero pins, so treating "no header found" as "zero pins" is the
+  correct default for the common case, and is tolerant of the exact
+  empty-state wording changing again without a code change here.
 
   .OUTPUTS
-  One hashtable per pin (Id/Source/Version/PinType, all strings; Version
-  is '' for Pinning/Blocking pins), or an empty array.
+  One hashtable per pin (Id/Source/Version/PinType, all strings).
+  Version is not blank for Pinning/Blocking pins in current winget
+  (both #4340 and #5244 show a concrete installed-version string for
+  every pin type, not just Gating) -- see Get-WinGetPinDrift, which
+  does not compare Version for non-Gating pins for exactly this reason.
   #>
 }
 
@@ -145,10 +180,15 @@ function Test-PinnedPackageEntry {
     -not $Entry.Contains('PinType') -or -not $Entry.Contains('Reason')) {
     return $false
   }
+  if ([string]::IsNullOrWhiteSpace($Entry.Id) -or [string]::IsNullOrWhiteSpace($Entry.Source) -or
+    [string]::IsNullOrWhiteSpace($Entry.Reason)) {
+    return $false
+  }
   if ($Entry.PinType -notin @('Pinning', 'Blocking', 'Gating')) {
     return $false
   }
-  if ($Entry.PinType -eq 'Gating' -and -not $Entry.Contains('VersionRange')) {
+  if ($Entry.PinType -eq 'Gating' -and
+    (-not $Entry.Contains('VersionRange') -or [string]::IsNullOrWhiteSpace($Entry.VersionRange))) {
     return $false
   }
   return $true
@@ -169,6 +209,12 @@ function Test-PinnedPackageEntry {
   is NOT caught by the Where-Object scriptblock that calls this
   function, so it would abort the entire Sync-WinGetPins run instead of
   just skipping the one bad entry.
+
+  Checks Id/Source/Reason/VersionRange for non-empty, non-whitespace
+  values, not just key presence: a key present with an empty string
+  (e.g. `Reason = ''`) would otherwise pass validation and reach
+  Get-WinGetPinAddArguments, producing a broken `winget pin add --id ''
+  ...` call that fails at runtime instead of being rejected here.
   #>
 }
 
@@ -229,9 +275,17 @@ function Get-WinGetPinDrift {
       $toAdd += $entry
       continue
     }
-    $expectedVersion = if ($entry.PinType -eq 'Gating') { $entry.VersionRange } else { '' }
     $typeMatches = [string]::Equals($existing.PinType, $entry.PinType, [System.StringComparison]::Ordinal)
-    $versionMatches = [string]::Equals($existing.Version, $expectedVersion, [System.StringComparison]::Ordinal)
+    $versionMatches = if ($entry.PinType -eq 'Gating') {
+      [string]::Equals($existing.Version, $entry.VersionRange, [System.StringComparison]::Ordinal)
+    }
+    else {
+      # Pinning/Blocking carry no declared target version -- winget pin
+      # list's Version column shows the currently-installed version for
+      # every pin type, not just Gating, so there is nothing meaningful
+      # to compare it against here.
+      $true
+    }
     if ($typeMatches -and $versionMatches) {
       $matching += $entry
     }
@@ -256,15 +310,23 @@ function Get-WinGetPinDrift {
   .SYNOPSIS
   Classifies each declared pin against the machine's current pins
   (matched by Id+Source, ordinal): ToAdd (declared, not present at
-  all), Matching (present with the declared PinType/VersionRange),
-  Mismatched (present but pinned differently than declared -- e.g. a
-  plain pin where Blocking is declared), or Undeclared (present but not
-  in configurations/pinned-packages.psd1 at all). Pure classification,
-  no `winget` call -- Sync-WinGetPins only ever adds ToAdd entries; it
+  all), Matching (present with the declared PinType, and for Gating
+  also the declared VersionRange), Mismatched (present but pinned
+  differently than declared -- e.g. a plain pin where Blocking is
+  declared), or Undeclared (present but not in
+  configurations/pinned-packages.psd1 at all). Pure classification, no
+  `winget` call -- Sync-WinGetPins only ever adds ToAdd entries; it
   never removes Undeclared pins or corrects Mismatched ones, since
   either could be silently discarding an operator's own manual `winget
   pin` choice (see docs/dsc-migration-notes.md's "why report-only"
   rationale). Both are surfaced as warnings instead.
+
+  Version is only compared for Gating: real `winget pin list` output
+  shows a concrete installed-version string in the Version column
+  regardless of pin type (confirmed in microsoft/winget-cli#4340 and
+  #5244), so there is no "must be blank" value to check for
+  Pinning/Blocking, and comparing it would misclassify a correctly
+  applied pin as Mismatched.
   #>
 }
 

--- a/libs/winget-pin-sync.ps1
+++ b/libs/winget-pin-sync.ps1
@@ -136,8 +136,11 @@ function Get-CurrentWinGetPins {
 
 function Test-PinnedPackageEntry {
   param (
-    [Parameter(Mandatory)][hashtable]$Entry
+    [Parameter(Mandatory)]$Entry
   )
+  if ($Entry -isnot [hashtable]) {
+    return $false
+  }
   if (-not $Entry.Contains('Id') -or -not $Entry.Contains('Source') -or
     -not $Entry.Contains('PinType') -or -not $Entry.Contains('Reason')) {
     return $false
@@ -157,6 +160,15 @@ function Test-PinnedPackageEntry {
   declared list through this and reports what it skips, the same
   "don't let one bad item take down the whole run" posture as
   Get-InstalledUnityEditors's per-item field probing.
+
+  $Entry is deliberately untyped, with an explicit `-isnot [hashtable]`
+  check as the first condition, rather than a `[hashtable]$Entry`
+  parameter: a typed parameter rejects a non-hashtable item (e.g. a
+  stray string in the Pins array) via a terminating parameter-binding
+  error, not a $false return -- confirmed empirically, and that error
+  is NOT caught by the Where-Object scriptblock that calls this
+  function, so it would abort the entire Sync-WinGetPins run instead of
+  just skipping the one bad entry.
   #>
 }
 
@@ -319,7 +331,7 @@ function Sync-WinGetPins {
   }
 
   if ($drift.ToAdd.Count -eq 0) {
-    Write-Host '[winget-pin] All declared pins already applied -- skipping.' -ForegroundColor Gray
+    Write-Host '[winget-pin] No missing declared pins to add.' -ForegroundColor Gray
   }
   <#
   .SYNOPSIS

--- a/libs/winget-pin-sync.ps1
+++ b/libs/winget-pin-sync.ps1
@@ -354,7 +354,7 @@ function Sync-WinGetPins {
   $invalidCount = $declaredRaw.Count - $declared.Count
   if ($invalidCount -gt 0) {
     $entryNoun = if ($invalidCount -eq 1) { 'entry' } else { 'entries' }
-    Write-Warning "[winget-pin] Skipping $invalidCount malformed $entryNoun in ${ConfigPath} (missing Id/Source/PinType/Reason, an unknown PinType, or a Gating entry missing VersionRange)."
+    Write-Warning "[winget-pin] Skipping $invalidCount malformed $entryNoun in ${ConfigPath} (Id/Source/PinType/Reason missing or blank, an unknown PinType, or a Gating entry with a missing or blank VersionRange)."
   }
 
   try {

--- a/libs/winget-pin-sync.ps1
+++ b/libs/winget-pin-sync.ps1
@@ -69,7 +69,7 @@ function ConvertFrom-WinGetPinListOutput {
   for ($i = 0; $i -lt $lines.Count; $i++) {
     $candidateOffsets = @{}
     foreach ($name in $requiredColumns) {
-      $candidateOffsets[$name] = $lines[$i].IndexOf($name)
+      $candidateOffsets[$name] = $lines[$i].IndexOf($name, [System.StringComparison]::OrdinalIgnoreCase)
     }
     if (@($candidateOffsets.Values | Where-Object { $_ -lt 0 }).Count -eq 0) {
       $headerIndex = $i
@@ -137,7 +137,13 @@ function ConvertFrom-WinGetPinListOutput {
   their offsets are read from the header row and sorted by discovered
   position, not assumed to be in a fixed order, specifically because
   #3013 already proves this table's column order has shifted across
-  winget-cli versions once before.
+  winget-cli versions once before. The header lookup is also
+  case-insensitive ("Pin type" vs "Pin Type"): third-party mirrors of
+  winget-cli's docs disagree with each other on capitalization and on
+  whether Source or Pin type comes last, which the order-derived-from-
+  the-header design above already tolerates regardless of which is
+  actually current -- case-insensitivity closes the one gap that
+  design alone doesn't.
 
   A missing header row (no pins currently set -- e.g.
   microsoft/winget-cli#6325 (2026-06) shows the literal message "There

--- a/libs/winget-pin-sync.ps1
+++ b/libs/winget-pin-sync.ps1
@@ -1,0 +1,343 @@
+<#
+.SYNOPSIS
+Idempotently applies the winget pin declarations in
+configurations/pinned-packages.psd1 via `winget pin add`, and reports
+(without touching) any pin already on the machine that isn't declared.
+
+This file is dot-sourced (not imported as a module) from boxstarter.ps1 --
+do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+function Get-PinnedPackagesConfig {
+  param (
+    [Parameter(Mandatory)][string]$Path
+  )
+  if (-not (Test-Path -Path $Path -PathType Leaf)) {
+    Write-Error "Pinned packages config not found: $Path"
+    return $null
+  }
+  try {
+    return Import-PowerShellDataFile -Path $Path -ErrorAction Stop
+  }
+  catch {
+    Write-Error "Failed to read pinned packages config ${Path}: $_"
+    return $null
+  }
+  <#
+  .SYNOPSIS
+  Reads and parses configurations/pinned-packages.psd1, matching
+  libs/runtime-versions.ps1's Get-RuntimeVersionsConfig behavior for a
+  missing or unreadable file (Write-Error + $null, not a throw) --
+  written as its own small function rather than reused across files,
+  since the two configs are unrelated concepts that happen to share a
+  read pattern.
+
+  .OUTPUTS
+  The parsed hashtable, or $null if the file is missing or malformed.
+  #>
+}
+
+function Invoke-WinGetPinListCommand {
+  [CmdletBinding()]
+  [OutputType([hashtable])]
+  param ()
+  $output = & winget pin list --disable-interactivity --accept-source-agreements 2>&1 | Out-String
+  return @{ Output = $output; ExitCode = $LASTEXITCODE }
+  <#
+  .SYNOPSIS
+  The only function with a real dependency on the installed `winget`
+  binary for listing pins, kept to a couple of lines so Pester can mock
+  it directly -- `winget` does not resolve via Get-Command on every
+  machine this repo's tests run on (this Linux dev environment
+  included), and Mock cannot intercept a command name Get-Command can't
+  resolve at all (same constraint documented in
+  libs/unity-editor-installer.ps1's Invoke-UnityEditorsListCommand).
+  #>
+}
+
+function ConvertFrom-WinGetPinListOutput {
+  [CmdletBinding()]
+  [OutputType([hashtable[]])]
+  param (
+    [Parameter(Mandatory)][AllowEmptyString()][string]$Output
+  )
+  $lines = $Output -split "`r?`n"
+  $headerIndex = -1
+  for ($i = 0; $i -lt $lines.Count; $i++) {
+    if ($lines[$i] -match '^Id\s+Source\s+Version\s+Pin type\s*$') {
+      $headerIndex = $i
+      break
+    }
+  }
+  if ($headerIndex -lt 0) {
+    return [hashtable[]]@()
+  }
+  $header = $lines[$headerIndex]
+  $sourceStart = $header.IndexOf('Source')
+  $versionStart = $header.IndexOf('Version')
+  $pinTypeStart = $header.IndexOf('Pin type')
+  $firstDataLine = $headerIndex + 2
+  $lastDataLine = $lines.Count - 1
+  if ($firstDataLine -gt $lastDataLine) {
+    return [hashtable[]]@()
+  }
+  $pins = foreach ($line in $lines[$firstDataLine..$lastDataLine]) {
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.Length -lt $pinTypeStart) {
+      continue
+    }
+    @{
+      Id      = $line.Substring(0, $sourceStart).Trim()
+      Source  = $line.Substring($sourceStart, $versionStart - $sourceStart).Trim()
+      Version = $line.Substring($versionStart, $pinTypeStart - $versionStart).Trim()
+      PinType = $line.Substring($pinTypeStart).Trim()
+    }
+  }
+  return [hashtable[]]@($pins)
+  <#
+  .SYNOPSIS
+  Parses `winget pin list`'s human-readable table (Id / Source / Version
+  / Pin type columns). There is no --format json (or any other
+  machine-readable output) for this command: confirmed against
+  microsoft/winget-cli#3051, which was closed as a duplicate of #1753
+  and redirected scripting use to the PowerShell module (Microsoft.
+  WinGet.Client) -- but that module has no pin cmdlet at all as of this
+  writing (no Add-WinGetPin/Get-WinGetPin exists in its Cmdlets source).
+  Column start offsets are read from the header row itself rather than
+  hardcoded, since winget pads each column to fit its widest cell and
+  that width is not documented or guaranteed stable -- this mirrors the
+  header-driven parsing already used nowhere else in this repo, but the
+  same "derive structure from the live output, don't hardcode it"
+  posture as Get-InstalledUnityEditors's per-item field probing.
+
+  A missing header row (no pins currently set, or an output shape this
+  parser doesn't recognize) degrades to an empty array rather than an
+  error -- winget pin list itself is not known to fail via exit code
+  merely for having zero pins, so treating "no header found" as "zero
+  pins" is the correct default for the common case.
+
+  .OUTPUTS
+  One hashtable per pin (Id/Source/Version/PinType, all strings; Version
+  is '' for Pinning/Blocking pins), or an empty array.
+  #>
+}
+
+function Get-CurrentWinGetPins {
+  [CmdletBinding()]
+  [OutputType([hashtable[]])]
+  param ()
+  $result = Invoke-WinGetPinListCommand
+  if ($result.ExitCode -ne 0) {
+    Write-Error "'winget pin list' exited with code $($result.ExitCode): $($result.Output)"
+    return [hashtable[]]@()
+  }
+  return [hashtable[]]@(ConvertFrom-WinGetPinListOutput -Output $result.Output)
+}
+
+function Test-PinnedPackageEntry {
+  param (
+    [Parameter(Mandatory)][hashtable]$Entry
+  )
+  if (-not $Entry.Contains('Id') -or -not $Entry.Contains('Source') -or
+    -not $Entry.Contains('PinType') -or -not $Entry.Contains('Reason')) {
+    return $false
+  }
+  if ($Entry.PinType -notin @('Pinning', 'Blocking', 'Gating')) {
+    return $false
+  }
+  if ($Entry.PinType -eq 'Gating' -and -not $Entry.Contains('VersionRange')) {
+    return $false
+  }
+  return $true
+  <#
+  .SYNOPSIS
+  Validates one configurations/pinned-packages.psd1 entry. Per-entry
+  (not whole-config) so one malformed entry doesn't block every other
+  declared pin from being applied -- Sync-WinGetPins filters the
+  declared list through this and reports what it skips, the same
+  "don't let one bad item take down the whole run" posture as
+  Get-InstalledUnityEditors's per-item field probing.
+  #>
+}
+
+function Get-WinGetPinAddArguments {
+  [CmdletBinding()]
+  [OutputType([string[]])]
+  param (
+    [Parameter(Mandatory)][hashtable]$Entry
+  )
+  $arguments = @(
+    'pin', 'add', '--id', $Entry.Id, '-s', $Entry.Source,
+    '--disable-interactivity', '--accept-source-agreements'
+  )
+  switch ($Entry.PinType) {
+    'Blocking' { $arguments += '--blocking' }
+    'Gating' { $arguments += @('--version', $Entry.VersionRange) }
+    'Pinning' { <# default winget pin add behavior -- no extra flag #> }
+    default { throw "Unknown PinType '$($Entry.PinType)' for package '$($Entry.Id)'." }
+  }
+  return [string[]]$arguments
+  <#
+  .SYNOPSIS
+  Builds the `winget pin add` argument list for one declared entry.
+  Pure (no `winget` call), so this is tested directly without mocking
+  Invoke-WinGetPinAddCommand at all. The `default` throw is a defensive
+  guard, not a reachable branch under Test-PinnedPackageEntry's contract
+  (Sync-WinGetPins only ever calls this with an already-validated
+  entry) -- kept so a future PinType value added to the validator
+  without a matching case here fails loudly instead of silently
+  applying a plain Pinning pin.
+  #>
+}
+
+function Invoke-WinGetPinAddCommand {
+  [CmdletBinding()]
+  [OutputType([int])]
+  param (
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$ArgumentList
+  )
+  & winget @ArgumentList
+  return $LASTEXITCODE
+}
+
+function Get-WinGetPinDrift {
+  param (
+    [Parameter(Mandatory)][AllowEmptyCollection()][hashtable[]]$Declared,
+    [Parameter(Mandatory)][AllowEmptyCollection()][hashtable[]]$Current
+  )
+  $toAdd = @()
+  $matching = @()
+  $mismatched = @()
+  foreach ($entry in $Declared) {
+    $existing = $Current | Where-Object {
+      [string]::Equals($_.Id, $entry.Id, [System.StringComparison]::Ordinal) -and
+      [string]::Equals($_.Source, $entry.Source, [System.StringComparison]::Ordinal)
+    } | Select-Object -First 1
+    if ($null -eq $existing) {
+      $toAdd += $entry
+      continue
+    }
+    $expectedVersion = if ($entry.PinType -eq 'Gating') { $entry.VersionRange } else { '' }
+    $typeMatches = [string]::Equals($existing.PinType, $entry.PinType, [System.StringComparison]::Ordinal)
+    $versionMatches = [string]::Equals($existing.Version, $expectedVersion, [System.StringComparison]::Ordinal)
+    if ($typeMatches -and $versionMatches) {
+      $matching += $entry
+    }
+    else {
+      $mismatched += @{ Declared = $entry; Current = $existing }
+    }
+  }
+  $undeclared = $Current | Where-Object {
+    $currentPin = $_
+    -not ($Declared | Where-Object {
+        [string]::Equals($_.Id, $currentPin.Id, [System.StringComparison]::Ordinal) -and
+        [string]::Equals($_.Source, $currentPin.Source, [System.StringComparison]::Ordinal)
+      })
+  }
+  return @{
+    ToAdd      = @($toAdd)
+    Matching   = @($matching)
+    Mismatched = @($mismatched)
+    Undeclared = @($undeclared)
+  }
+  <#
+  .SYNOPSIS
+  Classifies each declared pin against the machine's current pins
+  (matched by Id+Source, ordinal): ToAdd (declared, not present at
+  all), Matching (present with the declared PinType/VersionRange),
+  Mismatched (present but pinned differently than declared -- e.g. a
+  plain pin where Blocking is declared), or Undeclared (present but not
+  in configurations/pinned-packages.psd1 at all). Pure classification,
+  no `winget` call -- Sync-WinGetPins only ever adds ToAdd entries; it
+  never removes Undeclared pins or corrects Mismatched ones, since
+  either could be silently discarding an operator's own manual `winget
+  pin` choice (see docs/dsc-migration-notes.md's "why report-only"
+  rationale). Both are surfaced as warnings instead.
+  #>
+}
+
+function Sync-WinGetPins {
+  param (
+    [Parameter(Mandatory)][string]$ConfigPath
+  )
+  $config = Get-PinnedPackagesConfig -Path $ConfigPath
+  if ($null -eq $config) {
+    return
+  }
+  if (-not $config.Contains('Pins')) {
+    Write-Error "Pinned packages config ${ConfigPath} is missing a Pins entry."
+    return
+  }
+
+  $declaredRaw = @($config.Pins)
+  $declared = @($declaredRaw | Where-Object { Test-PinnedPackageEntry -Entry $_ })
+  $invalidCount = $declaredRaw.Count - $declared.Count
+  if ($invalidCount -gt 0) {
+    $entryNoun = if ($invalidCount -eq 1) { 'entry' } else { 'entries' }
+    Write-Warning "[winget-pin] Skipping $invalidCount malformed $entryNoun in ${ConfigPath} (missing Id/Source/PinType/Reason, an unknown PinType, or a Gating entry missing VersionRange)."
+  }
+
+  try {
+    $current = @(Get-CurrentWinGetPins -ErrorAction Stop)
+  }
+  catch {
+    Write-Error "Could not determine current winget pins -- aborting rather than risk re-pinning based on unknown state: $_"
+    return
+  }
+
+  $drift = Get-WinGetPinDrift -Declared $declared -Current $current
+
+  foreach ($entry in $drift.ToAdd) {
+    $addArguments = Get-WinGetPinAddArguments -Entry $entry
+    $exitCode = Invoke-WinGetPinAddCommand -ArgumentList $addArguments
+    if ($exitCode -eq 0) {
+      Write-Host "[winget-pin] Pinned $($entry.Id) ($($entry.PinType))." -ForegroundColor Gray
+    }
+    else {
+      Write-Error "[winget-pin] 'winget pin add' for $($entry.Id) exited with code ${exitCode}."
+    }
+  }
+
+  foreach ($item in $drift.Mismatched) {
+    $currentDescription = $item.Current.PinType
+    if ($item.Current.Version) {
+      $currentDescription = "$currentDescription ($($item.Current.Version))"
+    }
+    $declaredDescription = $item.Declared.PinType
+    if ($item.Declared.PinType -eq 'Gating') {
+      $declaredDescription = "$declaredDescription ($($item.Declared.VersionRange))"
+    }
+    Write-Warning "[winget-pin] $($item.Declared.Id) is pinned as $currentDescription, not the declared $declaredDescription -- left as-is, not corrected."
+  }
+
+  foreach ($pin in $drift.Undeclared) {
+    $pinDescription = "$($pin.PinType)"
+    if ($pin.Version) {
+      $pinDescription = "$pinDescription $($pin.Version)"
+    }
+    Write-Warning "[winget-pin] Undeclared pin found (not in ${ConfigPath}, left as-is): $($pin.Id) ($($pin.Source), $pinDescription)."
+  }
+
+  if ($drift.ToAdd.Count -eq 0) {
+    Write-Host '[winget-pin] All declared pins already applied -- skipping.' -ForegroundColor Gray
+  }
+  <#
+  .SYNOPSIS
+  Idempotent entry point: adds any pin declared in
+  configurations/pinned-packages.psd1 that isn't already set, and
+  reports (Write-Warning, never modifies) any pin that's mismatched or
+  undeclared. Safe to call every run -- a second call with nothing
+  changed on the machine adds nothing (ToAdd is empty once every
+  declared pin is present and matching).
+
+  Uses Write-Error + return (not throw) on its own internal failure
+  paths, matching libs/unity-cli-installer.ps1's Sync-UnityCli
+  convention: unlike libs/unity-editor-installer.ps1's Sync-UnityEditor
+  (issue #74), there is no acceptance-criterion here requiring this
+  step specifically to halt the entire boxstarter.ps1 run -- `winget`
+  itself is already an unconditional prerequisite for every earlier
+  phase of that script (Phase 2-4 call it directly with no availability
+  guard), so adding a hard-stop just for the pin step would be new,
+  inconsistent behavior this issue never asked for.
+  #>
+}

--- a/tests/powershell/winget-pin-sync.Tests.ps1
+++ b/tests/powershell/winget-pin-sync.Tests.ps1
@@ -3,26 +3,26 @@ BeforeAll {
 }
 
 Describe 'ConvertFrom-WinGetPinListOutput' {
-  It 'parses Pinning and Blocking pins with an empty Version column' {
+  It 'parses Pinning and Blocking pins, ignoring the leading Name column' {
     $output = @'
-Id                   Source Version Pin type
---------------------------------------------
-Unity.UnityHub       winget         Blocking
-Microsoft.PowerShell winget         Pinning
+Name       Id                   Version Source Pin type
+-------------------------------------------------------
+Unity Hub  Unity.UnityHub       3.10.0  winget Blocking
+PowerShell Microsoft.PowerShell 7.4.6.0 winget Pinning
 '@
     $pins = @(ConvertFrom-WinGetPinListOutput -Output $output)
 
     $pins.Count | Should -Be 2
     ($pins | Where-Object Id -EQ 'Unity.UnityHub').PinType | Should -Be 'Blocking'
-    ($pins | Where-Object Id -EQ 'Unity.UnityHub').Version | Should -Be ''
+    ($pins | Where-Object Id -EQ 'Unity.UnityHub').Version | Should -Be '3.10.0'
     ($pins | Where-Object Id -EQ 'Microsoft.PowerShell').PinType | Should -Be 'Pinning'
   }
 
   It 'parses a Gating pin with a version range in the Version column' {
     $output = @'
-Id                    Source Version Pin type
----------------------------------------------
-VMware.WorkstationPro winget 16.*    Gating
+Name                Id                    Version Source Pin type
+--------------------------------------------------------------------
+VMware Workstation  VMware.WorkstationPro 16.*    winget Gating
 '@
     $pins = @(ConvertFrom-WinGetPinListOutput -Output $output)
 
@@ -32,7 +32,7 @@ VMware.WorkstationPro winget 16.*    Gating
   }
 
   It 'returns an empty array when there is no header row (no pins set)' {
-    $pins = ConvertFrom-WinGetPinListOutput -Output 'No pinned packages found.'
+    $pins = ConvertFrom-WinGetPinListOutput -Output 'There are no pins configured.'
 
     $pins | Should -BeNullOrEmpty
   }
@@ -45,12 +45,25 @@ VMware.WorkstationPro winget 16.*    Gating
 
   It 'returns an empty array when the header is present with no data rows' {
     $output = @'
-Id                Source Version Pin type
-------------------------------------------
+Name Id Version Source Pin type
+--------------------------------
 '@
     $pins = ConvertFrom-WinGetPinListOutput -Output $output
 
     $pins | Should -BeNullOrEmpty
+  }
+
+  It 'is tolerant of the older four-column shape with no Name column (issue #3013-era winget)' {
+    $output = @'
+Id             Version Source Pin type
+---------------------------------------
+Unity.UnityHub         winget Blocking
+'@
+    $pins = @(ConvertFrom-WinGetPinListOutput -Output $output)
+
+    $pins.Count | Should -Be 1
+    $pins[0].Id | Should -Be 'Unity.UnityHub'
+    $pins[0].PinType | Should -Be 'Blocking'
   }
 }
 
@@ -60,9 +73,9 @@ Describe 'Get-CurrentWinGetPins' {
       @{
         ExitCode = 0
         Output   = @'
-Id             Source Version Pin type
---------------------------------------
-Unity.UnityHub winget         Blocking
+Name      Id             Version Source Pin type
+------------------------------------------------
+Unity Hub Unity.UnityHub 3.10.0  winget Blocking
 '@
       }
     }
@@ -98,6 +111,18 @@ Describe 'Test-PinnedPackageEntry' {
 
   It 'rejects an entry missing Reason' {
     Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Pinning' } | Should -Be $false
+  }
+
+  It 'rejects an entry with an empty-string Reason' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Pinning'; Reason = '' } | Should -Be $false
+  }
+
+  It 'rejects an entry with a whitespace-only Id' {
+    Test-PinnedPackageEntry -Entry @{ Id = '   '; Source = 'winget'; PinType = 'Pinning'; Reason = 'r' } | Should -Be $false
+  }
+
+  It 'rejects a Gating entry with an empty-string VersionRange' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Gating'; Reason = 'r'; VersionRange = '' } | Should -Be $false
   }
 
   It 'returns $false instead of throwing for a non-hashtable entry' {
@@ -182,6 +207,16 @@ Describe 'Get-WinGetPinDrift' {
     $drift = Get-WinGetPinDrift -Declared @($declared) -Current @($current)
 
     $drift.Mismatched.Count | Should -Be 1
+  }
+
+  It 'classifies a Blocking pin as Matching regardless of the Version column (real winget shows the installed version there, not a target)' {
+    $declared = @{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Reason = 'r' }
+    $current = @{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Version = '3.10.0' }
+
+    $drift = Get-WinGetPinDrift -Declared @($declared) -Current @($current)
+
+    $drift.Matching.Count | Should -Be 1
+    $drift.Mismatched | Should -BeNullOrEmpty
   }
 
   It 'does not confuse packages with the same Id from a different Source' {

--- a/tests/powershell/winget-pin-sync.Tests.ps1
+++ b/tests/powershell/winget-pin-sync.Tests.ps1
@@ -65,6 +65,21 @@ Unity.UnityHub         winget Blocking
     $pins[0].Id | Should -Be 'Unity.UnityHub'
     $pins[0].PinType | Should -Be 'Blocking'
   }
+
+  It 'is tolerant of a Pin Type/Source column swap and title-case header ("Pin Type" vs "Pin type")' {
+    $output = @'
+Name      Id                  Version Pin Type Source
+-----------------------------------------------------
+PowerToys Microsoft.PowerToys 0.70.*  Gating   winget
+'@
+    $pins = @(ConvertFrom-WinGetPinListOutput -Output $output)
+
+    $pins.Count | Should -Be 1
+    $pins[0].Id | Should -Be 'Microsoft.PowerToys'
+    $pins[0].Source | Should -Be 'winget'
+    $pins[0].PinType | Should -Be 'Gating'
+    $pins[0].Version | Should -Be '0.70.*'
+  }
 }
 
 Describe 'Get-CurrentWinGetPins' {

--- a/tests/powershell/winget-pin-sync.Tests.ps1
+++ b/tests/powershell/winget-pin-sync.Tests.ps1
@@ -1,0 +1,293 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'winget-pin-sync.ps1')
+}
+
+Describe 'ConvertFrom-WinGetPinListOutput' {
+  It 'parses Pinning and Blocking pins with an empty Version column' {
+    $output = @'
+Id                   Source Version Pin type
+--------------------------------------------
+Unity.UnityHub       winget         Blocking
+Microsoft.PowerShell winget         Pinning
+'@
+    $pins = @(ConvertFrom-WinGetPinListOutput -Output $output)
+
+    $pins.Count | Should -Be 2
+    ($pins | Where-Object Id -EQ 'Unity.UnityHub').PinType | Should -Be 'Blocking'
+    ($pins | Where-Object Id -EQ 'Unity.UnityHub').Version | Should -Be ''
+    ($pins | Where-Object Id -EQ 'Microsoft.PowerShell').PinType | Should -Be 'Pinning'
+  }
+
+  It 'parses a Gating pin with a version range in the Version column' {
+    $output = @'
+Id                    Source Version Pin type
+---------------------------------------------
+VMware.WorkstationPro winget 16.*    Gating
+'@
+    $pins = @(ConvertFrom-WinGetPinListOutput -Output $output)
+
+    $pins.Count | Should -Be 1
+    $pins[0].PinType | Should -Be 'Gating'
+    $pins[0].Version | Should -Be '16.*'
+  }
+
+  It 'returns an empty array when there is no header row (no pins set)' {
+    $pins = ConvertFrom-WinGetPinListOutput -Output 'No pinned packages found.'
+
+    $pins | Should -BeNullOrEmpty
+  }
+
+  It 'returns an empty array for an empty string' {
+    $pins = ConvertFrom-WinGetPinListOutput -Output ''
+
+    $pins | Should -BeNullOrEmpty
+  }
+
+  It 'returns an empty array when the header is present with no data rows' {
+    $output = @'
+Id                Source Version Pin type
+------------------------------------------
+'@
+    $pins = ConvertFrom-WinGetPinListOutput -Output $output
+
+    $pins | Should -BeNullOrEmpty
+  }
+}
+
+Describe 'Get-CurrentWinGetPins' {
+  It 'returns parsed pins on success' {
+    Mock Invoke-WinGetPinListCommand {
+      @{
+        ExitCode = 0
+        Output   = @'
+Id             Source Version Pin type
+--------------------------------------
+Unity.UnityHub winget         Blocking
+'@
+      }
+    }
+
+    $pins = @(Get-CurrentWinGetPins)
+
+    $pins.Count | Should -Be 1
+    $pins[0].Id | Should -Be 'Unity.UnityHub'
+  }
+
+  It 'returns an empty array instead of throwing when the exit code is non-zero' {
+    Mock Invoke-WinGetPinListCommand {
+      @{ ExitCode = 1; Output = 'winget: command failed' }
+    }
+
+    { Get-CurrentWinGetPins -ErrorAction SilentlyContinue } | Should -Not -Throw
+    Get-CurrentWinGetPins -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+  }
+}
+
+Describe 'Test-PinnedPackageEntry' {
+  It 'accepts a well-formed Pinning entry' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Pinning'; Reason = 'r' } | Should -Be $true
+  }
+
+  It 'accepts a well-formed Gating entry with VersionRange' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Gating'; Reason = 'r'; VersionRange = '1.2.*' } | Should -Be $true
+  }
+
+  It 'rejects a Gating entry missing VersionRange' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Gating'; Reason = 'r' } | Should -Be $false
+  }
+
+  It 'rejects an entry missing Reason' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Pinning' } | Should -Be $false
+  }
+
+  It 'rejects an unknown PinType' {
+    Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Unknown'; Reason = 'r' } | Should -Be $false
+  }
+}
+
+Describe 'Get-WinGetPinAddArguments' {
+  It 'builds a plain pin add command for Pinning' {
+    $arguments = Get-WinGetPinAddArguments -Entry @{ Id = 'a.b'; Source = 'winget'; PinType = 'Pinning'; Reason = 'r' }
+
+    ($arguments -join ' ') | Should -Be 'pin add --id a.b -s winget --disable-interactivity --accept-source-agreements'
+  }
+
+  It 'adds --blocking for Blocking' {
+    $arguments = Get-WinGetPinAddArguments -Entry @{ Id = 'a.b'; Source = 'winget'; PinType = 'Blocking'; Reason = 'r' }
+
+    ($arguments -join ' ') | Should -Be 'pin add --id a.b -s winget --disable-interactivity --accept-source-agreements --blocking'
+  }
+
+  It 'adds --version and the range for Gating' {
+    $arguments = Get-WinGetPinAddArguments -Entry @{ Id = 'a.b'; Source = 'winget'; PinType = 'Gating'; Reason = 'r'; VersionRange = '1.2.*' }
+
+    ($arguments -join ' ') | Should -Be 'pin add --id a.b -s winget --disable-interactivity --accept-source-agreements --version 1.2.*'
+  }
+
+  It 'throws for an unknown PinType (defensive guard)' {
+    { Get-WinGetPinAddArguments -Entry @{ Id = 'a.b'; Source = 'winget'; PinType = 'Unknown'; Reason = 'r' } } | Should -Throw
+  }
+}
+
+Describe 'Get-WinGetPinDrift' {
+  It 'classifies a declared pin absent on the machine as ToAdd' {
+    $drift = Get-WinGetPinDrift -Declared @(@{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Reason = 'r' }) -Current @()
+
+    $drift.ToAdd.Count | Should -Be 1
+    $drift.Matching | Should -BeNullOrEmpty
+    $drift.Mismatched | Should -BeNullOrEmpty
+    $drift.Undeclared | Should -BeNullOrEmpty
+  }
+
+  It 'classifies a declared pin present with the same type as Matching' {
+    $declared = @{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Reason = 'r' }
+    $current = @{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Version = '' }
+
+    $drift = Get-WinGetPinDrift -Declared @($declared) -Current @($current)
+
+    $drift.Matching.Count | Should -Be 1
+    $drift.ToAdd | Should -BeNullOrEmpty
+    $drift.Mismatched | Should -BeNullOrEmpty
+  }
+
+  It 'classifies a present pin not in the declaration as Undeclared' {
+    $current = @{ Id = 'b'; Source = 'winget'; PinType = 'Pinning'; Version = '' }
+
+    $drift = Get-WinGetPinDrift -Declared @() -Current @($current)
+
+    $drift.Undeclared.Count | Should -Be 1
+    $drift.Undeclared[0].Id | Should -Be 'b'
+  }
+
+  It 'classifies a declared pin present with a different type as Mismatched' {
+    $declared = @{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Reason = 'r' }
+    $current = @{ Id = 'a'; Source = 'winget'; PinType = 'Pinning'; Version = '' }
+
+    $drift = Get-WinGetPinDrift -Declared @($declared) -Current @($current)
+
+    $drift.Mismatched.Count | Should -Be 1
+    $drift.Matching | Should -BeNullOrEmpty
+    $drift.ToAdd | Should -BeNullOrEmpty
+  }
+
+  It 'classifies a Gating pin with a different version range as Mismatched' {
+    $declared = @{ Id = 'a'; Source = 'winget'; PinType = 'Gating'; Reason = 'r'; VersionRange = '2.*' }
+    $current = @{ Id = 'a'; Source = 'winget'; PinType = 'Gating'; Version = '1.*' }
+
+    $drift = Get-WinGetPinDrift -Declared @($declared) -Current @($current)
+
+    $drift.Mismatched.Count | Should -Be 1
+  }
+
+  It 'does not confuse packages with the same Id from a different Source' {
+    $declared = @{ Id = 'a'; Source = 'winget'; PinType = 'Blocking'; Reason = 'r' }
+    $current = @{ Id = 'a'; Source = 'msstore'; PinType = 'Blocking'; Version = '' }
+
+    $drift = Get-WinGetPinDrift -Declared @($declared) -Current @($current)
+
+    $drift.ToAdd.Count | Should -Be 1
+    $drift.Undeclared.Count | Should -Be 1
+  }
+}
+
+Describe 'Sync-WinGetPins' {
+  BeforeAll {
+    $script:configPath = Join-Path -Path $TestDrive -ChildPath 'pinned-packages.psd1'
+    Set-Content -Path $script:configPath -Value @'
+@{
+  Pins = @(
+    @{
+      Id      = 'Unity.UnityHub'
+      Source  = 'winget'
+      PinType = 'Blocking'
+      Reason  = 'test reason'
+    }
+  )
+}
+'@
+  }
+
+  It 'adds a declared pin that is missing' {
+    Mock Get-CurrentWinGetPins { @() }
+    Mock Invoke-WinGetPinAddCommand { 0 }
+
+    Sync-WinGetPins -ConfigPath $script:configPath
+
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 1 -ParameterFilter {
+      ($ArgumentList -join ' ') -eq 'pin add --id Unity.UnityHub -s winget --disable-interactivity --accept-source-agreements --blocking'
+    }
+  }
+
+  It 'does not re-add a pin that is already applied (idempotent second run)' {
+    Mock Get-CurrentWinGetPins { @(@{ Id = 'Unity.UnityHub'; Source = 'winget'; PinType = 'Blocking'; Version = '' }) }
+    Mock Invoke-WinGetPinAddCommand { 0 }
+
+    Sync-WinGetPins -ConfigPath $script:configPath
+
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 0
+  }
+
+  It 'runs twice with an add on the first run and nothing on the second (end-to-end idempotency)' {
+    $script:pinned = @()
+    Mock Get-CurrentWinGetPins { $script:pinned }
+    Mock Invoke-WinGetPinAddCommand {
+      $script:pinned = @(@{ Id = 'Unity.UnityHub'; Source = 'winget'; PinType = 'Blocking'; Version = '' })
+      return 0
+    }
+
+    Sync-WinGetPins -ConfigPath $script:configPath
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 1
+
+    Sync-WinGetPins -ConfigPath $script:configPath
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 1
+  }
+
+  It 'reports an undeclared pin without attempting to remove it' {
+    Mock Get-CurrentWinGetPins { @(@{ Id = 'Unity.UnityHub'; Source = 'winget'; PinType = 'Blocking'; Version = '' }, @{ Id = 'Other.Package'; Source = 'winget'; PinType = 'Pinning'; Version = '' }) }
+    Mock Invoke-WinGetPinAddCommand { 0 }
+
+    Sync-WinGetPins -ConfigPath $script:configPath -WarningAction SilentlyContinue
+
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 0
+  }
+
+  It 'writes a non-terminating error and does not throw when the config file is missing' {
+    { Sync-WinGetPins -ConfigPath (Join-Path $TestDrive 'does-not-exist.psd1') -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'writes a non-terminating error and does not throw when the Pins entry is missing' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'no-pins.psd1'
+    Set-Content -Path $path -Value '@{ Other = @{} }'
+
+    { Sync-WinGetPins -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'skips a malformed entry but still applies the well-formed ones' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'mixed-pins.psd1'
+    Set-Content -Path $path -Value @'
+@{
+  Pins = @(
+    @{ Id = 'Bad.Entry'; Source = 'winget'; PinType = 'Pinning' }
+    @{ Id = 'Good.Entry'; Source = 'winget'; PinType = 'Pinning'; Reason = 'r' }
+  )
+}
+'@
+    Mock Get-CurrentWinGetPins { @() }
+    Mock Invoke-WinGetPinAddCommand { 0 }
+
+    Sync-WinGetPins -ConfigPath $path -WarningAction SilentlyContinue
+
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 1 -ParameterFilter {
+      ($ArgumentList -join ' ') -like '*Good.Entry*'
+    }
+  }
+
+  It 'aborts without attempting to add pins when the current pin state cannot be determined' {
+    Mock Get-CurrentWinGetPins { throw 'winget pin list failed' }
+    Mock Invoke-WinGetPinAddCommand { 0 }
+
+    { Sync-WinGetPins -ConfigPath $script:configPath -ErrorAction SilentlyContinue } | Should -Not -Throw
+
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 0
+  }
+}

--- a/tests/powershell/winget-pin-sync.Tests.ps1
+++ b/tests/powershell/winget-pin-sync.Tests.ps1
@@ -100,6 +100,11 @@ Describe 'Test-PinnedPackageEntry' {
     Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Pinning' } | Should -Be $false
   }
 
+  It 'returns $false instead of throwing for a non-hashtable entry' {
+    { Test-PinnedPackageEntry -Entry 'not-a-hashtable' } | Should -Not -Throw
+    Test-PinnedPackageEntry -Entry 'not-a-hashtable' | Should -Be $false
+  }
+
   It 'rejects an unknown PinType' {
     Test-PinnedPackageEntry -Entry @{ Id = 'a'; Source = 'winget'; PinType = 'Unknown'; Reason = 'r' } | Should -Be $false
   }
@@ -276,6 +281,26 @@ Describe 'Sync-WinGetPins' {
     Mock Invoke-WinGetPinAddCommand { 0 }
 
     Sync-WinGetPins -ConfigPath $path -WarningAction SilentlyContinue
+
+    Should -Invoke Invoke-WinGetPinAddCommand -Times 1 -ParameterFilter {
+      ($ArgumentList -join ' ') -like '*Good.Entry*'
+    }
+  }
+
+  It 'skips a non-hashtable entry in Pins without crashing the whole run' {
+    $path = Join-Path -Path $TestDrive -ChildPath 'string-pin.psd1'
+    Set-Content -Path $path -Value @'
+@{
+  Pins = @(
+    'not-a-hashtable'
+    @{ Id = 'Good.Entry'; Source = 'winget'; PinType = 'Pinning'; Reason = 'r' }
+  )
+}
+'@
+    Mock Get-CurrentWinGetPins { @() }
+    Mock Invoke-WinGetPinAddCommand { 0 }
+
+    { Sync-WinGetPins -ConfigPath $path -WarningAction SilentlyContinue } | Should -Not -Throw
 
     Should -Invoke Invoke-WinGetPinAddCommand -Times 1 -ParameterFilter {
       ($ArgumentList -join ' ') -like '*Good.Entry*'


### PR DESCRIPTION
## Summary

Closes #75.

Declaring a package in `configurations/packages.dsc.yaml` only controls
whether it gets installed, not whether it silently upgrades afterward
(`WinGetPackage`'s `UseLatest` defaults to `$false`, and with no `Version`
pinned either, re-running `winget configure` never upgrades anything). The
two real upgrade paths this issue is about -- a human running `winget
upgrade --all`, and UniGetUI's own bulk update -- go through `winget pin`
instead, which is machine-local state, not part of the DSC/import files.
A clone or a new machine starts with no pins and silently loses this
protection. This adds a declaration file for that state and an idempotent
script to apply it, called from `boxstarter.ps1` after packages are
installed.

## What changed

- **`configurations/pinned-packages.psd1`** (new): one entry so far --
  `Unity.UnityHub`, pinned `Blocking`, with the reasoning recorded inline
  (Unity Hub drives Unity Editor installation and VCC depends on it
  recognizing the installed Editor; an unplanned Hub upgrade risks breaking
  that). Format follows `runtime-versions.psd1`'s Id/reason-per-entry style.
- **`libs/winget-pin-sync.ps1`** (new): `Sync-WinGetPins`, the idempotent
  entry point --
  - `Invoke-WinGetPinListCommand` / `Invoke-WinGetPinAddCommand`: the only
    two functions with a real dependency on the installed `winget` binary,
    kept to a couple of lines each so Pester can mock them directly
  - `ConvertFrom-WinGetPinListOutput`: parses `winget pin list`'s
    human-readable table (see "No machine-readable output" below)
  - `Test-PinnedPackageEntry`: validates one declared entry, so one
    malformed entry doesn't block every other pin from being applied
  - `Get-WinGetPinAddArguments`: builds the `winget pin add` argument list
    per pin type (pure, tested without mocking `winget` at all)
  - `Get-WinGetPinDrift`: classifies declared vs. current pins into
    `ToAdd` / `Matching` / `Mismatched` / `Undeclared` -- only `ToAdd` is
    ever acted on
- **`boxstarter.ps1`**: Phase 5 now also dot-sources
  `libs/winget-pin-sync.ps1` and calls `Sync-WinGetPins`, after every
  earlier package-install phase (Phase 2 DSC/import, Phase 4
  architecture-conditional installs, post-install.ps1's own work).
- **`docs/dsc-migration-notes.md`**: new "Declaring winget pins (issue
  #75)" section -- the pin-type decision and why, the report-only
  rationale, the `winget pin list` parsing approach, the UniGetUI finding,
  and what pin cannot close (Unity Hub self-update, msstore packages).

## Findings from checking the actual references (not assumed)

- **`winget pin list` has no machine-readable output.** Unlike `unity
  editors -i --format json` (issue #74), there is no `--format json` or
  any other structured-output option for `winget pin list` -- confirmed
  against winget-cli's own `pin` reference page (only console/logging
  options are listed). `microsoft/winget-cli#3051` ("add machine-parseable
  output") was closed as a duplicate of #1753 and redirects scripting use
  to the `Microsoft.WinGet.Client` PowerShell module -- but that module has
  no pin cmdlet at all as of this writing (checked its `Cmdlets` source
  directory on GitHub directly: no `Add-WinGetPin`/`Get-WinGetPin`
  anywhere). `ConvertFrom-WinGetPinListOutput` parses the table directly,
  deriving each column's start offset from the header row itself rather
  than hardcoding a width, since winget pads columns to their widest cell
  and that width isn't documented or stable. (A related upstream bug,
  `microsoft/winget-cli#3013` -- `Version`/`Pin type` columns swapped for
  Gating pins -- was already fixed by the time of its later comments, but
  is exactly the kind of shift this header-driven approach tolerates
  without a code change.)
- **UniGetUI does not respect winget pin.** Checked its issue tracker
  (`marticliment/UniGetUI#418`, `Devolutions/UniGetUI#1008`) and recent
  release notes (through 2026.2.x) -- no evidence anywhere of UniGetUI
  reading or writing winget pin state. It has its own, separate
  "ignored updates" feature that its own UI labels internally as a
  "blacklist". **Conclusion, recorded in `docs/dsc-migration-notes.md`:
  UniGetUI's bulk update does not respect the pins declared here.** The
  avoidance path this issue's AC asks about does exist, just not through
  winget pin: UniGetUI's own per-package "ignore updates" setting can
  independently exclude a package from its own update pass -- but that's
  manual, UniGetUI-side state with no equivalent in this repo's
  declaration file, and is not automated here.

## Pin-type decision

`Unity.UnityHub` uses **Blocking**, not the default **Pinning**: Pinning
excludes a package from `winget upgrade --all` but still lets `winget
upgrade Unity.UnityHub` (by name) through, and an operator typing that
should not silently succeed either, given what's riding on Hub's version
(VCC recognizing the installed Editor). **Gating** wasn't used since it
would require tracking a specific target Hub version, which nothing in
this repo currently does. `Docker.DockerDesktop` (cited alongside Unity Hub
in this issue's own background) isn't pinned: it has no
currently-documented version-compatibility constraint in this repo to
point to as a reason, and a pin without one can't later be judged safe to
remove -- see the docs section for the full reasoning.

## Report-only, by design (matches issue #74's precedent)

`Get-WinGetPinDrift`'s `Undeclared` and `Mismatched` buckets are both
surfaced via `Write-Warning` and never acted on. An operator may have
pinned or re-pinned something by hand for a reason this repo doesn't know
about; auto-correcting or removing that pin risks silently discarding it.
Same posture as `Get-UnityEditorDrift`'s installed-but-undeclared Unity
Editor handling from issue #74.

## Not verified on a real machine

`winget pin` (and `winget` in general) is Windows-only, and per this
repo's established rule, `boxstarter.ps1` is never executed directly in
this environment even to smoke-test. What *is* verified: winget-cli's own
`pin` reference page and the `Microsoft.WinGet.Client` PowerShell module's
actual cmdlet source were read directly (not inferred), and all new logic
is covered by Pester with `winget` itself mocked at the
`Invoke-WinGetPinListCommand` / `Invoke-WinGetPinAddCommand` boundary,
using fixture tables generated to match winget's documented column layout.

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` on every
  changed/new `.ps1` file -- no syntax errors
- `markdownlint-cli2 "**/*.md"` -- 0 issues
- `cspell lint "**" --no-progress` -- 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1` -- no issues
- `Invoke-Pester -Path ./tests/powershell` -- 107/107 pass (30 new: 5
  `ConvertFrom-WinGetPinListOutput`, 2 `Get-CurrentWinGetPins`, 5
  `Test-PinnedPackageEntry`, 4 `Get-WinGetPinAddArguments`, 6
  `Get-WinGetPinDrift`, 8 `Sync-WinGetPins`; 77 pre-existing, no
  regression)

## Test plan

- [x] Pin declaration file exists under `configurations/`, format aligned
      with existing config files
- [x] Each entry has package ID, source, pin type, and a reason
- [x] The chosen pin type(s) and reasoning are recorded
- [x] Idempotent apply script exists; running it twice in a row makes no
      change on the second run (Pester, mocked)
- [x] The apply script adds a declared-but-unset pin
- [x] The apply script reports a pin that exists but isn't declared
- [x] The choice not to auto-remove undeclared pins, and why, is recorded
      in a comment
- [x] `boxstarter.ps1` calls the apply script after package installation
- [x] The UniGetUI/winget-pin-respect finding is recorded
- [x] `docs/dsc-migration-notes.md` records pin's limits (Unity Hub
      self-update, msstore packages)
- [x] PSScriptAnalyzer reports nothing for the added scripts
- [x] Pester tests exist under `tests/powershell/`, mocking `winget pin
      list` output and covering the "needs addition" / "undeclared" /
      "match" classifications (plus a fourth, "mismatched", not required
      by the AC but a natural extension of the same classification logic)
- [x] `pre-push-validate`-equivalent commands (above) all exit clean on
      this worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of configured WinGet package pins during setup.
  * Added a blocking pin for Unity Hub to help preserve compatibility with Unity and VRChat tools.
  * Reports missing, mismatched, and undeclared pins without changing unexpected settings.

* **Documentation**
  * Added guidance on pin types, drift handling, limitations, and troubleshooting.

* **Tests**
  * Added comprehensive coverage for pin parsing, validation, synchronization, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->