### PR TITLE
docs(idd): record required-status-checks registration for #61

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -48,6 +48,7 @@
     "externalChecks": {
       "waivable": [{ "selector": "idd-advisory-convergence" }]
     },
-    "externalCheckWaivers": { "mode": "maintainer-authorized" }
+    "externalCheckWaivers": { "mode": "maintainer-authorized" },
+    "trustEmptyProtectionReads": true
   }
 }

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,6 +1,7 @@
-# Trust model: this workflow is a required-check gate (once #61
-# registers its job id in branch protection), so tampering matters more
-# here than in an ordinary lint check. This file is NOT self-protecting:
+# Trust model: this workflow is a required-check gate -- its job id is
+# registered as a required status check on master's `main` ruleset
+# (#61), so tampering matters more here than in an ordinary lint check.
+# This file is NOT self-protecting:
 # for `pull_request`, GitHub runs the PR's own copy of this workflow
 # file (unlike `pull_request_target`, which always resolves from the
 # base branch) -- so a PR editing this file does take effect for its own
@@ -13,13 +14,13 @@
 #     verdict logic (`advisory-convergence.mjs`) runs straight from the
 #     pinned upstream npm tarball below, never from a checked-out copy --
 #     there is no in-repository script for a PR to edit.
-#   - Once #61 registers this job's id as a required status check,
+#   - With this job's id registered as a required status check (#61),
 #     deleting/renaming the job or the trigger events in a PR makes the
 #     required check simply never report for that PR, rather than
 #     report a false "ready" -- required checks fail closed on absence.
-#     Until #61 lands, this workflow is advisory only; a PR that edits
-#     it to always pass would not yet be blocked by branch protection,
-#     only caught by ordinary human/bot review of the diff.
+#     A PR that edits this workflow to always pass is still caught by
+#     ordinary human/bot review of the diff, but can no longer bypass
+#     branch protection by doing so.
 # If a future change adds a `ref:` override that resolves to the PR head,
 # vendors the helper script into this repository, or widens
 # `permissions:` below, re-review this trust model before merging that
@@ -78,9 +79,8 @@ jobs:
   # The job id doubles as this check's required-status-check context name
   # and as the `ciGate.externalChecks.waivable[].selector` value in
   # `.github/idd/config.json` -- keep both in sync if this id ever
-  # changes. Branch-protection registration itself is out of scope here
-  # (tracked separately in #61, which is blocked on this workflow
-  # existing first).
+  # changes. Branch-protection registration (#61) is live: this id is
+  # registered as a required status check on master's `main` ruleset.
   idd-advisory-convergence:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -18,9 +18,12 @@
 #     deleting/renaming the job or the trigger events in a PR makes the
 #     required check simply never report for that PR, rather than
 #     report a false "ready" -- required checks fail closed on absence.
-#     A PR that edits this workflow to always pass is still caught by
-#     ordinary human/bot review of the diff, but can no longer bypass
-#     branch protection by doing so.
+#     This does NOT protect against a PR that keeps the job id but
+#     weakens its steps to an unconditional success: GitHub only checks
+#     that a check-run with this context name reports success, not what
+#     the job actually did, so branch protection alone would accept
+#     that. Ordinary human/bot review of the diff remains the only
+#     defense against that specific weakening, same as before #61.
 # If a future change adds a `ref:` override that resolves to the PR head,
 # vendors the helper script into this repository, or widens
 # `permissions:` below, re-review this trust model before merging that

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -130,10 +130,18 @@ correctly 404s — that is not a misconfiguration).
 - **`strict_required_status_checks_policy`**: `false`. This repository
   runs several IDD issue branches concurrently; requiring every branch
   to be re-verified against the latest `master` before its checks count
-  would force a rebase-and-rerun cascade on every unrelated merge. IDD's
-  own F1 branch-currency check (`branch-conflict-state`) and F2/F3
-  re-fetch-before-merge already cover staleness without that
-  GitHub-enforced cascade.
+  would force a rebase-and-rerun cascade on every unrelated merge.
+  This is a deliberate tradeoff, not a fully-covered gap: IDD's F1
+  branch-currency check (`branch-conflict-state`) only *prefers* a
+  fresh CI result over an old green one when the base has advanced
+  (`idd-pre-merge.instructions.md`'s `clean`/`behind-no-conflict`
+  routing) rather than requiring it, and a bare CI rerun after the base
+  moves can replay a `pull_request`-triggered run's stale merge-ref
+  (`docs/idd-helper-scripts.md`'s `baseAdvancedSinceMergeBase` note).
+  F2/F3 re-fetch the current HEAD's own status but do not themselves
+  validate that HEAD against the latest `master`. Accepting that
+  narrower, textual-conflict-freeness-only protection is the actual
+  cost of avoiding the GitHub-enforced cascade.
 - **Verification** (2026-08-14, live evidence): before this rule
   existed, PR #113 (issue #103) sat at `mergeStateStatus: UNSTABLE` with
   no enforced required checks. After registering the rule, #113 (all

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -62,11 +62,6 @@ recorded in `.github/idd/config.json`)
   `externalCheckWaivers` fields (`authorityPolicy`, `maxValidity`) are
   not overridden and use the bundle's distributed defaults
   (`owners-and-maintainers-only`, `PT24H`).
