### PR TITLE
refactor(setup): remove gh / ghq / Copilot CLI duplicated by dotfiles

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ setup.cmd                        ← 唯一のエントリーポイント
 
 1. **Chocolatey** と **Boxstarter** が未インストールならインストール
 2. `Install-BoxstarterPackage` 経由で `boxstarter.ps1` を起動（再起動耐性あり）
-3. **WinGet Configuration (DSC)** で 105 個のパッケージを宣言的にインストール
+3. **WinGet Configuration (DSC)** で 104 個のパッケージを宣言的にインストール
    （利用できない場合は **`winget import`**（縮退モード）にフォール
    バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール
@@ -90,7 +90,7 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 参照してください。主要カテゴリ:
 
 - **ランタイム:** .NET SDK 8/10, Rust, Visual C++ 再頒布可能パッケージ
-- **開発:** Git, GitHub CLI, Android Studio
+- **開発:** Git, Android Studio
 - **VRChat:** Unity Hub, VRChat Creator Companion, VRCX
 - **エディタ:** VS Code, Cursor, Sublime Text 4, Vim, Neovim
 - **CLI ツール:** 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert
@@ -98,6 +98,10 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 - **ゲーミング:** Steam, Epic Games, EA Desktop, Minecraft, StepMania
 - **コミュニケーション:** Discord, Slack, Zoom
 - **生産性:** Notion, OneNote, PowerToys, Grammarly, Kindle
