### PR TITLE
refactor(setup): git-vrc の導入を dotfiles へ委譲する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -69,7 +69,7 @@ setup.cmd                        ← 唯一のエントリーポイント
    （利用できない場合は **`winget import`**（縮退モード）にフォール
    バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール
-5. インストール後セットアップ（Node.js, Unity, Docker イメージ）
+5. インストール後セットアップ（Node.js, VPM CLI, Unity, mkcert, Docker イメージ）
 6. Microsoft Update を有効化し、Windows Update を実行
 
 Boxstarter が自動的に再起動を処理します。再起動により処理が中断した場合は、

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,6 @@ setup.cmd                        ← 唯一のエントリーポイント
             ├─ Phase 4: アーキテクチャ依存パッケージ
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
             │    ├─ fnm → Node.js 20/22/24/25
-            │    ├─ cargo → git-vrc
             │    ├─ dotnet tool → VPM CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
@@ -70,7 +69,7 @@ setup.cmd                        ← 唯一のエントリーポイント
    （利用できない場合は **`winget import`**（縮退モード）にフォール
    バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール
-5. インストール後セットアップ（Node.js, Rust/cargo パッケージ, Unity, Docker イメージ）
+5. インストール後セットアップ（Node.js, Unity, Docker イメージ）
 6. Microsoft Update を有効化し、Windows Update を実行
 
 Boxstarter が自動的に再起動を処理します。再起動により処理が中断した場合は、
@@ -113,7 +112,6 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 ### インストール後スクリプト経由
 
 - **Node.js**（fnm 経由）: v20, v22, v24 (LTS), v25 (Current)
-- **git-vrc**（cargo 経由）: VRChat Git 統合
 - **VPM CLI**（dotnet tool 経由）: VRChat パッケージマネージャー
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The script will:
    **`winget import`** (degraded mode) and report any resources it
    could not apply
 4. Install remaining packages via Chocolatey (fonts and audio drivers)
-5. Run post-install setup (Node.js, Unity, Docker images)
+5. Run post-install setup (Node.js, VPM CLI, Unity, mkcert, Docker images)
 6. Enable Microsoft Update and run Windows Update
 
 Boxstarter handles reboots automatically. If a reboot interrupts the process,

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ setup.cmd                        ← single entry point
             ├─ Phase 4: Architecture-conditional packages
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
             │    ├─ fnm → Node.js 20/22/24/25
-            │    ├─ cargo → git-vrc
             │    ├─ dotnet tool → VPM CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
@@ -70,7 +69,7 @@ The script will:
    **`winget import`** (degraded mode) and report any resources it
    could not apply
 4. Install remaining packages via Chocolatey (fonts and audio drivers)
-5. Run post-install setup (Node.js, Rust/cargo packages, Unity, Docker images)
+5. Run post-install setup (Node.js, Unity, Docker images)
 6. Enable Microsoft Update and run Windows Update
 
 Boxstarter handles reboots automatically. If a reboot interrupts the process,
@@ -113,7 +112,6 @@ the full list. Key categories:
 ### Via Post-Install Scripts
 
 - **Node.js** (via fnm): v20, v22, v24 (LTS), v25 (Current)
-- **git-vrc** (via cargo): VRChat Git integration
 - **VPM CLI** (via dotnet tool): VRChat package manager
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -62,24 +62,6 @@ else {
 }
 
 ###########################################################################
-### git-vrc (VRChat Git integration via cargo)
-###########################################################################
-if (Test-CommandExists git) {
-  if (Test-CommandExists cargo) {
-    Write-Host '[post-install] Installing git-vrc...' -ForegroundColor Cyan
-    cargo install --locked --git 'https://github.com/anatawa12/git-vrc.git'
-    git vrc install --config --global
-    Write-Host '[post-install] git-vrc setup complete.' -ForegroundColor Green
-  }
-  else {
-    Write-Warning '[post-install] cargo not found — skipping git-vrc.'
-  }
-}
-else {
-  Write-Warning '[post-install] git not found — skipping git-vrc.'
-}
-
-###########################################################################
 ### VRChat Creator Companion CLI (dotnet tool)
 ###########################################################################
 if (Test-CommandExists dotnet) {


### PR DESCRIPTION
## 概要

`libs/post-install.ps1` から git-vrc の導入ブロック（`cargo install
--locked --git 'https://github.com/anatawa12/git-vrc.git'` /
`git vrc install --config --global`）を削除する。

`dotfiles`（kurone-kito/dotfiles）が既にバイナリ導入（mise 経由）と
git 設定（chezmoi の `filter.vrc` テンプレート）の両方を所有しており、
本リポジトリ側の post-install スクリプトが同じグローバル git 設定を
上書きする形で重複していた。どちらが最後に走るかで結果が変わる
「最後勝ち」状態を解消する。

## 変更内容

- `libs/post-install.ps1`: git-vrc 導入ブロックを丸ごと削除。
  `Test-CommandExists git` / `Test-CommandExists cargo` の存在チェックは
  このブロック以外で使われていないため、ガードごと削除。
- `README.md` / `README.ja.md`: アーキテクチャ図・「Via Post-Install
  Scripts」一覧・導入手順の説明文から git-vrc / cargo への言及を削除し、
  一覧の整合を取った。
- `Rustlang.Rust.MSVC`（`configurations/packages.dsc.yaml`）や、ファイル
  冒頭の `PSAvoidUsingInvokeExpression`（fnm 由来）は対象外のため変更なし。

Closes #105

## 検証

- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` — exit 0
- `Invoke-Pester -Path ./tests/powershell -CI` — 115/115 passed
- `markdownlint-cli2 "**/*.md"` / `cspell lint "**"` — issues なし
- `libs/post-install.ps1` / `boxstarter.ps1` の実機実行は行っていない
  （issue の受け入れ基準どおり、Pester / ScriptAnalyzer / lint のみで検証）