-- **Not yet live until this change merges**: `idd-advisory-convergence.yml`
-  reads `.github/idd/config.json` from `master`, so this `ciGate`
-  addition only takes effect once this PR itself merges. A waiver
-  posted against the PR that introduces it would fail closed as an
-  unknown selector.
 - **Waiver path**: when installed, prefer the helper facade over
   hand-writing marker comments:
 
@@ -112,11 +107,15 @@ correctly 404s — that is not a misconfiguration).
 - **Required contexts**: `idd-advisory-convergence`, `lint`,
   `powershell-analyzer`, `pester`, `configuration-drift`. The first
   turns the F2 advisory/disposition sub-gate into a real GitHub-enforced
-  block (this issue's purpose); the other four are the existing
-  `Linting workflow` jobs that already mirror **pre-push-validate** —
-  registering them closes the gap where a maintainer could merge past
-  red CI through the merge button even though IDD's own F2 checklist
-  already required them to be green.
+  block (this issue's purpose); `lint`, `powershell-analyzer`, and
+  `pester` are the existing `Linting workflow` jobs that mirror
+  **pre-push-validate** (Markdown/cspell lint, PSScriptAnalyzer,
+  Pester); `configuration-drift` goes further — it also regenerates the
+  DSC-derived artifacts and checks for a zero diff, a check
+  **pre-push-validate** does not run locally. Registering all four
+  closes the gap where a maintainer could merge past red CI through the
+  merge button even though IDD's own F2 checklist already required them
+  to be green.
 - **Not registered**: `CodeRabbit`. It reports as a PR review/comment
   integration, not a check-run (`status`/`conclusion` are `null` in
   `statusCheckRollup`), so it can never satisfy a required-status-check

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -100,8 +100,8 @@ recorded in `.github/idd/config.json`)
 
 Resolves #61. `master`'s `main` ruleset (`~DEFAULT_BRANCH`) now carries a
 `required_status_checks` rule, registered via the GitHub Rulesets API
-(this repository predates classic branch protection and uses rulesets
-instead, so the classic `GET .../branches/{branch}/protection` endpoint
+(this repository uses rulesets rather than classic branch protection,
+so the classic `GET .../branches/{branch}/protection` endpoint
 correctly 404s — that is not a misconfiguration).
 
 - **Required contexts**: `idd-advisory-convergence`, `lint`,
@@ -116,10 +116,17 @@ correctly 404s — that is not a misconfiguration).
   closes the gap where a maintainer could merge past red CI through the
   merge button even though IDD's own F2 checklist already required them
   to be green.
-- **Not registered**: `CodeRabbit`. It reports as a PR review/comment
-  integration, not a check-run (`status`/`conclusion` are `null` in
-  `statusCheckRollup`), so it can never satisfy a required-status-check
-  context — registering it would permanently block merges.
+- **Not registered**: `CodeRabbit`. Unlike `idd-advisory-convergence`
+  and the four lint jobs, it is not itself an assertion of anything;
+  it reports its own progress as a legacy commit status with context
+  `CodeRabbit` (confirmed live: `state: success` even while its
+  description reads `Review rate limited`). Registering it as a
+  required check would therefore risk the opposite failure from a
+  missing context — a rate-limited or otherwise-skipped review could
+  still report `success` and satisfy the gate without having reviewed
+  anything. The E1 activity-universe snapshot plus `review-watermark`
+  delta remains the load-bearing safety net for CodeRabbit findings
+  (see [Scope — Copilot-only settle/wait window](../.github/instructions/idd-advisory-wait.instructions.md#scope--copilot-only-settlewait-window)).
 - **`strict_required_status_checks_policy`**: `false`. This repository
   runs several IDD issue branches concurrently; requiring every branch
   to be re-verified against the latest `master` before its checks count
@@ -139,17 +146,28 @@ correctly 404s — that is not a misconfiguration).
 - **`ciGate.trustEmptyProtectionReads`**: `true` (repository override;
   distributed default is `false`). This repository has no classic
   branch protection at all — only the `main`/`features` rulesets above
-  — so `GET .../branches/master/protection` genuinely 404s; it is not a
-  permission-scope artifact (the automation identity used to register
-  the ruleset above carries `admin: true` on this repository, so a real
-  classic-protection resource would be readable, not 404, if one
-  existed). `idd-ci.instructions.md`'s required-check-discovery step 4
-  otherwise treats every `404` on that endpoint as fail-closed
-  (structurally indistinguishable from a `403`) regardless of what the
-  ruleset read already found, which would have permanently blocked
-  `pre-merge-readiness` even with the required-status-checks rule above
-  fully satisfied. Opting in here is the documented escape hatch for
-  exactly this verified case.
+  — so `GET .../branches/master/protection` genuinely 404s. Per this
+  repository's own [Credential Scope](#credential-scope) policy, no
+  separate least-privilege worker identity exists: every IDD session in
+  this repository (interactive or delegated) authenticates as the same
+  account that registered the ruleset above. Read with `--include`
+  under that exact identity: the ruleset read returns a raw `HTTP/2.0
+  200 OK`, and the classic-protection read returns a raw `HTTP/2.0 404
+  Not Found` (not a `403` reported as `404`) — confirmed
+  2026-08-14. This is not a permission-scope artifact for *this*
+  identity; a differently-scoped credential without `administration:
+  read` (for example, a third-party review bot's own sandboxed
+  credential, unrelated to any identity that actually runs
+  `pre-merge-readiness` in this repository) could still see a `403` on
+  the same endpoint, which is exactly the ambiguity
+  `idd-ci.instructions.md`'s required-check-discovery step 4 is
+  designed to fail closed on for an *unverified* identity — it does not
+  apply once the specific identity in use has been read-verified, as
+  here. That step otherwise treats every `404` on that endpoint as
+  fail-closed regardless of what the ruleset read already found, which
+  would have permanently blocked `pre-merge-readiness` even with the
+  required-status-checks rule above fully satisfied. Opting in here is
+  the documented escape hatch for exactly this verified case.
 
 ### Credential Scope
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -51,8 +51,9 @@ recorded in `.github/idd/config.json`)
   bot's review has converged on the current PR HEAD, turning the F2
   advisory/disposition sub-gate into a non-bypassable GitHub status
   check. Branch-protection registration of this check as a required
-  status check is tracked separately in #61 (human-blocked; this
-  workflow must exist first).
+  status check is recorded in
+  [CI Gate (Required Status Checks)](#ci-gate-required-status-checks)
+  below (#61).
 - **`ciGate.externalChecks.waivable`**: `[{ "selector":
   "idd-advisory-convergence" }]` — this repository's only waivable
   external check.
@@ -99,6 +100,43 @@ recorded in `.github/idd/config.json`)
   introduces it (GitHub reads `pull_request_target` workflow files from
   the base branch) — that PR's own F4 cleanup goes through the normal
   IDD flow instead.
+
+### CI Gate (Required Status Checks)
+
+Resolves #61. `master`'s `main` ruleset (`~DEFAULT_BRANCH`) now carries a
+`required_status_checks` rule, registered via the GitHub Rulesets API
+(this repository predates classic branch protection and uses rulesets
+instead, so the classic `GET .../branches/{branch}/protection` endpoint
+correctly 404s — that is not a misconfiguration).
+
+- **Required contexts**: `idd-advisory-convergence`, `lint`,
+  `powershell-analyzer`, `pester`, `configuration-drift`. The first
+  turns the F2 advisory/disposition sub-gate into a real GitHub-enforced
+  block (this issue's purpose); the other four are the existing
+  `Linting workflow` jobs that already mirror **pre-push-validate** —
+  registering them closes the gap where a maintainer could merge past
+  red CI through the merge button even though IDD's own F2 checklist
+  already required them to be green.
+- **Not registered**: `CodeRabbit`. It reports as a PR review/comment
+  integration, not a check-run (`status`/`conclusion` are `null` in
+  `statusCheckRollup`), so it can never satisfy a required-status-check
+  context — registering it would permanently block merges.
+- **`strict_required_status_checks_policy`**: `false`. This repository
+  runs several IDD issue branches concurrently; requiring every branch
+  to be re-verified against the latest `master` before its checks count
+  would force a rebase-and-rerun cascade on every unrelated merge. IDD's
+  own F1 branch-currency check (`branch-conflict-state`) and F2/F3
+  re-fetch-before-merge already cover staleness without that
+  GitHub-enforced cascade.
+- **Verification** (2026-08-14, live evidence): before this rule
+  existed, PR #113 (issue #103) sat at `mergeStateStatus: UNSTABLE` with
+  no enforced required checks. After registering the rule, #113 (all
+  five contexts green, including a converged `idd-advisory-convergence`)
+  flipped to `mergeStateStatus: CLEAN`, and concurrently PR #114 (issue
+  #105), whose `idd-advisory-convergence` run had concluded `FAILURE`
+  (not yet converged), showed `mergeStateStatus: BLOCKED` — confirming
+  a PR whose advisory review has not converged is actually blocked from
+  merging by the required check, not merely flagged as advisory.
 
 ### Credential Scope
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -136,6 +136,20 @@ correctly 404s — that is not a misconfiguration).
   (not yet converged), showed `mergeStateStatus: BLOCKED` — confirming
   a PR whose advisory review has not converged is actually blocked from
   merging by the required check, not merely flagged as advisory.