+
+> **注意:** GitHub CLI（`gh`）はこのリポジトリではインストールしなくなりました。
+> [dotfiles](https://github.com/kurone-kito/dotfiles) が `mise` 経由で
+> 管理します。
 
 ### Chocolatey 経由（winget にないもの）
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The script will:
 
 1. Install **Chocolatey** and **Boxstarter** if not already present
 2. Launch `boxstarter.ps1` via `Install-BoxstarterPackage` (reboot-resilient)
-3. Apply the **WinGet Configuration (DSC)** to install 105 packages
+3. Apply the **WinGet Configuration (DSC)** to install 104 packages
    declaratively when available, otherwise fall back to
    **`winget import`** (degraded mode) and report any resources it
    could not apply
@@ -90,7 +90,7 @@ See [configurations/packages.dsc.yaml](configurations/packages.dsc.yaml) for
 the full list. Key categories:
 
 - **Runtimes:** .NET SDK 8/10, Rust, Visual C++ Redistributable
-- **Development:** Git, GitHub CLI, Android Studio
+- **Development:** Git, Android Studio
 - **VRChat:** Unity Hub, VRChat Creator Companion, VRCX
 - **Editors:** VS Code, Cursor, Sublime Text 4, Vim, Neovim
 - **CLI Tools:** 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert
@@ -98,6 +98,10 @@ the full list. Key categories:
 - **Gaming:** Steam, Epic Games, EA Desktop, Minecraft, StepMania
 - **Communication:** Discord, Slack, Zoom
 - **Productivity:** Notion, OneNote, PowerToys, Grammarly, Kindle
+
+> **Note:** GitHub CLI (`gh`) is no longer installed by this repository.
+> It is [dotfiles](https://github.com/kurone-kito/dotfiles)'s
+> responsibility, via `mise`.
 
 ### Via Chocolatey (winget unavailable)
 

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -838,14 +838,6 @@ properties:
     # ================================================================
     # CLI — GitHub / CI
     # ================================================================
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.ghCli
-      directives:
-        description: GitHub CLI
-      settings:
-        id: GitHub.cli
-        source: winget
-
     # NOTE: nektos/act is installed conditionally (non-ARM64) in post-install.ps1
 
     # ================================================================

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -81,7 +81,6 @@
         { "PackageIdentifier": "dbrgn.tealdeer" },
         { "PackageIdentifier": "junegunn.fzf" },
         { "PackageIdentifier": "Valve.SteamCMD" },
-        { "PackageIdentifier": "GitHub.cli" },
         { "PackageIdentifier": "Amazon.AWSCLI" },
         { "PackageIdentifier": "FiloSottile.mkcert" },
         { "PackageIdentifier": "Ngrok.Ngrok" },

--- a/configurations/packages.min.dsc.yaml
+++ b/configurations/packages.min.dsc.yaml
@@ -56,16 +56,6 @@ properties:
         source: winget
 
     # =======================================================================
-    # Install the CLI AI agent tools
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: github-copilot-cli
-      directives:
-        description: GitHub Copilot CLI
-      settings:
-        id: GitHub.Copilot
-        source: winget
-
-    # =======================================================================
     # Install the CLI benchmark tools
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: fastfetch
@@ -257,13 +247,6 @@ properties:
     # =======================================================================
     # Install the CLI Git tools
     - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: ghq
-      directives:
-        description: ghq
-      settings:
-        id: x-motemen.ghq
-        source: winget
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: git
       directives:
         description: Git
@@ -283,13 +266,6 @@ properties:
         description: git-sizer
       settings:
         id: GitHub.git-sizer
-        source: winget
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: github-cli
-      directives:
-        description: GitHub CLI
-      settings:
-        id: GitHub.cli
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: worktrunk

--- a/configurations/packages.min.import.json
+++ b/configurations/packages.min.import.json
@@ -4,7 +4,6 @@
     {
       "Packages": [
         { "PackageIdentifier": "jdx.mise" },
-        { "PackageIdentifier": "GitHub.Copilot" },
         { "PackageIdentifier": "Fastfetch-cli.Fastfetch" },
         { "PackageIdentifier": "marlocarlo.pstop" },
         { "PackageIdentifier": "twpayne.chezmoi" },
@@ -29,11 +28,9 @@
         { "PackageIdentifier": "BurntSushi.ripgrep.MSVC" },
         { "PackageIdentifier": "sxyazi.yazi" },
         { "PackageIdentifier": "ajeetdsouza.zoxide" },
-        { "PackageIdentifier": "x-motemen.ghq" },
         { "PackageIdentifier": "Git.Git" },
         { "PackageIdentifier": "GitHub.GitLFS" },
         { "PackageIdentifier": "GitHub.git-sizer" },
-        { "PackageIdentifier": "GitHub.cli" },
         { "PackageIdentifier": "max-sixty.worktrunk" },
         { "PackageIdentifier": "Amazon.AWSCLI" },
         { "PackageIdentifier": "JesseDuffield.lazygit" },


### PR DESCRIPTION
## Summary

dotfiles ([`kurone-kito/dotfiles`](https://github.com/kurone-kito/dotfiles))
already declares GitHub CLI (all profiles), ghq, and GitHub Copilot CLI
(min profile) via `mise`, duplicating this repository's winget
definitions. `docs/dotfiles-boundary.md` (#104, merged earlier) already
recorded the conclusion to **remove** `GitHub.cli`, not retain it, so
this PR follows that decision instead of the issue's own conditional
fallback.

- Remove `GitHub.cli` (`pkg.ghCli`) from `configurations/packages.dsc.yaml`
  (full profile)
- Remove `GitHub.cli` (`github-cli`), `x-motemen.ghq` (`ghq`), and
  `GitHub.Copilot` (`github-copilot-cli`) from
  `configurations/packages.min.dsc.yaml` (min profile)
- Regenerate `configurations/packages.import.json` and
  `configurations/packages.min.import.json` via
  `./scripts/Build-Configurations.ps1` (never hand-edited);
  `*.unapplied.json` for both profiles is unaffected — none of the
  three packages were on either profile's unapplied-resources list
- Update `README.md` / `README.ja.md`'s package summary: full-profile
  install count 105 → 104, "GitHub CLI" removed from the Development
  category bullet, and a new note (mirroring the existing Node.js
  delegation note) recording that GitHub CLI is now dotfiles-owned

## Deliberate, non-collateral choices

- **`configurations/packages.dsc.yaml`'s `# CLI — GitHub / CI` section
  header is kept even though no resource remains under it.** The
  `# NOTE: nektos/act is installed conditionally (non-ARM64) in
  post-install.ps1` comment directly below it documents unrelated,
  still-true information about `act`'s placement — removing it would
  be collateral cleanup outside this issue's scope, so only the
  `pkg.ghCli` resource block itself was removed (minimal diff).
- **`docs/dotfiles-boundary.md`'s "once #107 ships" / "#107, still
  open" phrasing is left untouched.** That file is a dated
  point-in-time inventory owned by the #104 track and outside this
  issue's `## Candidate files`; #107 doesn't rewrite it, it fulfills
  the removal that document already described.
- **`ghq` and `GitHub Copilot CLI` get no README note.** Neither ever
  appeared in `README.md`/`README.ja.md`'s package summary lists
  (confirmed by grep), so there's nothing to reconcile there beyond
  the `GitHub CLI` bullet/note above.

## Verification

- `pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit"` — clean, exit 0
- `pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"` — 115 passed,
  0 failed
- `./scripts/Build-Configurations.ps1` re-run against both
  `packages.dsc.yaml` and `packages.min.dsc.yaml` after the edits —
  zero working-tree diff (`configuration-drift` parity)
- `pre-push-validate` (markdownlint, cspell, ScriptAnalyzer, Pester) —
  all green on a clean tree

Closes #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed GitHub CLI, GitHub Copilot CLI, and ghq from the managed package configurations.
  - GitHub CLI installation is now handled through `mise` via the linked dotfiles repository.
  - Updated the documented WinGet Configuration package count from 105 to 104.
  - Updated both English and Japanese documentation to reflect the revised package management setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->