### PR TITLE
refactor(setup): opt out marlocarlo.pstop from winget

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -59,7 +59,6 @@ words:
   - posh
   - psmux
   - psscriptanalyzer
-  - pstop
   - sharkdp
   - slik
   - steamcmd

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -718,14 +718,6 @@ properties:
         id: Fastfetch-cli.Fastfetch
         source: winget
 
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.pstop
-      directives:
-        description: pstop — system information tool
-      settings:
-        id: marlocarlo.pstop
-        source: winget
-
     # ================================================================
     # CLI — Binary tools
     # ================================================================

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -69,7 +69,6 @@
         { "PackageIdentifier": "vim.vim" },
         { "PackageIdentifier": "Neovim.Neovim" },
         { "PackageIdentifier": "Fastfetch-cli.Fastfetch" },
-        { "PackageIdentifier": "marlocarlo.pstop" },
         { "PackageIdentifier": "7zip.7zip" },
         { "PackageIdentifier": "Gyan.FFmpeg" },
         { "PackageIdentifier": "ImageMagick.ImageMagick" },

--- a/configurations/packages.min.dsc.yaml
+++ b/configurations/packages.min.dsc.yaml
@@ -64,13 +64,6 @@ properties:
       settings:
         id: Fastfetch-cli.Fastfetch
         source: winget
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pstop-htop-for-windows
-      directives:
-        description: pstop (htop for Windows)
-      settings:
-        id: marlocarlo.pstop
-        source: winget
 
     # =======================================================================
     # Install the CLI configuration tools

--- a/configurations/packages.min.import.json
+++ b/configurations/packages.min.import.json
@@ -5,7 +5,6 @@
       "Packages": [
         { "PackageIdentifier": "jdx.mise" },
         { "PackageIdentifier": "Fastfetch-cli.Fastfetch" },
-        { "PackageIdentifier": "marlocarlo.pstop" },
         { "PackageIdentifier": "twpayne.chezmoi" },
         { "PackageIdentifier": "hpjansson.Chafa" },
         { "PackageIdentifier": "ImageMagick.ImageMagick" },


### PR DESCRIPTION
## Summary

Wave 2 of delegating winget-portable CLI tools to dotfiles/mise:
opt `marlocarlo.pstop` out of this repository's winget package
definitions, since it is now provisioned via `mise`
(`github:psmux/pstop`) in `kurone-kito/dotfiles`
(dotfiles#255, merged as PR #270).

Per the gate issue #106 handoff comment, `marlocarlo.pstop` is the
**only** package in scope for this wave. `twpayne.chezmoi`,
`Gyan.FFmpeg`, `SQLite.SQLite`, `Ngrok.Ngrok`, and `Valve.SteamCMD`
stay in winget, and the unrelated `marlocarlo.psmux` package is
untouched.

## Changes

- Removed the `pkg.pstop` `WinGetPackage` resource from
  `configurations/packages.dsc.yaml` (full profile).
- Removed the `pstop-htop-for-windows` `WinGetPackage` resource from
  `configurations/packages.min.dsc.yaml` (min profile).
- Regenerated `configurations/packages.import.json` and
  `configurations/packages.min.import.json` via
  `scripts/Build-Configurations.ps1` for both profiles (generated
  files, not hand-edited). `*.unapplied.json` files are unaffected —
  `pstop` was a `WinGetPackage` resource, never a non-package
  (Registry/OsVersion) resource, so it never appeared there.
- Removed the now-orphaned `pstop` custom word from
  `.cspell.config.yml` (`psmux` stays, since `marlocarlo.psmux` is
  untouched).
- `libs/post-install.ps1`, `README.md`, and `README.ja.md` were
  checked and need no change: none of them named `pstop` individually
  (the README's "CLI Tools" bullet lists other examples only, and is
  explicitly non-exhaustive).
- No User PATH logic added or changed anywhere; the "run `winget
  upgrade` from an interactive local/RDP session" operating assumption
  is unchanged.

## Verification

- `./scripts/Build-Configurations.ps1` re-run against both DSC files
  after the edit produces zero further diff (configuration-drift
  check).
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` — exit 0.
- `Invoke-Pester -Path ./tests/powershell -CI` — 115/115 passed.
- `pre-push-validate` (markdownlint + cspell + ScriptAnalyzer + Pester)
  — exit 0 on a clean tree.

Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `pstop` system information tool from package installation configurations.
  * Removed `pstop` from the supported package list and spelling allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->