### PR TITLE
refactor(setup): remove fnm and delegate Node.js to dotfiles

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -38,7 +38,6 @@ words:
   - dosbox
   - farah
   - fastfetch
-  - fnm
   - ghub
   - hkcu
   - hklm
@@ -61,7 +60,6 @@ words:
   - psmux
   - psscriptanalyzer
   - pstop
-  - schniz
   - sharkdp
   - slik
   - steamcmd

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -19,10 +19,11 @@
 
     # PSAvoidUsingInvokeExpression is intentionally NOT excluded here (flagged
     # by review): a global ExcludeRules entry would also silence any new
-    # Invoke-Expression call added later under libs/. The one existing
-    # occurrence (fnm's `fnm env --use-on-cd | Out-String | Invoke-Expression`
-    # in libs/post-install.ps1) is suppressed at the file scope instead via
-    # [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute], so the rule
-    # stays enabled for every other analyzed file.
+    # Invoke-Expression call added later under libs/. There is no current
+    # occurrence to suppress (the one that existed, fnm's env-init
+    # incantation in libs/post-install.ps1, was removed with fnm itself --
+    # issue #108); if a future occurrence needs one, suppress it at the file
+    # scope via [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute]
+    # instead, so the rule stays enabled for every other analyzed file.
   )
 }

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 🌐 [English](README.md)
 
 Windows 10 / 11 向けのデスクトップ環境自動セットアップスクリプトです。
-開発（Node.js, .NET, Rust, VRChat/Unity）、ゲーミング、日常利用まで
+開発（.NET, Rust, VRChat/Unity）、ゲーミング、日常利用まで
 一通りの環境を構築します。
 
 ## アーキテクチャ
@@ -22,7 +22,6 @@ setup.cmd                        ← 唯一のエントリーポイント
             ├─ Phase 3: Chocolatey（フォント、vb-cable）+ posh-git（PowerShellGet）
             ├─ Phase 4: アーキテクチャ依存パッケージ
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
-            │    ├─ fnm → Node.js 20/22/24/25
             │    ├─ dotnet tool → VPM CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
@@ -69,7 +68,7 @@ setup.cmd                        ← 唯一のエントリーポイント
    （利用できない場合は **`winget import`**（縮退モード）にフォール
    バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール
-5. インストール後セットアップ（Node.js, VPM CLI, Unity, mkcert, Docker イメージ）
+5. インストール後セットアップ（VPM CLI, Unity, mkcert, Docker イメージ）
 6. Microsoft Update を有効化し、Windows Update を実行
 
 Boxstarter が自動的に再起動を処理します。再起動により処理が中断した場合は、
@@ -91,7 +90,7 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 参照してください。主要カテゴリ:
 
 - **ランタイム:** .NET SDK 8/10, Rust, Visual C++ 再頒布可能パッケージ
-- **開発:** Git, GitHub CLI, fnm, Android Studio
+- **開発:** Git, GitHub CLI, Android Studio
 - **VRChat:** Unity Hub, VRChat Creator Companion, VRCX
 - **エディタ:** VS Code, Cursor, Sublime Text 4, Vim, Neovim
 - **CLI ツール:** 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert
@@ -111,11 +110,14 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 
 ### インストール後スクリプト経由
 
-- **Node.js**（fnm 経由）: v20, v22, v24 (LTS), v25 (Current)
 - **VPM CLI**（dotnet tool 経由）: VRChat パッケージマネージャー
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA
 - **Docker イメージ**: ベースイメージ (alpine, debian, ubuntu, node 各種)