+- **`ciGate.trustEmptyProtectionReads`**: `true` (repository override;
+  distributed default is `false`). This repository has no classic
+  branch protection at all — only the `main`/`features` rulesets above
+  — so `GET .../branches/master/protection` genuinely 404s; it is not a
+  permission-scope artifact (the automation identity used to register
+  the ruleset above carries `admin: true` on this repository, so a real
+  classic-protection resource would be readable, not 404, if one
+  existed). `idd-ci.instructions.md`'s required-check-discovery step 4
+  otherwise treats every `404` on that endpoint as fail-closed
+  (structurally indistinguishable from a `403`) regardless of what the
+  ruleset read already found, which would have permanently blocked
+  `pre-merge-readiness` even with the required-status-checks rule above
+  fully satisfied. Opting in here is the documented escape hatch for
+  exactly this verified case.
 
 ### Credential Scope
 


### PR DESCRIPTION
## Summary

- Registers `idd-advisory-convergence` plus the four existing `Linting workflow` jobs (`lint`, `powershell-analyzer`, `pester`, `configuration-drift`) as required status checks on `master`'s `main` ruleset via the GitHub Rulesets API.
- **Operational policy change, not docs-only**: sets `ciGate.trustEmptyProtectionReads: true` in `.github/idd/config.json`. Without this, `pre-merge-readiness`'s required-check discovery still fails closed on the classic branch-protection endpoint's `404` (this repo uses rulesets, not classic protection, so that endpoint always 404s) regardless of what the ruleset above already supplies — meaning the required-status-checks registration alone would not have actually unblocked autonomous merges. Verified under the exact identity every IDD session in this repo uses (this repo's Credential Scope policy has no separate least-privilege worker identity): `HTTP/2.0 200 OK` on the ruleset read, a genuine `HTTP/2.0 404 Not Found` (not a masked `403`) on the classic-protection read.
- Records both decisions, plus the CodeRabbit-exclusion rationale and the `strict_required_status_checks_policy: false` tradeoff, in `docs/idd-policy.md`.
- Live verification evidence recorded: PR #113 flipped `UNSTABLE` → `CLEAN` once its checks (including a converged `idd-advisory-convergence`) satisfied the new rule; PR #114 showed `BLOCKED` while its `idd-advisory-convergence` run was `FAILURE` (not yet converged).

This resolves #61 (`status:blocked-by-human`) — both the ruleset mutation and the `trustEmptyProtectionReads` config decision were maintainer-authorized repository-governance actions taken directly at the maintainer's explicit request in this session, outside the normal IDD claim/branch flow (matching upstream's documented boundary that GitHub Settings-level configuration operations are not something an agent applies to itself; the config-file change is a normal PR because master requires one).

Closes #61

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` clean
- [x] `npx cspell lint "**"` clean
- [x] `Invoke-ScriptAnalyzer` / `Invoke-Pester -CI` (115/115) clean
- [x] `gh api repos/kurone-kito/setup.windows/rulesets/20748458` shows `required_status_checks` including `idd-advisory-convergence`
- [x] Live before/after PR mergeability evidence recorded in the doc (PR #113 UNSTABLE→CLEAN, PR #114 BLOCKED on unconverged advisory)
- [x] `trustEmptyProtectionReads` behavior verified: `gh api --include repos/kurone-kito/setup.windows/branches/master/protection` returns raw `404` under the same identity that reads the ruleset (`200`), confirming the genuinely-empty case this flag is meant to trust

🤖 Generated with [Claude Code](https://claude.com/claude-code)