### PR TITLE
feat(setup): add mise to the full profile package list

### DIFF
--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -472,6 +472,14 @@ properties:
         id: MartiCliment.UniGetUI
         source: winget
 
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pkg.mise
+      directives:
+        description: mise-en-place (mise)
+      settings:
+        id: jdx.mise
+        source: winget
+
     # ================================================================
     # Runtimes & language packs
     # ================================================================

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -43,6 +43,7 @@
     {
       "Packages": [
         { "PackageIdentifier": "MartiCliment.UniGetUI" },
+        { "PackageIdentifier": "jdx.mise" },
         { "PackageIdentifier": "Microsoft.DirectX" },
         { "PackageIdentifier": "Microsoft.XNARedist" },
         { "PackageIdentifier": "Microsoft.DotNet.Framework.DeveloperPack_4" },


### PR DESCRIPTION
## Summary

Closes #103.

`jdx.mise` was only declared in `configurations/packages.min.dsc.yaml`
(`id: mise-en-place-mise`); the full profile
(`configurations/packages.dsc.yaml`) had no mise entry, even though it
already installs Node.js via `Schniz.fnm`. This adds mise to the full
profile so a later change can migrate Node.js off fnm and onto mise.

## What changed

- **`configurations/packages.dsc.yaml`**: new `Microsoft.WinGet.DSC/WinGetPackage`
  resource (`id: pkg.mise`, `settings.id: jdx.mise`, `source: winget`)
  under the existing "Package managers & dependencies" section, right
  after `pkg.unigetui`. The resource id follows this file's own `pkg.*`
  convention; the package id/description text mirrors the existing
  `packages.min.dsc.yaml` entry, per the issue's proposed change.
- **`configurations/packages.import.json`** (generated): regenerated via
  `./scripts/Build-Configurations.ps1 -DscPath ./configurations/packages.dsc.yaml`
  to include `jdx.mise`. `configurations/packages.unapplied.json` has no
  diff (mise is applied, not skipped).

## Out of scope (by design)

- **`libs/post-install.ps1` is untouched.** User PATH registration for
  mise's shim directory (`%LOCALAPPDATA%\mise\shims`) is
  [`kurone-kito/dotfiles`](https://github.com/kurone-kito/dotfiles)'s
  responsibility (`data.wingetUserPath.packages` already carries a
  `jdx.mise` default entry there) — see the issue body for the full
  rationale on why this repo intentionally does not also write that
  registry value.
- Removing `Schniz.fnm` — tracked separately; this issue only adds mise
  ahead of that later migration wave.

## Verification

- `npx markdownlint-cli2 "**/*.md"` — 0 issues
- `npx cspell lint "**" --no-progress` — 0 issues
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit` — 0 findings
- `Invoke-Pester -Path ./tests/powershell -CI` — 115/115 pass, 0 failed
- `./scripts/Build-Configurations.ps1 -DscPath ./configurations/packages.dsc.yaml` run a second time on the committed tree — no diff (configuration-drift clean)
- Not verified by actually running `boxstarter.ps1` / `libs/post-install.ps1` as a real installer, per this repo's standing rule and the issue's own acceptance criteria — verification stays at the Pester/ScriptAnalyzer/drift-diff level.

## Test plan

- [x] `configurations/packages.dsc.yaml` contains a `WinGetPackage` resource for `jdx.mise`
- [x] `configurations/packages.import.json` contains `jdx.mise`
- [x] `Build-Configurations.ps1` re-run produces no working-tree diff
- [x] `libs/post-install.ps1` has no added User-PATH-writing code
- [x] `Invoke-Pester -Path ./tests/powershell -CI` exits 0
- [x] `pre-push-validate` command set exits 0 on this branch's HEAD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mise-en-place (`jdx.mise`) to the available Windows package installations.
  - The package can now be installed through the WinGet source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->