+
+> **注意:** Node.js のバージョン管理はこのリポジトリの責務ではありません。
+> [dotfiles](https://github.com/kurone-kito/dotfiles) が `mise` 経由で
+> 管理します。
 
 ### 条件付き（非ARM64 のみ）
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 🌐 [日本語](README.ja.md)
 
 Automated desktop environment setup for Windows 10 / 11, covering
-development (Node.js, .NET, Rust, VRChat/Unity), gaming, and daily use.
+development (.NET, Rust, VRChat/Unity), gaming, and daily use.
 
 ## Architecture
 
@@ -21,7 +21,6 @@ setup.cmd                        ← single entry point
             ├─ Phase 3: Chocolatey (fonts, vb-cable) + posh-git (PowerShellGet)
             ├─ Phase 4: Architecture-conditional packages
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
-            │    ├─ fnm → Node.js 20/22/24/25
             │    ├─ dotnet tool → VPM CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
@@ -69,7 +68,7 @@ The script will:
    **`winget import`** (degraded mode) and report any resources it
    could not apply
 4. Install remaining packages via Chocolatey (fonts and audio drivers)
-5. Run post-install setup (Node.js, VPM CLI, Unity, mkcert, Docker images)
+5. Run post-install setup (VPM CLI, Unity, mkcert, Docker images)
 6. Enable Microsoft Update and run Windows Update
 
 Boxstarter handles reboots automatically. If a reboot interrupts the process,
@@ -91,7 +90,7 @@ See [configurations/packages.dsc.yaml](configurations/packages.dsc.yaml) for
 the full list. Key categories:
 
 - **Runtimes:** .NET SDK 8/10, Rust, Visual C++ Redistributable
-- **Development:** Git, GitHub CLI, fnm, Android Studio
+- **Development:** Git, GitHub CLI, Android Studio
 - **VRChat:** Unity Hub, VRChat Creator Companion, VRCX
 - **Editors:** VS Code, Cursor, Sublime Text 4, Vim, Neovim
 - **CLI Tools:** 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert
@@ -111,11 +110,14 @@ the full list. Key categories:
 
 ### Via Post-Install Scripts
 
-- **Node.js** (via fnm): v20, v22, v24 (LTS), v25 (Current)
 - **VPM CLI** (via dotnet tool): VRChat package manager
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)
+
+> **Note:** Node.js version management is not handled by this repository.
+> It is [dotfiles](https://github.com/kurone-kito/dotfiles)'s
+> responsibility, via `mise`.
 
 ### Conditional (non-ARM64 only)
 

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -174,7 +174,7 @@ else {
 }
 
 ###########################################################################
-### Phase 5 — Post-install setup (fnm, cargo, Unity, mkcert, Docker)
+### Phase 5 — Post-install setup (VPM CLI, Unity, mkcert, Docker)
 ###########################################################################
 # Unity CLI must be in place before post-install.ps1's own Unity Editor
 # install step (issue #76) -- installed here, ahead of that step, rather

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -688,14 +688,6 @@ properties:
         id: GnuPG.GnuPG
         source: winget
 
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.fnm
-      directives:
-        description: Fast Node Manager (fnm)
-      settings:
-        id: Schniz.fnm
-        source: winget
-
     # ================================================================
     # Text editors
     # ================================================================

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -66,7 +66,6 @@
         { "PackageIdentifier": "GitHub.GitLFS" },
         { "PackageIdentifier": "Slik.Subversion" },
         { "PackageIdentifier": "GnuPG.GnuPG" },
-        { "PackageIdentifier": "Schniz.fnm" },
         { "PackageIdentifier": "vim.vim" },
         { "PackageIdentifier": "Neovim.Neovim" },
         { "PackageIdentifier": "Fastfetch-cli.Fastfetch" },

--- a/configurations/runtime-versions.psd1
+++ b/configurations/runtime-versions.psd1
@@ -1,32 +1,4 @@
 @{
-  # Node.js versions installed via fnm (libs/post-install.ps1).
-  #
-  # Source of truth for each entry's Status/Eol: the official Node.js
-  # release schedule (https://github.com/nodejs/Release, schedule.json).
-  # Re-check that file when reviewing this list -- do not hand-roll EOL
-  # dates from memory, since that is exactly how this list went stale
-  # before (issue #73).
-  Node      = @{
-    # Default is the version `fnm default` selects. Kept as its own key
-    # (not "first entry wins") so removing/reordering Versions can't
-    # silently change the default.
-    Default  = 24
-    Versions = @(
-      @{
-        Version = 22
-        Status  = 'Maintenance LTS'
-        Eol     = '2027-04-30'
-        Reason  = 'Still under maintenance support; kept for projects pinned to v22 while v24 is the default for new work.'
-      }
-      @{
-        Version = 24
-        Status  = 'Active LTS'
-        Eol     = '2028-04-30'
-        Reason  = 'Current Active LTS release; the default version for new work.'
-      }
-    )
-  }
-
   # Unity Editor version installed via the Unity CLI (`unity install`,
   # libs/unity-editor-installer.ps1) -- not Unity Hub's unofficial
   # `-- --headless` interface (replaced by issue #74; see

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -302,12 +302,15 @@ a sound single-file mechanism becomes available.
 
 ## Reviewing pinned Node/Unity versions (issue #73)
 
-`libs/post-install.ps1` installs Node.js (via fnm) and the Unity Editor
-(via Unity Hub CLI). Both used to have hardcoded version numbers,
-including one comment block that named its own EOL dates while
-continuing to install two already-EOL'd Node releases -- the versions
-went stale and nothing surfaced it. Both are now declared in
-`configurations/runtime-versions.psd1` instead.
+`libs/post-install.ps1` used to install Node.js (via fnm) and, at the
+time, the Unity Editor (via Unity Hub CLI -- migrated to the Unity CLI
+by issue #74, below). Both had hardcoded version numbers, including
+one comment block that named its own EOL dates while continuing to
+install two already-EOL'd Node releases -- the versions went stale and
+nothing surfaced it. Both moved to `configurations/runtime-versions.psd1`
+at the time (Node's entry has since been removed entirely -- see
+"Node.js ownership moved to dotfiles (issue #108)" below; Unity's
+entry remains).
 
 ### Why `.psd1`, not YAML or JSON
 
@@ -322,21 +325,21 @@ above each entry, same as the hardcoded declarations it replaces.
 ### Where to look for the next EOL
 
 Every entry in `configurations/runtime-versions.psd1` carries its own
-`Eol` (Node) or `VerifiedDate` (Unity, which has no EOL concept)
-alongside `Reason` -- the file itself is the answer to "when does this
-go stale," no separate tracking needed. `Node.Default` is a distinct
-key (not "first entry wins"), so reordering or trimming `Versions`
-can't silently change which version `fnm default` selects.
+`VerifiedDate` (Unity, which has no EOL concept) alongside `Reason` --
+the file itself is the answer to "when does this go stale," no
+separate tracking needed. (The `Node` entry used the same pattern with
+an `Eol` field and a distinct `Node.Default` key -- not "first entry
+wins," so reordering or trimming `Versions` couldn't silently change
+which version `fnm default` selected -- before Node.js version
+management moved to dotfiles; see "Node.js ownership moved to
+dotfiles (issue #108)" below.)
 
 ### Review cadence
 
-- **Node**: re-check the
-  [official release schedule](https://github.com/nodejs/Release)
-  (`schedule.json`) whenever a version's `Eol` in
-  `runtime-versions.psd1` has passed, or at least whenever an issue
-  like this one revisits the file. Drop any version past its `Eol`,
-  and confirm `fnm` itself supports whichever version is added, since a
-  version fnm doesn't yet recognize will fail `fnm install` outright.
+- **Node**: no longer tracked here -- Node.js version management moved
+  to dotfiles (see
+  ["Node.js ownership moved to dotfiles (issue #108)"](#nodejs-ownership-moved-to-dotfiles-issue-108)
+  below). Review cadence for Node.js releases is now dotfiles' concern.
 - **Unity**: no fixed EOL, so `VerifiedDate` records when the pinned
   version/changeset pair was last confirmed against VRChat's own
   [current-version page](https://creators.vrchat.com/sdk/upgrade/current-unity-version/).
@@ -363,6 +366,23 @@ can't silently change which version `fnm default` selects.
   against Unity's own release API (`services.api.unity.com`), which
   returns that exact changeset for `2022.3.22f1`'s Windows x86_64
   download.
+
+### Node.js ownership moved to dotfiles (issue #108)
+
+Node.js version management (formerly `pkg.fnm` in
+`configurations/packages.dsc.yaml`, the `Node` section above, and the
+fnm block in `libs/post-install.ps1`) has been removed from this
+repository entirely. It is now
+[dotfiles](https://github.com/kurone-kito/dotfiles)'s responsibility,
+via its `home/dot_config/mise/config.toml` (`node = "latest"`), which
+became viable once issue #103 added `jdx.mise` to the `full` profile.
+
+This is an **intentional scope change**, not an oversight: fnm allowed
+multiple Node.js LTS lines to be installed side by side (see the
+"2026-08-02 verification" entry above -- v22 and v24 co-installed).
+`mise` instead resolves to a single version per its config. This
+repository no longer supports co-installed Node LTS lines; anyone who
+needs that must configure it in dotfiles/mise directly, not here.
 
 ## Installing the Unity CLI (issue #76)
 

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -5,13 +5,12 @@ after the declarative DSC phase completes.
 
 All steps are idempotent and safe to re-run after a reboot.
 #>
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification = 'fnm official env-init incantation (fnm env --use-on-cd)')]
 param()
 
 Set-StrictMode -Version Latest
 
 ###########################################################################
-### Runtime version config (issue #73) — Node/Unity versions live in
+### Runtime version config (issue #73) — Unity versions live in
 ### configurations/runtime-versions.psd1, not hardcoded here. See that
 ### file for each version's EOL/verification info and the reason it is
 ### pinned, and docs/dsc-migration-notes.md for the review cadence.
@@ -40,25 +39,6 @@ function Test-CommandExists {
   This avoids the historic `Get-Command ... | Out-Null` bug where the
   pipeline always evaluates to $null ($false).
   #>
-}
-
-###########################################################################
-### Node.js via fnm
-###########################################################################
-if (Test-CommandExists fnm) {
-  Write-Host '[post-install] Setting up Node.js via fnm...' -ForegroundColor Cyan
-  fnm env --use-on-cd | Out-String | Invoke-Expression
-
-  $nodeConfig = $runtimeVersions.Node
-  foreach ($entry in @($nodeConfig.Versions)) {
-    Write-Host "  Installing Node.js v$($entry.Version) ($($entry.Status), EOL $($entry.Eol))..." -ForegroundColor Gray
-    fnm install $entry.Version
-  }
-  fnm default $nodeConfig.Default
-  Write-Host '[post-install] Node.js setup complete.' -ForegroundColor Green
-}
-else {
-  Write-Warning '[post-install] fnm not found — skipping Node.js setup.'
 }
 
 ###########################################################################

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -14,16 +14,17 @@ Set-StrictMode -Version Latest
 ### configurations/runtime-versions.psd1, not hardcoded here. See that
 ### file for each version's EOL/verification info and the reason it is
 ### pinned, and docs/dsc-migration-notes.md for the review cadence.
+###
+### Only the path is needed here -- Sync-UnityEditor (below) loads and
+### validates the file itself (non-terminating error, no throw, on a
+### missing/malformed file), so parsing it a second time up front would
+### only make an unrelated config problem skip VPM CLI / Vagrant /
+### mkcert / Docker too, not just the Unity step that actually needs it.
 ###########################################################################
-. (Join-Path -Path $PSScriptRoot -ChildPath 'runtime-versions.ps1')
 $runtimeVersionsFile = $PSScriptRoot `
   | Join-Path -ChildPath '..' `
   | Join-Path -ChildPath 'configurations' `
   | Join-Path -ChildPath 'runtime-versions.psd1'
-$runtimeVersions = Get-RuntimeVersionsConfig -Path $runtimeVersionsFile
-if ($null -eq $runtimeVersions) {
-  return
-}
 
 ###########################################################################
 ### Helper — correct command existence check (fixes the Out-Null bug)

--- a/libs/runtime-versions.ps1
+++ b/libs/runtime-versions.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
 Shared reader for configurations/runtime-versions.psd1 -- the single
-source of truth for pinned Node, Unity Editor, and Unity CLI versions.
+source of truth for pinned Unity Editor and Unity CLI versions.
 
 This file is dot-sourced (not imported as a module) from post-install.ps1
 and unity-cli-installer.ps1 -- do not add Export-ModuleMember here.

--- a/tests/powershell/unity-cli-installer.Tests.ps1
+++ b/tests/powershell/unity-cli-installer.Tests.ps1
@@ -142,7 +142,7 @@ Describe 'Sync-UnityCli' {
 
   It 'writes a non-terminating error and does not throw when the UnityCli entry is missing' {
     $path = Join-Path -Path $TestDrive -ChildPath 'no-unity-cli.psd1'
-    Set-Content -Path $path -Value "@{ Node = @{} }"
+    Set-Content -Path $path -Value "@{ Other = @{} }"
 
     { Sync-UnityCli -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
   }

--- a/tests/powershell/unity-editor-installer.Tests.ps1
+++ b/tests/powershell/unity-editor-installer.Tests.ps1
@@ -265,7 +265,7 @@ Describe 'Sync-UnityEditor' {
 
   It 'writes a non-terminating error and does not throw when the Unity entry is missing' {
     $path = Join-Path -Path $TestDrive -ChildPath 'no-unity.psd1'
-    Set-Content -Path $path -Value "@{ Node = @{} }"
+    Set-Content -Path $path -Value "@{ Other = @{} }"
 
     { Sync-UnityEditor -ConfigPath $path -ErrorAction SilentlyContinue } | Should -Not -Throw
   }


### PR DESCRIPTION
## Summary

Removes fnm/Node.js version management from this repository entirely,
delegating it to dotfiles' `mise` (viable since #103 added `jdx.mise`
to the `full` profile).

- Drop `pkg.fnm` (`Schniz.fnm`) from `configurations/packages.dsc.yaml`
  and regenerate `packages.import.json` / `packages.unapplied.json`
  via `Build-Configurations.ps1`.
- Remove the fnm block from `libs/post-install.ps1`, along with its
  now-unneeded `PSAvoidUsingInvokeExpression` suppression (confirmed
  no other `Invoke-Expression` use remains in the file).
- Remove the `Node` key from `configurations/runtime-versions.psd1`;
  `Unity` / `UnityCli` stay intact.
- Update `libs/runtime-versions.ps1` and the two Unity installer test
  fixtures that used an incidental `Node = @{}` placeholder, so no
  stray `Node`-key reference remains under `tests/powershell/`.
- Update `README.md` / `README.ja.md` (intro line, architecture
  diagram, install-steps list, package list, post-install-scripts
  list) to drop Node.js/fnm and note dotfiles' ownership.
- Record the ownership move and the scope change in
  `docs/dsc-migration-notes.md`, including updating the
  runtime-versions review-cadence text.
- Drop the now-unused `fnm`/`schniz` cspell words and fix two comments
  (`PSScriptAnalyzerSettings.psd1`, `boxstarter.ps1` Phase 5) that
  referenced the removed fnm occurrence.

This is an **intentional scope change**: fnm allowed multiple
co-installed Node LTS lines side by side; `mise` resolves to a single
version per its config, so this repo no longer supports that pattern.

Closes #108

## Verification

Per the issue's own acceptance criteria, verification never executes
`boxstarter.ps1` or `libs/post-install.ps1` for real:

- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit`
  — 0 findings
- `Invoke-Pester -Path ./tests/powershell -CI` — 115/115 passed
- `./scripts/Build-Configurations.ps1 -DscPath ./configurations/packages.dsc.yaml`
  — zero diff on rerun (configuration-drift parity)
- `markdownlint-cli2` / `cspell` — 0 issues
