### PR TITLE
chore(idd): bump idd-skill pin to cac92e3e and reconcile template drift

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -34,6 +34,7 @@ words:
   - chezmoi
   - choco
   - dbrgn
+  - dedup
   - dind
   - dosbox
   - farah

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.4.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "setup-windows",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior.
+owns behavior; `advisoryWait.exemptBotAuthoredPrs` is convergence-only.
 
 ## Scope — Copilot-only settle/wait window
 
@@ -35,8 +35,11 @@ one). Enter the full protocol below **only** when
 Keep the wait itself cheap per the
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline): a
 single wake at the **expected** completion, or background only if the
-topology-safety condition holds; otherwise wait synchronously. Batch
-all post-wait actions into one turn.
+topology-safety condition holds; otherwise wait synchronously — no
+single `gh` command blocks on Copilot review state; run the protocol
+below (helper-first, AW1-AW5 fallback) as a foreground wait, never
+`run_in_background`, absent the confirmed condition. Batch all
+post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 
@@ -113,7 +116,6 @@ stalled `SATISFIED`) and request procedure:
 exclusively** (the **F3** column reads from it); `Outcome` governs
 **E14**, **F2**, and shell-fallback rows only (no `f3Outcome` there).
 
-- F3 must use `f3Outcome` when helper output is available.
 - If `copilotPending` is `false`, F3 treats advisory wait as satisfied.
 - If `copilotPending` is `true`, F3 must not merge on `WAIT`,
   `REQUEST_NEEDED`, or `RECOVERY_NEEDED`.
@@ -267,11 +269,13 @@ verified HEAD within one pass).
 ### AW3-H — Hide superseded advisory-wait markers
 
 After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
-for the current `PR_HEAD_SHA`, minimize every trusted prior
-`advisory-wait*` marker whose embedded HEAD SHA does **not** match, as
-`OUTDATED` (cuts F4 backlog and review-page noise). Find candidate IDs
-(trusted `advisory-wait*` markers with a differing embedded SHA), then
-call the minimize-markers command:
+for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
+the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
+family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
+F4 backlog and review-page noise — a stale-HEAD `advisory-reroll:`
+marker is exactly as much operational noise as a stale advisory-wait
+one). Find candidate IDs (trusted markers of that family with a
+differing embedded SHA), then call the minimize-markers command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is
@@ -314,20 +318,23 @@ this hold and stop:
 
 F2-only (`#1511`) on `sameHeadReroll.eligible`; see
 `docs/idd-helper-scripts.md`. `requestable`: post the marker below
-**before** requesting the review, then poll (not E14's loop).
+**before** requesting review, then poll (not E14's loop).
 `inFlight`: poll only. Else F2's route; `!inFlight`: E1.
 
 ```text
 advisory-reroll: {agent-id} {PR_HEAD_SHA} {ISO8601-requested-at}
 ```
 
-Plain text, no HTML comment (matches `advisory-wait:`/
-`advisory-wait-recovery:`'s shape). Helper-first: the profile-selected
-post-idd-marker command (`--type advisory-reroll --target pr
-<pr-number> --agent-id <id> --head-sha <PR_HEAD_SHA> --timestamp
-<ISO8601> --apply`); manual JSON `POST` is the fallback. If it cannot
-be posted or verified, fail closed to AW4's **Recovery failed** hold
-(mirrors AW3-R's routing on the same failure).
+Plain text, no HTML comment (matches `advisory-wait:`'s shape).
+Helper-first: profile-selected post-idd-marker command (`--type advisory-reroll
+--target pr <pr-number> --agent-id <id> --head-sha <PR_HEAD_SHA>
+--timestamp <ISO8601> --apply`); manual `POST` is fallback. If it
+cannot be posted or verified, fail closed to AW4's **Recovery failed**
+hold.
+
+**`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
+never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
+(2026-08-10/11).
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 
@@ -367,8 +374,8 @@ alone never proves `COPILOT_UNAVAILABLE` (see **State**).
 ### Terminal routing (`#1570`)
 
 One `idd-external-check-waiver:` marker (selector
-`idd-advisory-convergence`, current HEAD, active claim) satisfies both
-consumers: the CI check's `terminal` field (its waiver hatch also opens
+`idd-advisory-convergence`, current HEAD, active claim/`none`) satisfies
+both consumers: the CI check's `terminal` field (its waiver hatch opens
 on `COPILOT_UNAVAILABLE` independent of `deadline.passed` — `ready`
 still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 `copilotUnavailableWaived` (`f3Outcome` unchanged; unwaived adds
@@ -381,8 +388,8 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > recovery cycle is exhausted and the terminal window elapsed with no
 > current-HEAD review. A maintainer must post an
 > `idd-external-check-waiver:` marker for selector
-> `idd-advisory-convergence`, this HEAD, and the active claim before
-> this PR can proceed.
+> `idd-advisory-convergence`, this HEAD, and active claim/`none` before
+> merging.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never
 `workflow_dispatch` — see Rerun mechanics below); both fields recompute

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -194,7 +194,7 @@ does **not** reliably refresh the PR's required-check rollup for current
 HEAD — a manually dispatched run has no `pull_request` context to
 associate with the PR's HEAD SHA (full investigation: this repo's
 dogfooded
-[`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)
+[`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e/.github/workflows/idd-advisory-convergence.yml)
 header comment — not present in the portable stub this template
 ships). For a stuck or stale rollup entry, rerun the _existing_
 PR-linked run (`gh run rerun <run-id>`) instead of `workflow_dispatch`.

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -21,8 +21,8 @@ node scripts/ci-wait-policy.mjs
 <profile-selected-ci-wait-policy-command>
 ```
 
-Append `--rerun-count <count>` when the caller needs the deterministic
-rerun-budget decision. Resolve
+Prefer `--run-id <run-id>` (from run_attempt; mirrors
+`rerun-advisory-convergence.mts`) to `--rerun-count <count>`. Resolve
 `<profile-selected-ci-wait-policy-command>` from
 `docs/idd-helper-scripts.md`. Do not hardcode
 `node scripts/ci-wait-policy.mjs` for profiles that don't vendor
@@ -189,16 +189,15 @@ check name.
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
-**`idd-advisory-convergence` specifically** (when hosted as a required
-check): `workflow_dispatch` does **not** reliably refresh the PR's
-required-check rollup for current HEAD — a manually dispatched run has
-no `pull_request` context to associate with the PR's HEAD SHA (full
-investigation: this repo's dogfooded
+**`idd-advisory-convergence`** (as a required check): `workflow_dispatch`
+does **not** reliably refresh the PR's required-check rollup for current
+HEAD — a manually dispatched run has no `pull_request` context to
+associate with the PR's HEAD SHA (full investigation: this repo's
+dogfooded
 [`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)
 header comment — not present in the portable stub this template
-ships). For a stuck or stale rollup entry, apply the rerun mechanic
-above (`gh run rerun <run-id>` on the _existing_ PR-linked run)
-instead of `workflow_dispatch`.
+ships). For a stuck or stale rollup entry, rerun the _existing_
+PR-linked run (`gh run rerun <run-id>`) instead of `workflow_dispatch`.
 
 A second cause: GitHub gates a bot-triggered run (e.g. Copilot's
 `pull_request_review`/`pull_request_review_comment` event) to
@@ -212,19 +211,47 @@ The check also self-heals on the next non-bot trigger — a push or a
 **review-thread** reply, not a regular PR comment (no `issue_comment`
 subscription).
 
-**Helper-first**: prints this diagnosis and ordered rerun plan, read-only.
+**If rerunning the passing non-bot instance alone does not clear the
+rollup (`#1745`)**: a HEAD can carry several `idd-advisory-convergence`
+check-run instances (the check fires on `pull_request` plus
+`pull_request_review`/`pull_request_review_comment`, and
+`cancel-in-progress` cancels most of them), and GitHub's own required-check
+rollup can stay pinned to a bot-triggered instance whose **conclusion** is
+`CANCELLED`. Unlike `action_required`, a `CANCELLED`-conclusion
+bot-triggered instance is **not** gated: rerunning it completes
+normally and does not re-enter `action_required` (confirmed by direct
+experiment, `#1745`). If the
+non-bot rerun above does not clear the block, rerun every
+`CANCELLED`-conclusion bot-triggered sibling instance for the same HEAD
+next (`gh run rerun <run-id>` on each, per the plan below) — only an
+`action_required`-conclusion instance stays withheld from rerun.
+
+Note: this is a known Rulesets platform behavior, not an `idd-skill`
+dedup bug — GitHub can require every same-named instance non-failing,
+not just the dedup-selected latest.
+
+**Helper-first**: prints this diagnosis and ordered rerun plan, read-only
+by default; pass `--apply` to also execute it — the preferred recovery
+path when available. `--apply` reruns each
+rerun-eligible instance in order (recovery-refresh first when one
+applies), waits for each to reach a terminal state before starting the
+next, and stops early as soon as the rollup resolves — never a
+`bot-gated-skip` or rerun-budget-held instance.
 
 ```sh
 # source repo / vendored-node profile
-node scripts/rerun-advisory-convergence.mjs --pr <n>
+node scripts/rerun-advisory-convergence.mjs --pr <n> [--apply]
 
 # package-manager / ephemeral-npx profile
-<profile-selected-rerun-advisory-convergence-command> --pr <n>
+<profile-selected-rerun-advisory-convergence-command> --pr <n> [--apply]
 ```
 
 Resolve `<profile-selected-rerun-advisory-convergence-command>` from
 `docs/idd-helper-scripts.md`; do not hardcode `node scripts/...` for
-non-vendored profiles.
+non-vendored profiles. On `instructions-only` (no helper runtime), fall
+back to the manual sequence: run the diagnostic, then `gh run rerun
+<run-id>` on each plan entry, waiting for each to finish before the
+next.
 
 **Terminal-waiver recheck (`#1570`)**: once a maintainer waives a proven
 `COPILOT_UNAVAILABLE` state
@@ -269,7 +296,27 @@ condition below accounts for this.
 
 - **No interim polling turns** — schedule one wake at the **expected**
   completion, or background only if the topology is confirmed to route
-  completion back to this turn; otherwise wait synchronously. Never
+  completion back to this turn; otherwise wait synchronously — block
+  with `gh pr checks <pr-number> --watch --required` (works on a
+  fine-grained PAT; `gh run watch <run-id> --exit-status` does not).
+  Both only block, never decide: required-only scoping, duplicate-name
+  collapse, the no-required-checks route, and the
+  `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
+  algorithm above — track elapsed time and apply its rerun-or-hold
+  decision if a watch outlasts it. Issue that blocking call with an
+  execution-timeout override set at or near the calling tool's own
+  execution-timeout ceiling, not the tool's default, which can
+  hard-kill the wait well short of `ciWait.runningTimeout`; a
+  tool-timeout kill of the watch call is not a CI verdict — re-issue
+  the same blocking watch, keep accumulating elapsed time against the
+  bound above, and do not fall back to `run_in_background` or another
+  detached/backgrounded mechanism just because of the kill. Neither
+  watches Copilot review state — see
+  `idd-advisory-wait.instructions.md`. A bare `sleep` may
+  be sandboxed or blocked in some runtimes (preventive; no observed
+  incident yet); a `run_in_background` Bash task or other
+  detached/backgrounded mechanism must not be used for this wait
+  unless the topology-safety condition above is confirmed. Never
   insert "is it done yet?" turns or end this turn assuming an
   unconfirmed background/async notification resumes it — that stalls
   silently under supervisor/worker topologies.

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -353,12 +353,35 @@ race-safe checks below:
    forced-handoff, where steps 1–4 see nothing to disagree about (both
    `{claim-id}`s genuinely match). No marker posted: treat as passed.
 
-If any check fails, treat the claim as contested. Return to Discover
-using the same selection mode that produced this target and pick the
-next eligible issue (orphan-first: continue the A0-O capable path;
-roadmap mode: continue the A3-ready path). Do not retry the same issue.
-For explicit-target A0-T runs, report the contested claim and stop
-unless the operator has explicitly switched to normal discovery.
+If any check fails, treat the claim as contested.
+
+**Release before walking away when you provably own the active claim
+(step 4 failure only).** When steps 1–3 passed — the active claim
+genuinely uses your `{claim-id}` — and step 4 is the sole failing check
+(a trusted competing `claimed-by` with a different `{claim-id}` landed
+in a strictly later `created_at` second), post `unclaimed-by` for your
+own `{agent-id}` / `{claim-id}` (see
+[Unclaim format](idd-overview-core.instructions.md#unclaim-format))
+before returning to Discover. You provably hold the active claim, so
+releasing it is safe and restores the issue to unclaimed — without this
+release, the issue would stay locked against mechanical reclaim
+(including the 24 h stale-takeover) with no live owner, since the
+losing side of a different-second claim race never activates. Verify
+step 5 independently before releasing — do not infer "step 4 only"
+merely from a helper's single `reason` field, since a combined
+`later-competing-claim-and-activation-nonce-mismatch` verdict means
+step 5 also failed. Do **not** release whenever step 5
+(activation-nonce) fails, alone or together with step 4: a nonce
+mismatch means a second, independent activation shares your exact
+`{agent-id}` / `{claim-id}` pair, and releasing it would also evict
+that other session's legitimate claim.
+
+Return to Discover using the same selection mode that produced this
+target and pick the next eligible issue (orphan-first: continue the
+A0-O capable path; roadmap mode: continue the A3-ready path). Do not
+retry the same issue. For explicit-target A0-T runs, report the
+contested claim and stop unless the operator has explicitly switched to
+normal discovery.
 
 Once verified, record this `{claim-id}` as your current claim token for
 the rest of the workflow.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -20,7 +20,10 @@ see A0), A3 (default; see decision tree).
 
 The configured authoring label is `issueAuthoring.authoringLabelName`
 (default: `status:authoring`); the stale threshold is
-`issueAuthoring.authoringStaleAge` (default: `PT4H`).
+`issueAuthoring.authoringStaleAge` (default: `PT4H`). The label doubles
+as the draft marker for a held issue (issue-authoring skill's Stage 1)
+and the claim-suppression lock this guard enforces — Discover treats
+either role the same way: skip the issue while the label is present.
 
 A0-T, A0-O, and A3 must treat a matching label as not startable. A0-T
 reports `Issue #N is currently being authored` and stops before claim;
@@ -282,6 +285,19 @@ authorizes an alternate scope for the current run:
   unresolvable with the reason, skip that branch, and continue
   traversal. Not an enumeration failure.
 
+**Termination.** Do not re-expand a target already on the current
+traversal path; record the back-edge as a cycle with its path and
+continue with the next reference.
+
+**Single visit.** A node is identified by issue number; a node
+reached again through another path is the same node — collect it
+once, never enter it into the candidate set twice.
+
+**Provenance.** Keep and report every distinct path that reaches a
+node, not only the first — the same rule the cross-roadmap union
+below already applies to a leaf reachable from several roadmap
+roots.
+
 **Helper read timing.** The `discover-roadmap-graph` helper (see
 [IDD helper script evaluation](../../docs/idd-helper-scripts.md)) is
 long-running on large graphs, emitting the whole graph in one final
@@ -289,9 +305,9 @@ stdout write. Redirect stdout to a file and wait for process exit before
 parsing — a zero-byte or mid-run read is **"still running," not** an A2
 enumeration failure.
 
-Report every A2 execution candidate with its provenance path (e.g.
-`#222 → #228 → #257`), any open roadmap nodes, and unresolvable
-references before passing to A3.
+Report every A2 execution candidate with its provenance paths (e.g.
+`#222 → #228 → #257`), any open roadmap nodes, cycles, duplicate
+references, and unresolvable references before passing to A3.
 
 **Autopilot cross-roadmap union (optional, additive).** When A1 elected
 the cross-roadmap mode, enumerate from **each** open roadmap root and
@@ -350,7 +366,7 @@ apply this decision tree — do not silently expand scope:
    filtered out): report each candidate and the filter criterion it
    failed, then proceed to step 5.
 
-   See [Discover — A3 Diagnostic](../../docs/idd-design-rationale.md#a3---diagnostic-all-candidates-blocked-by-an-open-roadmap)
+   See [Discover — A3 Diagnostic](../../docs/idd-design-rationale.md#a3--diagnostic-all-candidates-blocked-by-an-open-roadmap)
    for the marker-misuse pattern this case typically indicates.
 
 5. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
@@ -526,9 +542,21 @@ for how the remaining tie-breakers below apply after this rule.
 highest-score tie band has more than one eligible candidate, pick the
 band entry at index `selectDesyncedIndex(session-token, band-size)`
 instead of index 0 — a pure `hash(session-token) mod band-size` over
-the band ordered by ascending issue number, `session-token` being this
-session's `{agent-id}`. Compute it with the CLI instead of hand-tracing
-`scripts/policy-helpers.mjs`:
+the band ordered by ascending issue number.
+
+`session-token` **must be per-session-unique**: the bare, session-shared
+`{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a
+compliant token. Use the session-suffixed `{agent-id}` (e.g.,
+`copilot-8122ca35`) when this session already appends one; otherwise
+generate a session-local token once at Discover entry — it must carry
+enough entropy to stay distinct across sessions launched at the same
+moment (a random or UUID-derived value; a bare timestamp alone is not
+sufficient, since same-second concurrent launches would still collide)
+— and reuse that same value for every A4 Step 2 selection this session
+makes, including re-entry after a collision. See
+[rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync)
+for why a bare shared token defeats this mechanism. Compute the index
+with the CLI instead of hand-tracing `scripts/policy-helpers.mjs`:
 
 ```sh
 # source repo / vendored-node
@@ -597,7 +625,7 @@ roadmap is open belong in the roadmap's task list as `- [ ] #NNN`
 entries; `blocked-by` is reserved for issues that must wait for a
 separate, prior roadmap to close (cross-phase sequential dependency) —
 see the
-[A3 diagnostic](../../docs/idd-design-rationale.md#a3---diagnostic-all-candidates-blocked-by-an-open-roadmap)
+[A3 diagnostic](../../docs/idd-design-rationale.md#a3--diagnostic-all-candidates-blocked-by-an-open-roadmap)
 for the resulting deadlock pattern.
 
 ## Scope invariant (summary)

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -82,7 +82,12 @@ Before any mutating action in F3, apply the
    is an instant state read, not itself a wait. If it escalates to a
    genuine wait, return to the F2 advisory bot wait check (backgrounds
    only if the topology-safety condition holds — confirmed to route
-   completion back to this turn — otherwise waits synchronously).
+   completion back to this turn — otherwise waits synchronously): no
+   single `gh` command blocks on Copilot review state, so run the AW
+   poll loop as a foreground wait, never via `run_in_background` absent
+   the confirmed condition — see
+   [idd-ci.instructions.md's Wake-up
+   discipline](idd-ci.instructions.md#wake-up-discipline).
    Re-fetch the HEAD SHA:
 
    ```sh
@@ -281,7 +286,8 @@ Before any mutating action in F3, apply the
      `OUTDATED` only after merge, once the marker is no longer needed
      for resume, advisory wait, or review-currency checks. Candidate
      prefixes: `<!-- review-watermark:`, `<!-- review-baseline:`,
-     `advisory-wait:`, `advisory-wait-recovery:`, `<!-- advisory-wait:`.
+     `advisory-wait:`, `advisory-wait-recovery:`, `<!-- advisory-wait:`,
+     `advisory-reroll:`.
    - Do not minimize comments with unresolved maintainer decisions,
      active holds, failed-CI context maintainers still need,
      non-operational human discussion, or content still in active F2/F3
@@ -300,11 +306,18 @@ Before any mutating action in F3, apply the
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a
    `<!-- idd-cleanup-evidence:` comment recording a successful outcome
-   (`applied` or `clean`) — for example one the `post-merge-cleanup`
-   workflow posted within seconds of the merge — to avoid a duplicate
-   success record; otherwise post (a fresh success record, or a
-   correction of an existing `failed` / `incomplete` /
-   `permission-blocked` record).
+   (`applied` or `clean`) **whose author is a trusted marker actor**
+   (`github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
+   under, or a configured `trustedMarkerActors` login) — for example one
+   the `post-merge-cleanup` workflow posted within seconds of the merge —
+   to avoid a duplicate success record. An untrusted commenter's
+   marker-prefixed comment never counts as evidence and must not suppress
+   this post — the same trust-scoping every other IDD operational marker
+   already applies (see the shared
+   [Trusted marker actors](idd-overview-core.instructions.md#trusted-marker-actors)
+   rule). Otherwise post (a fresh success record, or a correction of an
+   existing `failed` / `incomplete` / `permission-blocked` record, or a
+   correction of an untrusted-author record).
 
    Evaluate the dry-run `status` field (this is a dry-run status; apply
    mode emits different values and is never invoked unless dry-run
@@ -332,10 +345,32 @@ Before any mutating action in F3, apply the
      `viewer-cannot-minimize` counts for `applied`, or a converged
      `clean` record) so this run's work is recorded. Proceed to step 3.
 
-     If the apply `status` is `failed` or `incomplete`: post the
-     cleanup-failure comment format instead, including the
-     `viewer-cannot-minimize` count when non-zero. Explicit evidence,
-     not a merge gate — the merge already succeeded. Proceed to step 3.
+     The helper internally retries a whole scan-and-minimize pass, bounded,
+     when a fresh rescan still reports candidates after applying (a
+     candidate that only became eligible after the previous pass, e.g.
+     GraphQL read-after-write lag) — the common case still converges to
+     `applied`/`clean` within this one invocation. If the output also
+     reports `retryBoundExhausted: true` (visible as
+     `retryBoundExhausted=true` in table format), the retry bound was
+     reached while a rescan still found candidates. Route by the apply
+     `status` exactly as above, even then: if `status` is still
+     `applied`/`clean`, follow that evidence-comment path and note the
+     `retryAttempts` count as an informational, non-blocking
+     residual-lag signal rather than a defect; if `status` came back
+     `incomplete` (the fresh rescan found a genuine permission-blocked
+     remainder) or `failed`, follow the `failed`/`incomplete`
+     cleanup-failure path below instead — `retryBoundExhausted: true`
+     never overrides a non-success `status`.
+
+     If the apply `status` is `failed`, `incomplete`, or
+     `rescan-failed`: post the cleanup-failure comment format instead,
+     including the `viewer-cannot-minimize` count when non-zero.
+     `rescan-failed` means the confirming rescan itself errored after a
+     mutation (already-applied work is preserved in the report but
+     convergence was never confirmed) — note that distinction in the
+     comment and re-run `--apply` to confirm convergence. Explicit
+     evidence, not a merge gate — the merge already succeeded. Proceed
+     to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates found.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -306,18 +306,20 @@ Before any mutating action in F3, apply the
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a
    `<!-- idd-cleanup-evidence:` comment recording a successful outcome
-   (`applied` or `clean`) **whose author is a trusted marker actor**
-   (`github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
-   under, or a configured `trustedMarkerActors` login) — for example one
-   the `post-merge-cleanup` workflow posted within seconds of the merge —
-   to avoid a duplicate success record. An untrusted commenter's
-   marker-prefixed comment never counts as evidence and must not suppress
-   this post — the same trust-scoping every other IDD operational marker
-   already applies (see the shared
+   (`applied` or `clean`) **whose author is a trusted marker actor** —
+   the current session actor, a configured `trustedMarkerActors` login,
+   or another configured trusted bot/GitHub App login for IDD automation
+   (see the shared
    [Trusted marker actors](idd-overview-core.instructions.md#trusted-marker-actors)
-   rule). Otherwise post (a fresh success record, or a correction of an
-   existing `failed` / `incomplete` / `permission-blocked` record, or a
-   correction of an untrusted-author record).
+   rule; the identity `post-merge-cleanup.yml` posts under, commonly
+   `github-actions[bot]`, only qualifies when the repository has
+   actually configured it as trusted) — to avoid a duplicate success
+   record. An untrusted commenter's marker-prefixed comment never counts
+   as evidence and must not suppress this post — the same trust-scoping
+   every other IDD operational marker already applies. Otherwise post (a
+   fresh success record, or a correction of an existing `failed` /
+   `incomplete` / `permission-blocked` record, or a correction of an
+   untrusted-author record).
 
    Evaluate the dry-run `status` field (this is a dry-run status; apply
    mode emits different values and is never invoked unless dry-run

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,12 +86,12 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-In non-interactive agent or CI environments where GPG pinentry cannot be
-presented, add `--no-gpg-sign` to all `git commit` and `git merge`
-commands to prevent blocking.
+When it blocks, check `docs/idd-helper-scripts.md`'s Signed-Commit
+Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
+on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments at the time they are made. This ensures that any agent resuming
+comments as they happen. This ensures that any agent resuming
 without session context can understand the current state and continue
 correctly. Do not rely on session memory alone for information that
 another agent may need.

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -33,8 +33,8 @@ post via direct HTTP `POST` with a JSON body; see
 `docs/idd-helper-scripts.md` for the full `gh api` pitfalls. When
 helper runtime is enabled, the `post-idd-marker` helper (`--type claim
 --target issue <number> --apply` plus the claim fields) posts this
-marker through that JSON path (dry-run, posting nothing, without
-`--apply`); the direct `POST` stays the canonical fallback.
+marker through that JSON path (dry-run without `--apply`); the direct
+`POST` is the fallback.
 
 Every new HTML-comment operational marker must include a short visible
 note after the token: `review-watermark`/`review-baseline` use the
@@ -52,11 +52,9 @@ but never create new hidden-only claim comments.
   and is the portable ownership token used with trusted actor and
   session-record checks. Generate a fresh value on every fresh claim or
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
-  that already-verified claim. A matching `{agent-id}` is never
-  ownership proof by itself, because separate live sessions can share
-  the same agent ID. Reading an existing `{claim-id}` from issue comments
-  during discovery or resume does not by itself prove ownership; the
-  current session must have already recorded that token before the
+  that already-verified claim. Reading an existing `{claim-id}` from
+  issue comments does not by itself prove ownership; the current
+  session must have recorded that token before the
   revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
@@ -75,8 +73,7 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 When helper runtime is enabled, post this with `post-idd-marker --type
 unclaim --target issue <number> --apply` (plus agent-id / claim-id /
 timestamp; see `docs/idd-helper-scripts.md`); without `--apply` it is
-dry-run. The direct HTTP `POST` above is the fallback when helper
-runtime is unavailable.
+dry-run. The direct HTTP `POST` above is the fallback.
 
 ## Trusted marker actors
 
@@ -223,6 +220,9 @@ Out of scope and explicitly **not** blocked:
 - F4 post-merge cleanup (F4 itself removes the sibling worktree;
   subsequent local `main` updates run from the primary worktree by
   design).
+- [Operator-present release](idd-resume.instructions.md#operator-present-release)
+  steps 1-2 (pre-claim for the resuming session; the issue's own
+  active claim is untouched until step 2).
 
 The claim and cwd checks are read-only and pre-mutation; the lock
 acquisition is the final local guard. When in scope, all of these checks
@@ -297,11 +297,11 @@ file that matches your current situation.
 | --- | --- |
 | Starting fresh (no active claim) | `idd-discover.instructions.md`, then `idd-claim.instructions.md` |
 | Starting fresh with one explicit issue target | `idd-discover.instructions.md` A0-T, then `idd-claim.instructions.md` |
-| Resuming after crash / rate-limit / handoff | `idd-resume.instructions.md` |
+| Resuming after crash / rate-limit / handoff / operator-present deliberate pause | `idd-resume.instructions.md` |
 | Claimed, branch exists, no PR yet | `idd-work.instructions.md` |
 | PR open, CI running, no reviews yet | `idd-pr-submit.instructions.md` |
 | PR open, CI running, reviews exist | `idd-review-snapshot.instructions.md` (E1–E3) |
-| PR open, CI passed, no reviews yet | `idd-review-snapshot.instructions.md` (E3 empty-list → merge) |
+| PR open, CI passed, no reviews yet | `idd-review-snapshot.instructions.md` (E3 empty-list → branch-sync → F1) |
 | PR open, CI passed, reviews pending | `idd-review-snapshot.instructions.md` |
 | Snapshot done, ReviewItems_snapshot non-empty | `idd-review-triage.instructions.md` (E4–E8) |
 | Review feedback accepted, pushing fixes | `idd-review-fix.instructions.md` |

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -133,6 +133,26 @@ when one exists:
   Include only context grounded in the issue discussion, commits, diff,
   or explicit operator instructions; omit rather than speculate.
 
+### PR body language
+
+The PR body's prose sections above (summary, background/rationale,
+follow-up notes) follow the resolved `authoringLanguage` value from
+`.github/idd/config.json`: a fixed language tag when configured, the
+claimed issue's own body language when the value is `match-source`
+(this file's unattended-execution case, with no live operator), or
+English when the field is absent. See the
+[Authoring Language](../../docs/customization.md#authoring-language)
+section for the full field definition.
+
+This never changes a machine-parsed marker or an exact-regex-matched
+visible line, which always stays in its canonical form regardless of
+`authoringLanguage`. Concretely here, the closing keyword line below
+(`Closes #N` and its variants) must keep its exact English keyword
+form: GitHub's own closing-keyword parser and this file's D3.5
+verification regex both match only the English keyword forms
+(`close[sd]?`/`fix(e[sd])?`/`resolve[sd]?`), so translating that line
+would silently break auto-close detection.
+
 ### Closing keyword
 
 The closing keyword must appear in the PR **body** (not the title) as
@@ -147,7 +167,10 @@ constraint applies only to the actual PR body content that GitHub
 must parse.
 
 GitHub recognizes the following keyword forms: close, closes, closed,
-fix, fixes, fixed, resolve, resolves, resolved.
+fix, fixes, fixed, resolve, resolves, resolved. GitHub's merge-time
+detection reads these same forms in the branch's commit messages too,
+not only the PR body — see Mirror false-positive below for the
+structural-separation rule that covers both surfaces.
 
 #### Anti-patterns
 
@@ -165,28 +188,35 @@ merge and the issue↔PR linking surfaces (sidebar, timeline) will not
 populate.
 
 **Mirror false-positive — negation-blind detection**: the same literal
-matching runs in the other direction too. GitHub's detector matches a
-recognized keyword form immediately adjacent to a `#N` reference and
-has no concept of negation — wrapping the keyword in surrounding
-"not" / "deliberately" / "isn't" wording does not stop detection when
-the keyword itself still sits next to the `#N` it must not close. Keep
-every recognized keyword form (`close`, `closes`, `closed`, `fix`,
-`fixes`, `fixed`, `resolve`, `resolves`, `resolved`) structurally apart
-from any reference it must not close:
+matching runs in the other direction too, and it is not limited to the
+PR body — GitHub's merge-time scan reads the same recognized keyword
+forms in the branch's commit messages (subject and body) as well.
+GitHub's detector matches a recognized keyword form immediately
+adjacent to a `#N` reference and has no concept of negation —
+wrapping the keyword in surrounding "not" / "deliberately" / "isn't"
+wording does not stop detection when the keyword itself still sits
+next to the `#N` it must not close, whether that text lives in the PR
+body or in a commit message. Keep every recognized keyword form
+(`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`,
+`resolves`, `resolved`) structurally apart from any reference it must
+not close, in both locations:
 
 - Risky — a keyword sits directly before the reference, even inside a
-  negation clause: "this PR does not close #42" (`close` is
-  immediately adjacent to `#42`; GitHub cannot see the "not").
+  negation clause, whether in the PR body or a commit message: "this
+  PR does not close #42" (`close` is immediately adjacent to `#42`;
+  GitHub cannot see the "not").
 - Safe — reorder so no recognized keyword is adjacent to the
   reference: "Refs #42 (deliberately not a closing keyword — see the
   discussion there for why this PR does not resolve it directly)".
   Here `resolve` is followed by "it", not a `#N` token, so nothing
-  adjacent to `#42` matches.
+  adjacent to `#42` matches. The same reordering works verbatim inside
+  a commit subject or body.
 
 Do not rely on careful phrasing alone as the only safeguard — the
-strengthened check in D3.5 below verifies `closingIssuesReferences`
-against the deliberate closing set exactly, catching a spurious extra
-close even if phrasing slips.
+strengthened checks in D3.5 below verify `closingIssuesReferences`
+against the deliberate closing set exactly and scan the branch's own
+commit messages, catching a spurious extra close even if phrasing
+slips.
 
 #### Multiple closing issues
 
@@ -275,11 +305,75 @@ completion.
    hold note on the issue citing the PR URL and stop. Do not proceed to
    D4.
 
+7. **Scan the branch's own commit messages**: GitHub's merge-time
+   closing-keyword scan also reads commit messages (subject and body),
+   not only the PR body, so a stray keyword there can auto-close an
+   issue outside the deliberate set even when the PR body is clean.
+   List the branch's own commits, using a visible delimiter rather
+   than a NUL byte so common terminals and search tools don't treat
+   the output as binary:
+
+   ```sh
+   git log origin/main..HEAD --pretty=format:'%H%n%B%n===commit-boundary==='
+   ```
+
+   For each commit's full message, search using step 3's same keyword
+   alternation, generalized to any issue number instead of the fixed
+   `<N>`:
+
+   ```text
+   (?im)\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b
+   ```
+
+   A match against any issue number in the deliberate closing set from
+   D3 is expected (deliberate — this covers both the single-issue `<N>`
+   case and "Multiple closing issues" above); only a captured number
+   **outside** that set is a stray commit-message close.
+
+   **On a stray match**: amend the offending commit (`git commit
+   --amend` for the tip commit, or an interactive rebase for an
+   earlier one) using the same safe reordering as the Mirror
+   false-positive example above. If the branch already carries a merge
+   commit (for example, from an E-phase `main` sync), rebase with
+   `--rebase-merges` instead of a plain interactive rebase, so the
+   merge and its recorded conflict resolution aren't silently
+   linearized or dropped. On a signed-commit repo whose primary
+   signing is non-interactive-hostile, run the amend or rebase through
+   the same D1 fallback-signing wrapper noted above, including any
+   rebase continuation — the plain command can stall the same way D1
+   already documents. Then force-push the correction (`git push
+   --force-with-lease`) only when repository policy permits
+   force-pushing a published branch, mirroring D2's own force-push
+   restriction; if it does not, hold for operator intervention instead
+   of rewriting published history. **Amend before merge** — this scan
+   runs at merge time, so the fix must land before the PR merges; a
+   commit message caught only after merge cannot be amended, and
+   recovery requires reopening the affected issue by hand. Repeat this
+   step once after the amendment. If it still finds a stray match,
+   post a hold note on the issue citing the PR URL and stop. Do not
+   proceed to D4.
+
+   **Re-run before merge**: this scan only covers commits present at
+   D3.5 time. Later branch commits — accepted review fixes
+   (`idd-review-fix.instructions.md` E9-E12) or a `main` merge — are
+   not automatically covered; re-run this step against the final HEAD
+   before F3 merges.
+
 ## D4 — Wait for CI
 
 Schedule a wake, or background this wait only if the
 topology-safety condition holds (confirmed to route completion back to
-this turn); otherwise wait synchronously. Delegate polling mechanics to
+this turn); otherwise wait synchronously — block with:
+
+- `gh run watch <run-id> --exit-status` (single workflow run; not
+  usable on a fine-grained PAT)
+- `gh pr checks <pr-number> --watch --required` (PR required-check
+  rollup)
+
+See [idd-ci.instructions.md's Wake-up
+discipline](idd-ci.instructions.md#wake-up-discipline) for the
+caveats on both. Do not `run_in_background` this wait absent the
+confirmed condition above. Delegate polling mechanics to
 `idd-ci.instructions.md`.
 
 - **On success** → proceed to `idd-review-snapshot.instructions.md`

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -314,8 +314,12 @@ completion.
    the output as binary:
 
    ```sh
-   git log origin/main..HEAD --pretty=format:'%H%n%B%n===commit-boundary==='
+   git log origin/HEAD..HEAD --pretty=format:'%H%n%B%n===commit-boundary==='
    ```
+
+   Use `origin/HEAD` (the remote's own default-branch pointer), not a
+   hardcoded `origin/main`, so this command works unchanged on
+   repositories whose default branch is `master` or any other name.
 
    For each commit's full message, search using step 3's same keyword
    alternation, generalized to any issue number instead of the fixed

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -150,11 +150,24 @@ nonce was recorded for the active claim.
   A current-claim agent's own post-watermark disposition replies are
   expected convergence activity, not reviewer input, and the watermark
   refresh on the E-phase branch-sync `clean` / `behind-no-conflict`
-  route already re-covers them. If a return-to-E1 is triggered solely by
-  those replies, refresh the watermark instead.
+  route already re-covers them. The same holds for any other
+  own-agent-authored procedural or status comment posted after the
+  watermark (for example, a hold comment explaining a blocker) that
+  introduces no reviewer or bot finding of its own — it is expected
+  convergence activity too, though the branch-sync route's own
+  refresh does not independently re-cover it. If a return-to-E1 is
+  triggered solely by disposition replies, other own-agent
+  procedural or status comments of that kind, or both, refresh the
+  watermark directly instead; every other F2 trigger and gate is
+  unaffected.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
-  route completion back to this turn) — otherwise wait synchronously.
+  route completion back to this turn) — otherwise wait synchronously:
+  no single `gh` command blocks on Copilot review state (unlike a CI
+  run), so run the AW poll loop below as a foreground wait, never via
+  `run_in_background` absent the confirmed condition — see
+  [idd-ci.instructions.md's Wake-up
+  discipline](idd-ci.instructions.md#wake-up-discipline).
   `PR_HEAD_SHA` is already available from the review-currency check
   above. Apply the advisory-wait protocol
   (`idd-advisory-wait.instructions.md`):

--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -87,6 +87,14 @@ the manual quiet-window check described in S2.
   stalled-session takeover case. Return to
   `idd-resume.instructions.md` Step 1 and use the forced-handoff route
   instead. Do not apply the quiet-window or stale-threshold gates here.
+- If the active claim satisfies Step 0's full operator-present release
+  condition in `idd-resume.instructions.md` — including that this
+  session has received the operator-supplied input — this is not a
+  stalled-session takeover case either. Return to
+  `idd-resume.instructions.md` Step 0 and use that path instead. Do not
+  apply the quiet-window or stale-threshold gates here. Pause evidence
+  alone, with the input not yet received, does not match this bullet;
+  fall through to the next.
 - If the active claim belongs to another `{claim-id}`, continue.
 
 ### S2 — Quiet-window check (stall evidence, not ownership transfer)

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -1,9 +1,12 @@
 # IDD — Resume Phase
 
 Use this file when taking over a crashed or rate-limited session with no
-prior session context. Read `idd-overview-core.instructions.md` for shared
-definitions (claim format, stale threshold, abort, hold). For full narrative
-detail on each routing branch, see
+prior session context, or when a fresh session resumes an issue whose prior
+session left an active claim after its own deliberate, announced pause (see
+[Operator-present release](#operator-present-release)
+below). Read `idd-overview-core.instructions.md` for shared definitions
+(claim format, stale threshold, abort, hold). For full narrative detail on
+each routing branch, see
 [`docs/idd-resume-detail.md`](../../docs/idd-resume-detail.md).
 
 Resume stale checks use the `claim-stale-age` policy default from
@@ -32,13 +35,14 @@ Collect all signals before routing. Use GitHub server timestamps only.
 
 Evaluate in order; take the first matching row.
 
-| Condition                                                                                 | Route                                                              |
-| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Issue closed or PR merged                                                                 | Step 1 (cleanup only)                                              |
-| `forced-handoff: human-gated` + valid evidence matching active/inheritable state          | Step 1 forced-handoff path (skip stall check)                      |
-| `forced-handoff: human-gated` + evidence exists but mismatches live claim/branch/PR state | STOP — report mismatch; do not claim, push, or mutate review state |
-| Non-owned active claim + no valid forced-handoff evidence                                 | `idd-resume-stall.instructions.md`; then Step 1 if unblocked       |
-| Otherwise                                                                                 | Step 1                                                             |
+| Condition                                                                                                               | Route                                                              |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Issue closed or PR merged                                                                                               | Step 1 (cleanup only)                                              |
+| `forced-handoff: human-gated` + valid evidence matching active/inheritable state                                        | Step 1 forced-handoff path (skip stall check)                      |
+| `forced-handoff: human-gated` + evidence exists but mismatches live claim/branch/PR state                               | STOP — report mismatch; do not claim, push, or mutate review state |
+| Non-owned active claim + evidence satisfying the operator-present release path below + operator-supplied input received | Operator-present release path (below); skip the stall file         |
+| Non-owned active claim + no valid forced-handoff evidence                                                               | `idd-resume-stall.instructions.md`; then Step 1 if unblocked       |
+| Otherwise                                                                                                               | Step 1                                                             |
 
 Autopilot and unattended agents must never invent, request, or broaden
 forced handoff; they may only consume already-recorded human-gated evidence.
@@ -63,6 +67,56 @@ If stalled-session routing returns hold/inconclusive, stop.
   `instructions-only` (no helper runtime vended), the operator instead
   posts the manual consent text and marker documented in
   `docs/customization.md` themselves.
+
+### Operator-present release
+
+Use this path only when the non-owned active claim carries a
+claimant-authored comment, postdating that claim's latest valid
+`claimed-by` `created_at`, explicitly recording a deliberate pause and
+the awaited input, with no later trusted claimant activity (heartbeat,
+branch/PR movement, or claimant-authored comment/review activity --
+this path's own step-1 input comment excepted) postdating that
+comment — later activity means work resumed, so fall back to the
+stale-takeover procedure in `idd-resume-stall.instructions.md`
+instead, per the shared fail-closed default. The needs-decision label
+(`labels.needsDecisionLabelName`) can corroborate but never substitute
+-- automation can apply it unattended. This session must have received
+the awaited operator input. Mere silence or staleness does not qualify
+either.
+
+Steps 1-2 are pre-claim actions, like a fresh A5 claim's own pre-claim
+state; the shared claim revalidation gate's own-claim-id precondition
+attaches from step 4, not before. The operator's chat input is never
+itself the release: it is recorded as the separate normal comment in
+step 1, and the trusted-marker-actor `unclaimed-by` in step 2 (rule 5)
+alone carries the canonical marker body (same nothing-appended rule as
+other operational markers) and performs the release. This path is
+unrelated to the TTY-gated forced-handoff safeguard above: it opts
+into no `forcedHandoff` policy and requires no `idd-force-handoff`
+`y/N` confirmation, and it does not loosen that safeguard.
+
+Sequence:
+
+1. Post the operator-supplied input (with any acceptance-criteria
+   amendment it implies) as a normal issue comment. If a configured
+   needs-decision/blocked-by-human label is present, also ask the
+   operator to remove it -- a human action only, never this session.
+2. Re-read the issue and confirm the active claim and the predicate
+   above still hold — stop and restart if either changed since Step 0 —
+   then post a trusted-marker-actor-authored `unclaimed-by` matching the
+   held claim's exact `{agent-id}` and `{claim-id}` (Claim-state
+   parsing rule 5, `idd-claim.instructions.md`). GitHub comments have no
+   compare-and-swap, so this narrows, not closes, the recheck-to-release
+   window; an accepted, bounded risk, since a resumed claimant's own
+   next revalidation check surfaces the loss rather than staying silent.
+3. Re-read the issue and confirm it now parses as unclaimed — the
+   release registered — before continuing; if not, stop and restart.
+4. Post a normal fresh A5 claim with `supersedes: none`, then continue
+   to Step 1.
+
+The 30-minute quiet window and 24h stale threshold in
+`idd-resume-stall.instructions.md` surface an _unannounced_ stall
+only; this path's own already-announced pause waits on neither.
 
 ## Step 1 — Identify claim state
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -305,7 +305,9 @@ hold/escalation path above.
 Schedule a wake, or background this wait only if the
 topology-safety condition holds (confirmed to route completion back to
 this turn); otherwise wait synchronously — see
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline).
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline) for
+the blocking commands and caveats; do not `run_in_background` this
+wait absent the confirmed condition above.
 
 Use `idd-ci.instructions.md` for the polling mechanics and timing. E15
 reuses the same resolved `ciWait.runningTimeout`,

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -111,8 +111,9 @@ single italic note — any deviation fails the parser's whole-body anchor
 and the comment isn't recognized as a live watermark, though it is
 still detectable as a malformed marker
 (`detectMalformedOperationalMarker` in `marker-helpers.mts`). See
-`idd-claim.instructions.md` for the full rule and the related
-disposition-marker no-code-fence note.
+`idd-claim.instructions.md` for the full rule and
+`idd-review-triage.instructions.md` for the related disposition-marker
+no-code-fence note.
 
 - **`{head-SHA}`**: the value read at the very start of Step 1, before
   any fetching. F2 uses this to detect pushes that occurred between E1's

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -24,6 +24,8 @@ For each item in ReviewItems_snapshot, first classify it:
   included by E1 for traceability, even when they do not require a code
   change.
 - If classification is ambiguous, default to PATH A.
+- Record each PATH A actor's permission standing (CODEOWNER, required
+  reviewer, Triage/Write/Maintain/Admin, or none) — E5's cap reads it.
 
 **Advisory non-review notice.** Before scoring a PATH B item, decide
 whether it is a _completed_ advisory review of the current HEAD or an
@@ -39,7 +41,8 @@ Then apply path-specific scoring:
 
 - **PATH A**: assess severity/relevance to PR intent. **High** (safety,
   correctness, requirement violations, CI stability) → **Accept
-  forced**; **Low** (minor, unrelated to PR intent) → **Reject
+  forced**, gated by "Verify before accept" and the actor-permission cap
+  (E5); **Low** (minor, unrelated to PR intent) → **Reject
   recommended**; **Medium** → judge by context.
 - **PATH B**: no High/Medium/Low. Score only a _completed_ review of
   current HEAD as `Accepted` (confirmed/useful) or `Rejected`
@@ -49,19 +52,49 @@ Then apply path-specific scoring:
 
 Record a path-specific disposition for every item:
 
-- **PATH A**: High-severity items are Accepted automatically;
-  Medium/Low require an explicit Accept or Reject decision.
+- **PATH A**: High-severity items reach Accepted only via "Verify
+  before accept" below, or — when the actor-permission cap applies —
+  an explicit maintainer confirmation reply; Medium/Low require an
+  explicit Accept or Reject decision.
 - **PATH B** (a _completed_ review of the current HEAD): `Accepted`
   means the advisory confirms the implementation or captures useful
   context; `Rejected` means noted, no action required. An advisory
   non-review notice (E4) is **not scored** here — record it, but always
   as `Rejected` per the E6 non-review-notice rule.
 
+**Actor-permission cap (PATH A).** Before an Accept, check whether the
+actor is a CODEOWNER, required reviewer, or holds Triage/Write/Maintain/
+Admin access (`GET
+/repos/{owner}/{repo}/collaborators/{username}/permission`). Absent all
+three, assertion alone never reaches Accept forced — only "Verify before
+accept" confirming the claim, or an explicit maintainer confirmation
+reply, gets it there. Otherwise cap it at Rejected with the reasoned
+reply E6 already requires. CODEOWNER/required-reviewer AMD handling is
+unchanged.
+
 Accepted PATH B items do **not** enter review-fix. They are fully
 handled in E6-E7.
 
+**Verify before accept (PATH A and PATH B).** A PATH A or PATH B item
+often asserts a fact — about safety, correctness, the runtime, CI, or an
+artifact. Before `Accept`ing it, confirm the claim against live evidence
+(a code read, reproduction, or an equivalent check), not the comment
+text alone — the actor-permission cap above is the only exception, via
+maintainer confirmation for an unprivileged PATH A actor: confirmed →
+`Accept` and act; **false on the live evidence** → disposition it
+`Rejected` and cite the contradicting evidence (the code as read, the
+real run conclusion, file contents, or artifact) — a verified-false
+claim is a reasoned rejection, not an action item (scoped to this
+verification only — not E4/E5's Low-severity/no-action `Rejected`
+routes); **inconclusive** (neither confirmed nor contradicted — the
+needed check has no route here, not merely low confidence) → for an
+actor-permission-capped, reviewer-feedback PATH A item, route it
+through the CODEOWNER/required-reviewer AMD hold (E6) instead of
+`Rejected`, using E6's marker (a critique-pass finding stays under
+the unchanged cap above).
+
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
-Before verification below, check whether a new PATH B item — a review
+Before verification above, check whether a new PATH B item — a review
 thread or a regular comment (E6 supports both PATH B sources) — matches
 an entry in this PR's resolved-thread index
 (`idd-review-snapshot.instructions.md` E1 Step 3). Matching is scoped to
@@ -70,9 +103,8 @@ state of its own, but can still match a prior resolved thread's claim.
 
 - Match the new item against the index by file area and substantive
   claim, requiring the identical claim rather than merely a related
-  topic in the same file. (For example, a prior "raw SQL concatenation"
-  rejection on `db/query.mts` does not match a new "missing index"
-  comment on the same file: same file area, different claim.)
+  topic in the same file (same file but a different claim is not a
+  match).
 - On a match, open the linked prior thread — the index disposition alone
   is not proof. Re-confirm the new item raises that **same underlying
   claim**, not just a related one, then confirm the prior thread
@@ -90,37 +122,19 @@ state of its own, but can still match a prior resolved thread's claim.
   thread; reply only for a regular comment. Every recurrence still gets
   its own reply, so the 1:1 disposition-count / no-combined-replies rule
   (E6) is unchanged — only the reply's content is shortcut.
-- **Fall through** unchanged to "Verify before accept (PATH B)" below
+- **Fall through** unchanged to "Verify before accept" above
   when there is no match, re-confirmation shows the new item is not
   actually the same underlying claim, the matched disposition is not a
   reasoned rejection with evidence, the cited evidence no longer holds
   at current HEAD, or the new occurrence carries genuinely new
   information the prior thread did not address.
 
-**Worked example.** A bot re-raises "this workflow step needs
-`contents: write`" two rounds after an identical claim on the same file
-was rejected with evidence (the step only uploads an artifact). Confirm
-the claim and evidence still hold at current HEAD, reply `**Rejected**
-— same claim as {prior thread URL}: verified false there; unchanged at
-current HEAD.`, then resolve the thread.
-
-**Verify before accept (PATH B).** A PATH B advisory often asserts a fact
-about the runtime, CI, or an artifact. Before `Accept`ing it, verify the
-claim against the live runtime / artifact / CI run, not the comment text
-alone: confirmed → `Accept` and act; **false on the live evidence** →
-disposition it `Rejected` and cite the contradicting evidence (the real
-run conclusion, file contents, or artifact) — a verified-false advisory
-is a reasoned rejection, not an action item.
-
 **Reasoned-rejection convergence.** The iterate-to-zero loop may converge
 by reasoned rejection of peripheral or verified-false items — not every
 comment needs a code change. Record the reason in the disposition reply;
-"a bot raised it" alone never forces a change.
-
-**Worked example.** A bot flags a "credential leak" on a config-only file
-that in fact holds only public placeholders. Reply `**Rejected** —
-verified: the flagged file contains only public placeholders; no
-credential is present.`
+"a bot raised it" alone never forces a change (e.g., a "credential
+leak" flag on a placeholders-only config file:
+`**Rejected** — verified placeholders-only`).
 
 ## E6 — Post disposition replies
 
@@ -132,15 +146,19 @@ PATH A — Accepted items:
   reviewer feedback is replied to after the fix work in
   `idd-review-fix.instructions.md`.
 
-PATH A — Rejected reviewer feedback:
+PATH A — Rejected/inconclusive reviewer feedback:
 
-For each Rejected PATH A item whose source is reviewer feedback:
+For each Rejected or inconclusive (E5) PATH A item whose source is
+reviewer feedback:
 
-- Reply using the format: `**Rejected** — {reason}`
-- **Exception**: if the source is a CODEOWNER or required reviewer, do
-  not reject unilaterally. Reply using the format:
-  `**Awaiting maintainer decision** — {your reasoning}` and wait for the
-  maintainer's response.
+- Reply using the format: `**Rejected** — {reason}` — unless the
+  Exception below applies.
+- **Exception**: if the source is a CODEOWNER or required reviewer, or
+  the item is E5's inconclusive outcome, do not reject unilaterally.
+  Reply using the format:
+  `**Awaiting maintainer decision** — {your reasoning}` (name the
+  unavailable check when inconclusive) and wait for the maintainer's
+  response.
 - After posting your reply, **immediately resolve the thread** — except
   for `**Awaiting maintainer decision**`. When helper runtime is enabled,
   the profile-selected resolve-review-thread command (`--pr <number>
@@ -158,8 +176,7 @@ For each Rejected PATH A item whose source is reviewer feedback:
   (CODEOWNER/required-reviewer feedback with no thread) cannot use that
   gate structurally — instead post the hold comment stating you will
   **not** merge until the decision appears, and stop. Either way, wait
-  for the response in a future E1 pass: agreement closes the AMD (reply
-  to confirm, remove the hold); an override moves it to Accepted.
+  for the response in a future E1 pass (see the transitions below).
 - **When an `Awaiting maintainer decision` thread re-appears in ReviewItems_snapshot**:
   scan the activity universe for a **qualifying response** — a reply on
   this thread, or a separate comment/review that clearly references
@@ -176,13 +193,12 @@ For each Rejected PATH A item whose source is reviewer feedback:
   in a future E1 pass.
 - **When the maintainer eventually responds** (their response surfaces
   in a future E1 pass as an unresolved thread or new reply):
-  - If the maintainer **agrees with your rejection**: reply summarizing
+  - If the maintainer **agrees no action is needed**: reply summarizing
     the agreed decision (e.g.,
     `**Rejection confirmed by maintainer** — {summary}`) and resolve the
     thread.
-  - If the maintainer **disagrees**: move the item from Rejected to
-    Accepted and proceed through the fix flow. Resolve the thread after
-    fixing.
+  - If the maintainer **disagrees**: move the item to Accepted and
+    proceed through the fix flow. Resolve the thread after fixing.
   - If the maintainer's response arrived in a separate PR comment or
     review rather than in the original thread: mirror the decision onto
     the original thread and resolve the thread. Also **reply to the
@@ -230,7 +246,7 @@ Use these prefixes so that disposition is always unambiguous:
 - PATH B acceptance marker (only for a _completed_ review of the current
   HEAD): `**Accepted** — {what the advisory comment confirmed}`
 - Ordinary rejection: `**Rejected** — {reason}`
-- CODEOWNER / required reviewer exception:
+- CODEOWNER / required reviewer, or inconclusive (E5), exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
 Two requirements make the F2/F3 disposition-evidence gate recognize an
@@ -336,11 +352,14 @@ review state.
 Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
-- Every PATH A item has a recorded classification and an Accept or
-  Reject decision.
-- Every Rejected PATH A item whose source is reviewer feedback has the
-  required rejection or `**Awaiting maintainer decision**` reply posted,
-  and any non-AMD thread resolution is complete.
+- Every PATH A item has a recorded classification and an Accept,
+  Reject, or AMD decision (including E5 inconclusive). Every Accepted
+  item cites its "Verify before accept" evidence, or the maintainer
+  confirmation reply when actor-permission capped.
+- Every Rejected or inconclusive PATH A item whose source is reviewer
+  feedback has the required rejection or
+  `**Awaiting maintainer decision**` reply posted, and any non-AMD
+  thread resolution is complete.
 - Every PATH B item has a posted `**Accepted**` or `**Rejected**`
   marker. Review threads are resolved immediately after the marker.
 - Only Accepted PATH A items remain candidates for

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -82,7 +82,16 @@ outside the selected roadmap graph.
   inside the recursive roadmap graph, preserve that evidence and treat
   the affected path as unresolved until the graph can be interpreted
   safely. Do not guess at a closure order when the traversal graph is
-  ambiguous.
+  ambiguous. **Root-preserving exemption for cycles only** (duplicate
+  references are unaffected): define the cycle's **segment** as the
+  suffix of the recorded path starting at the first occurrence of the
+  back-edge target. When the segment excludes the roadmap under audit
+  AND every node in it is CLOSED, treat the cycle as informational
+  provenance instead of a blocker, regardless of relationship type —
+  such a loop has no closure order left to get wrong. A cycle whose
+  segment includes the audited roadmap, or holds any node that is open,
+  inaccessible, unresolved, or absent from the traversal's node set,
+  still blocks.
 - If all referenced child and descendant work is closed or otherwise
   complete, compare the roadmap success criteria against the closed
   child issues, linked merged PRs, task-list state, follow-up comments,

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -242,5 +242,17 @@ and treat as a PASS so work is not blocked by agent capability limits.
 classify as `invalid` and stop rather than treating it as a PASS.
 Failing open on a safety check is a concrete security risk.
 
+**Escape-hatch acceptance criteria**: an either/or acceptance-criteria
+bullet where one branch is a substantive change and the other reads as
+"or document the gap/tradeoff" is not a Check 7 (Verifiability) PASS by
+default just because the second branch sounds safer. Worked example:
+"Add retry logic to the flaky network call, or document why retries are
+unsafe here" leaves an unresolved subjective call — whether a piece of
+documentation adequately discloses a known gap has no automated check
+unless the acceptance criteria state exactly what the documentation must
+say. Evaluate the documentation branch on its own merits, not as an
+automatic pass; if it only restates the bullet without disclosing the
+tradeoff, classify as `needs-decision` rather than PASS.
+
 After A4.5 passes, proceed to `idd-claim.instructions.md`; for rejected
 candidates follow the Failure Outcomes section above.

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -87,6 +87,18 @@ branch name with every `/` replaced by `-`.
 Example: repo `setup.windows`, branch `issue/123-add-foo` → worktree path
 `../setup.windows.issue-123-add-foo`.
 
+**Harness-native worktree tools**: an agent harness's own worktree
+primitive — for example, Claude Code's `EnterWorktree` — is a third
+path outside the two enumerated below. Use one only when both its
+target directory can be pinned to the sibling path above and its
+branch can be pinned to the `issue/<number>-<slug>` branch — never a
+tool-chosen default of either. `EnterWorktree`'s create action always
+places the worktree under a harness-owned directory (observed as
+`.claude/worktrees/agent-<hash>`), never the sibling path above, so it
+can never satisfy the directory half of this rule — never use it to
+create the B1 worktree. When a harness-native tool cannot pin both, use
+the documented `git worktree add` path below (or WorkTrunk) instead.
+
 **Step 1 — Check for orphaned path**: if the target path already exists
 but is not listed in `git worktree list`, stop and report for manual
 cleanup before continuing.
@@ -115,8 +127,10 @@ If WorkTrunk is not available, choose the correct case:
 | Takeover — neither local nor remote (rare) | treat as fresh claim; preserve the inherited branch name |
 <!-- dprint-ignore-end -->
 
-For manual `git worktree add`, or WorkTrunk without an install hook,
-acquire the [worktree-local lock file](idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision)
+For manual `git worktree add`, WorkTrunk without an install hook, or a
+compliant pinned harness-native tool (per "Harness-native worktree
+tools" above), acquire the
+[worktree-local lock file](idd-claim.instructions.md#worktree-local-lock-file-same-machine-collision)
 immediately after the worktree exists, **before Step 3** —
 `install-deps` itself writes into the worktree and runs lifecycle
 hooks, so acquiring the lock any later leaves that install unprotected.
@@ -144,8 +158,9 @@ are installed:
   `[pre-start].install` in `.config/wt.toml`): The hook must acquire the
   lock before installing, as described above; after the hook succeeds,
   skip this step.
-- **Manual `git worktree add` or WorkTrunk without a hook**: `cd` into
-  the newly created worktree, then run **install-deps**.
+- **Manual `git worktree add`, WorkTrunk without a hook, or a
+  compliant pinned harness-native tool**: `cd` into the newly created
+  worktree, then run **install-deps**.
 
 `install-deps` must remain safe to rerun during retries, takeovers, and
 recreated worktrees without manual cleanup.

--- a/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -110,7 +110,7 @@ no `advisoryWait.*` config are: `requestCap` 30,
 | Outcome | E14 action |
 | --- | --- |
 | `SATISFIED` | proceed to CI wait |
-| `REQUEST_NEEDED` | remove the stale pending request if one exists, request Copilot, post the request marker, then poll |
+| `REQUEST_NEEDED` | `copilotPending`: false → request Copilot + marker, poll; true (no marker) → no `AW3-S` here — stop and ask |
 | `RECOVERY_NEEDED` | post the recovery marker (do not request another review), then poll |
 | `CAP_EXHAUSTED` | `phase-specific` (default): proceed to CI wait. `hold`: stop and ask (`HOLD`'s only route; see above) |
 | `WAIT` | keep polling |

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -20,9 +20,10 @@ CI-polling instructions instead of this file.
 
 - A required helper is missing, fails, returns invalid JSON, or
   disagrees with live state.
-- Any required-check discovery read below is unreadable (a confirmed
-  `403`, or an untrusted `404`) — the ruleset list, any per-ruleset
-  detail call, or the branch-protection read.
+- `requiredChecks.status` is `source-pinned` (a real, pinned gating
+  check whose provenance the helper cannot verify — its name may be
+  unresolvable, or resolvable-and-passing but not confirmably from the
+  pinned source).
 - A non-pass check is not clearly code-caused or recognized
   infra-flaky/pre-existing, except the sole-failing
   `idd-advisory-convergence` exception the caller's own routing names.
@@ -36,8 +37,9 @@ CI-polling instructions instead of this file.
 ## Helper-first canonical path
 
 1. Resolve policy: `node scripts/ci-wait-policy.mjs` (append
-   `--rerun-count <count>` for the rerun-budget decision). Resolve the
-   package-manager / ephemeral-npx equivalent from
+   `--run-id <run-id>` — preferred, derives the rerun budget from
+   `run_attempt` — or `--rerun-count <count>` as a manual fallback).
+   Resolve the package-manager / ephemeral-npx equivalent from
    `docs/idd-helper-scripts.md`. This helper already resolves
    `ciWait.*` from `.github/idd/config.json` and emits the final
    `runningTimeout` / `generationTimeout` / `rerunPolicy` values
@@ -68,24 +70,28 @@ hand:
 
 ## Required-check discovery
 
-Before interpreting checks, determine the required-check set:
+Never derive this by hand — the Helper-first canonical path's
+`ci-wait-state` call already resolves the required-check set as
+`requiredChecks`; manual `gh api .../rulesets` / `.../protection`
+derivation belongs only to `idd-ci.instructions.md` (the full-size
+CI-polling shared helper file), never this one. Read
+`requiredChecks.status`:
 
-1. `gh api repos/{owner}/{repo}/rulesets --paginate`, then
-   `gh api repos/{owner}/{repo}/rulesets/{ruleset-id}` for each id
-   returned.
-2. `gh api repos/{owner}/{repo}/branches/{url-encoded-base-branch}/protection`.
-3. A `403` on any of these reads is unreadable — stop and ask; never
-   substitute an empty result. Treat a `404` the same as a `403`
-   (unreadable) unless `.github/idd/config.json` sets
-   `ciGate.trustEmptyProtectionReads: true`, in which case a `404`
-   means genuinely empty.
-4. Union the enforcing-ruleset checks and branch-protection checks from
-   the genuine (non-unreadable) reads only.
-5. If neither source yields a required-check set and no read was
-   unreadable, derive from the PR head SHA's actual runs instead: all
-   passing → proceed to the caller's on-success target; any pending →
-   keep polling; any failing, or no runs at all → stop and ask. Never
-   treat an empty required-check set as a vacuous pass.
+- `success`: every required check passed — proceed per Interpretation
+  below.
+- `pending` or `missing`: keep polling (a required check is still
+  running, or one expected has not posted a result yet).
+- `failing`: at least one required check is non-passing — apply
+  Interpretation below to it.
+- `no-required-checks`: a repository can legitimately have none while
+  still running normal CI — fall back to `checks[]`'s own per-check
+  `status` (already bucketed by the helper as `success` / `pending` /
+  `failure` / `unknown`, distinct from step 2's raw-state normalization
+  below): every entry `success` → proceed; any `pending`/`unknown` →
+  keep polling (`unknown` isn't settled yet, so treat it like
+  `pending`); any `failure`, or `checks[]` itself empty → stop and ask.
+  Never treat an empty required-check set as a vacuous pass.
+- `source-pinned`: stop and ask (see Stop-and-ask conditions above).
 
 ## Polling algorithm
 
@@ -97,7 +103,9 @@ Before interpreting checks, determine the required-check set:
    Commit-Status `expected` → running; `failure` / `cancelled` /
    `timed_out` / `action_required` / `startup_failure` / `stale` →
    non-pass.
-3. Evaluate only checks in the required-check set.
+3. Evaluate only checks in the required-check set — except the
+   `no-required-checks` fallback above, which evaluates every present
+   check instead.
 4. Repeat at a reasonable interval until a terminal outcome below is
    reached. Anchor every timeout to the check's own server `startedAt`,
    never a client clock.

--- a/.github/instructions/lite/idd-claim-lite.instructions.md
+++ b/.github/instructions/lite/idd-claim-lite.instructions.md
@@ -1,7 +1,8 @@
 # IDD — Claim Phase (Lite) A5
 
 Lite profile for weak / local models. Same semantics as
-`idd-claim.instructions.md`. Prefer helpers over prose.
+`idd-claim.instructions.md`, except the forced-handoff bind below.
+Prefer helpers over prose.
 
 **Load this file alone** for the claim phase. Do not open the standard
 claim file in the same turn.
@@ -9,8 +10,7 @@ claim file in the same turn.
 **Scope note**: this file always covers a single, already-selected
 issue (the lite profile excludes open-ended Discover). Every "return
 to Discover and pick the next candidate" branch in the standard file
-therefore collapses to a single outcome here: **STOP and report; do
-not claim**. There is no fallback issue to select.
+collapses to a single outcome here: **STOP and report; do not claim**.
 
 ## Helper runtime contract
 
@@ -26,11 +26,11 @@ not claim**. There is no fallback issue to select.
 
 Every `node scripts/<name>.mjs` command below is the **source-repo /
 vendored-node** invocation form. Under `package-manager` /
-`ephemeral-npx` profiles, `scripts/` is not vendored into the repo —
-resolve each command's profile-selected equivalent from
-`docs/idd-helper-scripts.md` instead of running the vendored form
-verbatim. A helper missing on the active profile is a missing-helper
-case under rule 1 (stop and ask), not a reason to fall through.
+`ephemeral-npx` profiles, `scripts/` is not vendored — resolve each
+command's profile-selected equivalent from
+`docs/idd-helper-scripts.md`. A helper missing on the active profile
+is a missing-helper case under rule 1 (stop and ask), not a reason to
+fall through.
 
 `{agent-id}` is a tool/agent identifier shared across concurrent
 sessions of the same agent type — pick or confirm one before the first
@@ -186,15 +186,17 @@ takeover, migrate with a fresh `{claim-id}` and `supersedes: none`.
 **Forced-handoff** (`<!-- forced-handoff: {...} -->`): transfers the
 active claim to `newAgentId` / `newClaimId` only when **all** hold: the
 comment author is a trusted marker actor; the author (case-insensitive)
-equals the marker's `forcedBy` field — this blocks a same-identity
-self-signed hijack where a displaced session spoofs a different
-`forcedBy` name while posting the marker itself; that author is
-authorized under `forcedHandoff.authorityPolicy`; `forcedHandoff.mode`
-is `human-gated`; `oldAgentId` / `oldClaimId` / `branch` all match
-the active claim; and, when an open PR already backs this claim, the
-marker's evidence has `contextScope` of `issue-plus-pr` with `linkedPr`
-naming that PR — an issue-only handoff is not enough once a PR exists.
-On success, the
+equals the marker's `forcedBy` field — unconditionally, a
+deliberately stricter bind than the full spec's opt-in
+(`requireAuthorMatchesForcedBy`) — this blocks a
+same-identity self-signed hijack where a displaced session spoofs a
+different `forcedBy` name while posting the marker itself; that author
+is authorized under `forcedHandoff.authorityPolicy`;
+`forcedHandoff.mode` is `human-gated`; `oldAgentId` / `oldClaimId` /
+`branch` all match the active claim; and, when an open PR already backs
+this claim, the marker's evidence has `contextScope` of
+`issue-plus-pr` with `linkedPr` naming that PR — an issue-only
+handoff is not enough once a PR exists. On success, the
 successor claim is **sticky**: adopt
 `newAgentId` / `newClaimId` **verbatim** as your own for the rest of
 the run (do not mint a fresh pair), and still post your own
@@ -357,7 +359,11 @@ comments, and check:
    its winner and confirm it is yours (no marker posted → treat as
    passed).
 
-Any failure → claim contested → **STOP**, do not proceed.
+Any failure → claim contested → **STOP**, do not proceed. **Exception:
+only step 4 fails** (1-3 passed — the claim is genuinely yours) → post
+`unclaimed-by` for your own `{agent-id}`/`{claim-id}` first (safe: you
+provably hold it), **then STOP**. Step 5 also failing (alone or with
+step 4) → never release (shares that exact pair) — STOP as usual.
 
 **Forced-handoff adopt-verbatim** only: skip steps 1-4 (no
 `claimed-by` was posted for this path); only step 5 applies — wait the
@@ -412,7 +418,6 @@ first, then `--fresh-claim-gate` if not `already_owned`):
 No release step: `git worktree remove` at F4 deletes the lock with the
 worktree.
 
-Then continue to `idd-work-lite.instructions.md` — except on the
-`instructions-only` profile, where that file explicitly declines the
-profile in its own header; continue to the standard
-`idd-work.instructions.md` instead.
+Then continue to `idd-work-lite.instructions.md` — except on
+`instructions-only`, where that file declines the profile in its own
+header; use `idd-work.instructions.md` instead.

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -111,12 +111,12 @@ This section's rebase only applies **before the branch's first push**.
      package-manager-profile `idd:branch-conflict-state` command
      (resolve the exact command from `docs/idd-helper-scripts.md` if
      unsure). This is the same helper `idd-review-triage.instructions.md`
-     uses for its own branch-sync check (the standard `idd-pr-submit.
-     instructions.md` file does not reference it directly, since D1 there
-     only covers the pre-first-push case), so it already accounts for
-     whether a merely-`BEHIND` head actually needs a resync (branch
-     protection requiring an up-to-date head) rather than treating every
-     non-`CLEAN` state the same:
+     uses for its own branch-sync check (the standard
+     `idd-pr-submit.instructions.md` file does not reference it directly,
+     since D1 there only covers the pre-first-push case), so it already
+     accounts for whether a merely-`BEHIND` head actually needs a resync
+     (branch protection requiring an up-to-date head) rather than treating
+     every non-`CLEAN` state the same:
      - `syncRecommendation: "none"`: D1-D3 already happened in an
        earlier session. Run D3.5's closing-keyword check first — it is
        idempotent even if an earlier session already verified it, and
@@ -208,7 +208,14 @@ loop instead of returning to this D1 rebase path.
    background/rationale only when it materially affects review. Ground
    any background/rationale only in the issue discussion, commits,
    diff, or explicit operator instructions — omit rather than
-   speculate.
+   speculate. The prose sections follow the resolved `authoringLanguage` value
+   from `.github/idd/config.json` (fixed tag, the claimed issue's own body
+   language for `match-source`, or English if absent — see
+   [Authoring Language](../../../docs/customization.md#authoring-language));
+   this never changes any machine-parsed marker or exact-regex-matched visible
+   line, which stays canonical regardless — concretely, the closing keyword line
+   stays canonical English: GitHub's parser and D3.5's verification regex below
+   match only the English keyword forms.
 4. **Closing keyword**: write a plain-text line such as `Closes #N` for
    the claimed issue number, on its own line. GitHub recognizes these
    keyword forms (case-insensitive): `close`, `closes`, `closed`, `fix`,
@@ -364,18 +371,19 @@ than the run it supersedes. Once both have completed, the later
    external target rather than an Actions run; or its entry has `type:
    "check-run"` but an empty `url` (the upstream `detailsUrl` was
    itself absent). Otherwise resolve the rerun
-   decision from the
-   run's own history: `gh run view <run-id-from-url> --json attempt` —
-   GitHub's `attempt` starts at `1` for a never-rerun run, so pass
-   `attempt - 1` as `<count>` to `node scripts/ci-wait-policy.mjs
-   --rerun-count <count>`, never this wait's own memory. If it allows
+   decision directly from the run's own live state:
+   `node scripts/ci-wait-policy.mjs --run-id <run-id-from-url>`
+   (`--owner`/`--repo` when targeting a different repository) — this
+   derives the budget mechanically from the run's own `run_attempt`
+   field, never this wait's own memory. If it allows
    a rerun, rerun that check once as a **whole-run rerun, not
    `--failed`** (`gh run rerun <run-id-from-url>`) — a stalled check
    has no failed jobs to selectively rerun, only a run that never
    finished — and resume polling. If it is `hold`, or the timeout
    recurs after a rerun, stop per the condition above and post a hold
    note.
-7. **`success`**: proceed to `idd-review-snapshot.instructions.md` (E1).
+7. **`success`**: proceed to `idd-review-snapshot-lite.instructions.md`
+   (E1).
 8. **Exception**: if `idd-advisory-convergence` is the only
    non-passing required check, and that check's own run-log JSON verdict
    reports `pending: false` with outstanding review reasons (thread

--- a/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -79,25 +79,28 @@ gate.
 
 ## S4 — Race-safe recheck (immediately before write)
 
-1. Re-run `resume-claim-routing.mjs --issue <N>`.
-2. Active claim still the same non-owned `{claim-id}`.
-3. Still stale (≥ 12 h) now.
-4. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
+1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+   failing → STOP.
+2. Re-run `resume-claim-routing.mjs --issue <N>`.
+3. Active claim still the same non-owned `{claim-id}`.
+4. Still stale (≥ 12 h) now.
+5. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
    restart from resume discovery.
-5. Issue still open; PR not merged.
-6. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
+6. Issue still open; PR not merged.
+7. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
    `PT5S`) and same-second claim-id tie-break.
 
 Any failure → STOP and restart. Do not post takeover on stale evidence.
 
 ## S5 — Takeover
 
-1. Post claim with fresh `{claim-id}` and `supersedes: <prior-claim-id>`
-   via `post-idd-marker --type claim ... --apply` (or equivalent).
-2. Wait settle delay; re-parse; confirm active claim is yours.
-3. If lost: STOP.
-4. If verified: return to `idd-resume-lite.instructions.md` Step 1, then
-   Step 2/3.
+1. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
+   `post-idd-marker --type claim ... --apply`, then an
+   activation-nonce (`idd-claim-lite.instructions.md` step 5).
+2. Wait settle delay; re-parse; confirm claim and nonce winner are
+   yours.
+3. Lost → STOP. Verified → record nonce; return to
+   `idd-resume-lite.instructions.md` Step 1, Step 2/3.
 
 ## Hold behavior
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -69,16 +69,19 @@ Before any commit, push, merge, reply, resolve, reviewer request, or
 other GitHub side effect, confirm all of the following:
 
 1. The active claim still uses this session's claim id.
-2. The current directory is the sibling worktree for the claimed branch.
-3. `git branch --show-current` equals the claimed branch.
-4. Acquire the worktree-local claim lock with the profile-selected
+2. If this session posted an activation nonce for the current claim,
+   confirm it still wins (no later trusted marker for this claim id
+   won the tie-break instead).
+3. The current directory is the sibling worktree for the claimed branch.
+4. `git branch --show-current` equals the claimed branch.
+5. Acquire the worktree-local claim lock with the profile-selected
    `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
    --worktree <this-worktree-path> --agent-id <id> --claim-id <id>`, or
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed.
-5. If any check fails, stop.
+6. If any check fails, stop.
 
 ## E9 — Fix accepted issues
 
@@ -234,22 +237,21 @@ other GitHub side effect, confirm all of the following:
      `advisory-wait-recovery: {agent-id} {PR_HEAD_SHA}
      {ISO8601-recovery-time}` as plain text. Do not request another
      review. Then go to the polling loop below.
-   - `REQUEST_NEEDED`: if `copilotPending` is true, first remove the
-     stale pending request with `gh pr edit {pr-number}
-     --remove-reviewer "@{primary-advisory-bot}"` (on a GraphQL
-     login-resolution failure, retry via `gh api
-     repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X
-     DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"`; if
-     removal fails because the bot is no longer pending, re-run this
-     step from the top; if it fails for any other reason, post a hold
-     comment and stop). Then request the review with `gh pr edit
-     {pr-number} --add-reviewer "@{primary-advisory-bot}"` (on the same
-     GraphQL failure, retry via `gh api
+   - `REQUEST_NEEDED`, `copilotPending` `false`: request the review with
+     `gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"`
+     (on a GraphQL login-resolution failure, retry via `gh api
      repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X POST
-     -f "reviewers[]={primary-advisory-bot-rest-login}"`). Immediately
-     post `advisory-wait: {agent-id} {PR_HEAD_SHA}
-     {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
+     -f "reviewers[]={primary-advisory-bot-rest-login}"`). If both
+     attempts fail, stop and ask instead of posting a marker. On
+     success, immediately post `advisory-wait: {agent-id} {PR_HEAD_SHA}
+     {ISO8601-requested-at}` as plain text, not an HTML comment, then go
      to the polling loop below.
+   - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
+     pending but unproven for current HEAD, no same-head marker to
+     anchor polling): lite does not track the claim-id/agent-id the
+     full protocol's bounded `AW3-S` remove/re-request cycle requires —
+     stop and ask rather than remove, re-request, or enter the
+     marker-based polling loop below with no marker.
    - `CAP_EXHAUSTED`: apply step 10 below (the secondary-bot check)
      first — it is a non-gating supplement that fires on cap exhaustion
      independent of the cap-exhausted route. Then, if the helper's
@@ -285,7 +287,7 @@ other GitHub side effect, confirm all of the following:
    exists, stop polling and return to E1 to create one.
 8. Poll on the interval from the helper's `pollIntervalMinutes`. Each
    cycle: re-fetch the current head; if it differs from `PR_HEAD_SHA`,
-   stop polling and return to `idd-review-snapshot.instructions.md`
+   stop polling and return to `idd-review-snapshot-lite.instructions.md`
    (E1). Otherwise re-read threads, review bodies, and regular comments
    (excluding trusted operational markers); if anything has `updatedAt`
    newer than the polling watermark, stop polling and return to E1.
@@ -334,8 +336,8 @@ other GitHub side effect, confirm all of the following:
    routing for this phase.
 3. If new review threads or comments arrive during the wait, note them
    but keep waiting for CI.
-4. On success: return to `idd-review-snapshot.instructions.md` (E1) —
-   do not skip triage.
+4. On success: return to `idd-review-snapshot-lite.instructions.md`
+   (E1) — do not skip triage.
 5. On failure that is code-caused: fix it, run `fix-validate`, commit
    atomically, then return to E11.
 6. On failure that is infra-flaky or pre-existing (also failing on

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -18,17 +18,15 @@ standard review-snapshot instructions instead.
 
 ## Triage hand-off boundary (E4-E8 excluded)
 
-This file only fetches, freezes, and routes ReviewItems_snapshot. It
-never classifies findings, scores severity, or decides Accept/Reject —
-those are E4-E8 judgment calls, excluded from every lite profile, the
-same boundary `idd-review-fix-lite.instructions.md` states on its own
-downstream side (it only executes dispositions an E4-E8 pass already
-made).
+This file only fetches, freezes, and routes ReviewItems_snapshot — it
+never classifies findings, scores severity, or decides Accept/Reject;
+those are excluded E4-E8 judgment calls, the same boundary
+`idd-review-fix-lite.instructions.md` states on its downstream side.
 
 1. E3's non-empty-list outcome hands off to
-   `idd-review-triage.instructions.md` (E4-E8). A stronger session or a
-   human runs that pass — this lite file never runs E4-E8 itself, even
-   when a finding looks trivial to classify.
+   `idd-review-triage.instructions.md` (E4-E8) for a stronger session
+   or a human — never run E4-E8 yourself, even for a trivial-looking
+   finding.
 2. If you catch yourself judging severity, deciding Accept/Reject, or
    assigning a PATH before handing off to E4, stop and ask instead.
 
@@ -241,10 +239,11 @@ watermark. The same "nothing after the note" rule applies here too.
 
 ## E3 — Empty/non-empty routing
 
-- **ReviewItems_snapshot is empty** → proceed to the E-phase branch-sync
-  check in `idd-review-triage.instructions.md`.
-- **ReviewItems_snapshot is non-empty** → this lite session's job for
-  this PR ends here. Do not classify or disposition any item yourself
-  (see Triage hand-off boundary above); hand off to
+- **ReviewItems_snapshot is empty** → proceed to
+  `idd-pre-merge-lite.instructions.md` (F1), which covers the
+  branch-sync decision. Do not route this case directly to the
+  excluded `idd-review-triage.instructions.md`.
+- **ReviewItems_snapshot is non-empty** → this lite session's job ends
+  here (see Triage hand-off boundary above); hand off to
   `idd-review-triage.instructions.md` (E4) for a stronger session or a
   human to run.

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -32,10 +32,19 @@ Before any commit, push, rebase, claim heartbeat, reply, resolve, reviewer
 request, or other GitHub side effect, confirm all of the following:
 
 1. The active claim still uses this session's claim id.
-2. The current directory is the sibling worktree for the claimed branch.
-3. `git branch --show-current` equals the claimed branch.
-4. The worktree-local claim lock is held.
-5. If any check fails, stop.
+2. If this session posted an activation nonce for the current claim,
+   confirm it still wins (no later trusted marker for this claim id
+   won the tie-break instead).
+3. The current directory is the sibling worktree for the claimed branch.
+4. `git branch --show-current` equals the claimed branch.
+5. Acquire the worktree-local claim lock with the profile-selected
+   `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
+   --worktree <this-worktree-path> --agent-id <id> --claim-id <id>`, or
+   the package-manager-profile `idd:claim-lock` command with the same
+   arguments — resolve the exact command from
+   `docs/idd-helper-scripts.md` if unsure). A `collision` result is
+   fail-closed: stop rather than proceed.
+6. If any check fails, stop.
 
 ## B1 — Create worktree
 

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -101,5 +101,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
-          npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+          npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e \
             idd-advisory-convergence --pr "$PR_NUMBER" --assert

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -88,7 +88,7 @@ jobs:
             echo "::error::PR_NUMBER is empty"
             exit 1
           fi
-          JSON=$(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+          JSON=$(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e \
             idd-audit-pr-cleanup \
             --pr "$PR_NUMBER" \
             --apply \

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -224,9 +224,11 @@ never changes any HTML-comment marker's machine-parsed format, nor any
 visible-line mirror whose exact wording a mechanical regex parses —
 concretely, the autopilot-suitability and effort footers' visible lines
 (`_Autopilot suitability: N / 5 ...` / `_Effort: S|M|L ...`), which
-`src/scripts/audit-authored-issue.mts` matches against a fixed
-English-phrase regex, must stay in their exact canonical English wording
-regardless of the configured language.
+upstream's `src/scripts/audit-authored-issue.mts` (in the
+`kurone-kito/idd-skill` source repository — this repository has no
+`src/` tree of its own) matches against a fixed English-phrase regex,
+must stay in their exact canonical English wording regardless of the
+configured language.
 
 **Cross-references**:
 
@@ -237,14 +239,14 @@ regardless of the configured language.
 - `idd-review-snapshot.instructions.md`'s existing "detect the PR body's
   language for the visible note" rule already composes correctly with
   this field with no code change required: now that PR-submit applies
-  `authoringLanguage` (#1982), that rule keeps following whatever
-  language the PR body ends up in.
+  `authoringLanguage` (`kurone-kito/idd-skill#1982`), that rule keeps
+  following whatever language the PR body ends up in.
 
 **Landed vs. pending**: this field is schema-defined and documented now.
-PR-submit's D3 "Create PR" step applies it to PR body prose (#1982), and
-the issue-authoring skill's contract applies it to drafted issue prose
-(#1983); the distributed discover and claim runtime does not read or
-apply it yet.
+PR-submit's D3 "Create PR" step applies it to PR body prose
+(`kurone-kito/idd-skill#1982`), and the issue-authoring skill's contract
+applies it to drafted issue prose (`kurone-kito/idd-skill#1983`); the
+distributed discover and claim runtime does not read or apply it yet.
 
 ## Policy Constants
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -200,6 +200,52 @@ merge-ready before the selected acknowledgement appears. Branch
 protection conversation-resolution requirements still override any local
 profile.
 
+## Authoring Language
+
+The distributed default is fail-safe: an absent `authoringLanguage`
+behaves as `en`, codifying today's actual emergent behavior, so no
+adopter's existing setup changes. Set `authoringLanguage` in
+`.github/idd/config.json` to make issue/PR body prose language an
+explicit, schema-validated choice instead:
+
+- A fixed BCP-47-shaped language tag (for example `en`, `ja`, `fr`,
+  `zh-Hans`, `pt-BR`) makes every newly-authored issue and PR body's
+  human-readable prose use that language.
+- The literal `match-source` matches the operator's live conversational
+  language during an interactive/hearing session (issue-authoring,
+  onboarding), and the language of the issue body being implemented
+  during unattended execution with no live operator (for example
+  PR-submit implementing an already-claimed issue).
+
+**Scope carve-out**: `authoringLanguage` governs human-readable prose
+sections only (Background, Proposed change, Acceptance criteria, PR
+descriptions, roadmap Goal/Tracks/Success criteria, and similar). It
+never changes any HTML-comment marker's machine-parsed format, nor any
+visible-line mirror whose exact wording a mechanical regex parses —
+concretely, the autopilot-suitability and effort footers' visible lines
+(`_Autopilot suitability: N / 5 ...` / `_Effort: S|M|L ...`), which
+`src/scripts/audit-authored-issue.mts` matches against a fixed
+English-phrase regex, must stay in their exact canonical English wording
+regardless of the configured language.
+
+**Cross-references**:
+
+- Adjacent bot configs keep their own independent language settings —
+  for example this repository's own `.coderabbit.yaml` sets
+  `language: en` — so an operator switching `authoringLanguage` away
+  from English should align those separately.
+- `idd-review-snapshot.instructions.md`'s existing "detect the PR body's
+  language for the visible note" rule already composes correctly with
+  this field with no code change required: now that PR-submit applies
+  `authoringLanguage` (#1982), that rule keeps following whatever
+  language the PR body ends up in.
+
+**Landed vs. pending**: this field is schema-defined and documented now.
+PR-submit's D3 "Create PR" step applies it to PR body prose (#1982), and
+the issue-authoring skill's contract applies it to drafted issue prose
+(#1983); the distributed discover and claim runtime does not read or
+apply it yet.
+
 ## Policy Constants
 
 Start with [IDD policy constants](policy-constants.md) when a

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -66,7 +66,7 @@ recorded in `.github/idd/config.json`)
   hand-writing marker comments:
 
   ```sh
-  npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+  npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e \
     idd-external-check-waiver --pr <number> \
     --check idd-advisory-convergence \
     --reason "<short reason>" \
@@ -197,7 +197,7 @@ Helper scripts run via `npx` against the pinned upstream package spec
 into this repository or installed as a project dependency:
 
 ```sh
-npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d <idd-command>
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e <idd-command>
 ```
 
 ### Issue-Author Approval Gate
@@ -255,7 +255,7 @@ clone.
 Template files and helper scripts are pinned to:
 
 ```text
-kurone-kito/idd-skill @ 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
+kurone-kito/idd-skill @ cac92e3eb21d978e1e039a8d88cb7d50fd9d640e
 ```
 
 When a future change bumps this pin, treat it as a **named-gap

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# IDD Documentation Index
+
+Use this page as the entry point to this documentation bundle. If you
+are an agent working in this repository for the first time, start with
+[Getting started](getting-started.md) or [Core concepts](concepts.md);
+otherwise use the table below to find a page by topic.
+
+Every page in this bundle follows the OKF (Open Knowledge Format)
+frontmatter convention this table is generated from — see
+[Customizing IDD § Docs Bundle Frontmatter Convention
+(OKF)](customization.md#docs-bundle-frontmatter-convention-okf) before
+adding a page of your own.
+
+## Reference Map
+
+<!-- audit:generated id=idd-template-docs-index-okf-table -->
+
+<!-- dprint-ignore-start -->
+| Type | Page | Description |
+| ---- | ---- | ----------- |
+| guide | [Customizing IDD](customization.md) | Lists which IDD surfaces adopters can safely customize and points to the authoritative file for each policy. |
+| guide | [Getting Started with IDD](getting-started.md) | Walks a new adopter through the shortest safe path from deciding to adopt IDD to running the first Issue-Driven Development loop. |
+| guide | [IDD Review Policy Profiles](idd-review-policy-profiles.md) | Names the supported PR review policy profiles and the instruction files an adopter must edit to select one other than the Copilot-advisory default. |
+| guide | [Permissions and Threat Model](permissions.md) | Defines the credential profiles, merge-policy boundaries, and threat model an operator must choose before granting IDD agents GitHub access. |
+| concept | [Core IDD Concepts](concepts.md) | Introduces the loop-engineering vocabulary and mental model behind the IDD phase instructions before diving into phase-by-phase rules. |
+| reference | [IDD — Advisory-Wait Shell Fallback (AW1 / AW2 / AW3-R / AW3-S / AW3-H detail)](idd-advisory-wait-shell-fallback.md) | Provides the verbatim gh, gh api, jq, and curl commands the advisory-wait shell fallback uses when helper support cannot be trusted. |
+| reference | [IDD Autonomy Contract](idd-autonomy-contract.md) | Classifies every externally visible IDD mutation as reversible or irreversible and names the gate or undo path for each. |
+| reference | [IDD Comment Minimization](idd-comment-minimization.md) | Defines the live status digest contract and the safe procedure for minimizing completed review feedback and stale operational markers after merge. |
+| reference | [IDD — Concept Ownership Matrix](idd-concept-ownership.md) | Answers which actor may touch a given IDD concept at a given phase without re-reading every instruction file. |
+| reference | [IDD Resume — Detail Reference](idd-resume-detail.md) | Provides the full narrative detail behind idd-resume.instructions.md's compact routing tables for branches that need careful judgment. |
+| reference | [Onboarding Reference — Agent Entry and Verification](onboarding/agent-entry-and-verification.md) | Provides the detailed agent-entry examples and verification checklist referenced by ONBOARDING.md steps 5 and 6. |
+| reference | [Onboarding Reference — Issue-Mediated Bootstrap](onboarding/issue-mediated-bootstrap.md) | Documents an opt-in alternate bootstrap path that imports the IDD template through a reviewed issue-branch-PR cycle instead of theirs-flow's direct, unreviewed commit. |
+| reference | [Onboarding Reference — Placeholder Values](onboarding/placeholders.md) | Provides the full derivation and replacement rules for every template placeholder used during onboarding. |
+| reference | [Onboarding Reference — Policy Decisions](onboarding/policy-decisions.md) | Provides the detailed policy-decision guidance behind ONBOARDING.md's operator-confirmation steps. |
+| reference | [Template Distribution Maintainer Reference](onboarding/template-distribution.md) | Explains how the template's generated file-distribution lists in ONBOARDING.md stay correct as files are added, removed, or moved. |
+| reference | [IDD Policy Constants](policy-constants.md) | Inventories the distributed IDD policy defaults and names which configuration surface owns each one. |
+| reference | [IDD Detailed Reference](reference.md) | Maps each operational question to the authoritative phase file or policy page that answers it. |
+| workflow | [IDD workflow guide](idd-workflow.md) | Routes each agent to its entry file and the phase file matching its current state. |
+| design | [IDD — Design Rationale and Maintainer Notes](idd-design-rationale.md) | Collects maintainer-facing rationale for why IDD phase rules exist as they do, organized by phase file. |
+| design | [IDD Helper Script Evaluation](idd-helper-scripts.md) | Records the current adoption decision and trade-offs for IDD's optional helper scripts so future reviews do not re-evaluate them from scratch. |
+<!-- dprint-ignore-end -->
+
+<!-- /audit:generated -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,11 +5,13 @@ are an agent working in this repository for the first time, start with
 [Getting started](getting-started.md) or [Core concepts](concepts.md);
 otherwise use the table below to find a page by topic.
 
-Every page in this bundle follows the OKF (Open Knowledge Format)
-frontmatter convention this table is generated from — see
-[Customizing IDD § Docs Bundle Frontmatter Convention
-(OKF)](customization.md#docs-bundle-frontmatter-convention-okf) before
-adding a page of your own.
+Upstream (`kurone-kito/idd-skill`) generates this table from an OKF
+(Open Knowledge Format) frontmatter block on each page. This
+repository's own `docs/` bundle does not carry that frontmatter — it
+was intentionally stripped from imported pages to match this
+repository's existing plain-`# Heading`-only convention (no local
+`docs-bundle-frontmatter` checker is configured) — so this table is a
+plain, hand-maintained index instead of a generated one.
 
 ## Reference Map
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,13 @@ plain, hand-maintained index instead of a generated one.
 
 ## Reference Map
 
+The table below is maintained by hand in this repository. The
+`audit:generated` marker around it is retained only as an
+import/template-drift aid for future pin bumps (it lets a diff against
+upstream's generated version locate the matching block quickly) — no
+local tooling in this repository actually regenerates this table from
+it.
+
 <!-- audit:generated id=idd-template-docs-index-okf-table -->
 
 <!-- dprint-ignore-start -->

--- a/docs/onboarding/issue-mediated-bootstrap.md
+++ b/docs/onboarding/issue-mediated-bootstrap.md
@@ -123,8 +123,11 @@ angle-bracket author-time fills — keep them as shell variables (never
 angle brackets) in the generated issue body, since the issue-authoring
 release contract's checklist requires no unsubstituted placeholder
 remain before the authoring hold is released
-(`skills/issue-authoring/references/contract.md`, "Authoring hold and
-release"), and this value has nothing to substitute until the
+(`.claude/skills/issue-authoring/references/contract.md`, "Authoring
+hold and release" — this repository's install location, matching the
+same reference in
+[`docs/dotfiles-boundary.md`](../dotfiles-boundary.md)), and this value
+has nothing to substitute until the
 executor actually runs the command. Direct the issue's process
 section to that full-clone path rather than the single-file download,
 so this issue's own acceptance criterion below ("every file required

--- a/docs/onboarding/issue-mediated-bootstrap.md
+++ b/docs/onboarding/issue-mediated-bootstrap.md
@@ -1,0 +1,428 @@
+# Onboarding Reference — Issue-Mediated Bootstrap
+
+Use this reference alongside `idd-template/ONBOARDING.md` when the
+operator wants an audited bootstrap trail instead of the distributed
+default direct-import ("theirs-flow") path. This page is the detailed
+companion for the pointer subsection between Step 1C and Step 2.
+
+**This mode is opt-in, not a replacement.** The existing direct-import
+path (Steps 2, 4, 5, and 6 as already written in
+`idd-template/ONBOARDING.md`) remains the default for every adopter who
+does not explicitly choose this alternate. A brand-new repository
+usually has no configured CI, branch protection, or Copilot review bot
+yet, so routing the very first, most fragile action through a full
+review-gated PR would add fragility without benefit for solo or simple
+adopters.
+
+## When to choose this mode
+
+Theirs-flow accepts the template as a trusted baseline and imports it
+with a direct commit — no GitHub issue, no PR-mediated review — then
+hands off to the normal claim -> work -> PR -> CI -> merge loop for
+everything that follows. Every other change an IDD-run project makes
+flows through an issue and a reviewed PR; the bootstrap import itself
+is the one exception.
+
+Choose issue-mediated bootstrap instead when the operator wants that
+exception closed from day zero — for example, a team whose change-control
+policy requires every repository mutation to have a reviewable record, or
+an operator who simply prefers not to grant an agent a direct-commit
+path even for the first action. Treat this as an explicit operator
+choice made alongside the other Step 1B policy decisions (see
+[Onboarding Reference — Policy Decisions](policy-decisions.md)), not an
+automatic upgrade applied whenever a review bot happens to be available.
+If the operator does not state a preference, propose theirs-flow (the
+default) and only switch modes on explicit confirmation.
+
+**Prerequisite: the target repository needs a first commit.** GitHub
+cannot open a pull request against a repository with no commits at
+all — there is no default branch to target yet. A truly empty
+repository must get its base commit some other way (for example, an
+initial commit unrelated to IDD) before issue-mediated bootstrap's
+issue -> branch -> PR flow can run; creating that first commit is
+outside this alternate's own scope.
+
+## Drafting the bootstrap issue
+
+Draft the bootstrap issue only after Steps 1A-1C conclude ("the
+hearing"): the operator-confirmed placeholder values and the Step 1B
+policy decisions must already be settled, because the issue body has to
+carry them.
+
+**The issue body must be self-contained.** Unlike a normal IDD issue,
+there is no `.github/idd/config.json` yet in the target repository for
+an executing session to read those values from — the target repository
+is still pre-import. Embed the confirmed values for the placeholders
+listed in [Onboarding Reference — Placeholder
+Values](placeholders.md) directly in the issue body (the resolved
+values themselves, not a reference to where they live), together with
+the confirmed Step 1B decisions (merge policy, PR review profile,
+review-thread resolution policy, and the rest of the list in
+[Onboarding Reference — Policy Decisions](policy-decisions.md)).
+
+**Pin the process reference.** The issue's process section must point
+at idd-skill's own canonical `idd-template/ONBOARDING.md` Steps 2
+(fetch or copy template files), 4 (replace placeholders), 5 (update
+agent entry files), and 6 (verification checklist) — pinned to a
+specific released tag or commit SHA, for example:
+
+```text
+https://raw.githubusercontent.com/kurone-kito/idd-skill/<tag-or-sha>/idd-template/ONBOARDING.md
+```
+
+Never reference the unpinned `/main/` URL for this purpose: an unpinned
+reference can drift between when the issue is authored and when it is
+executed, so the steps a reviewer approved may not be the steps that
+actually ran (preventive; no observed incident yet).
+
+**Pinning the entry-point link alone is not enough.** Step 2's own file
+fetch commands carry their own source reference independent of which
+`ONBOARDING.md` revision you read them from, and Option A has **two**
+independent fetch loops that each need pinning separately:
+
+- the recommended `gh api` loop calls the Contents API
+  (`repos/kurone-kito/idd-skill/contents/idd-template/{path}`) with no
+  `ref` parameter, so it always resolves the default branch regardless
+  of any URL elsewhere in the document — pin it by appending
+  `?ref=<tag-or-sha>` to that endpoint;
+- the `curl` fallback loop uses a hardcoded `Base URL:`
+  (`https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/`)
+  — pin it by replacing `main` with the same `<tag-or-sha>` there.
+
+Option B copies whatever revision is currently checked out in the local
+clone — pin it by checking out that exact tag or SHA before running
+Option B. Reading a pinned `ONBOARDING.md` does not, by itself, pin any
+of these three fetches. In the issue's process section, explicitly
+instruct all three substitutions above — otherwise the actual imported
+file contents can still drift even though the instructions document
+you read were pinned.
+
+**If the confirmed helper runtime profile is `vendored-node`**, its
+profile-conditional helper bundle needs more than a pin. The
+single-file direct download in
+[Profile-conditional helper files](template-distribution.md#profile-conditional-helper-files-vendored-node)
+supplies only `minimize-superseded-markers.mjs`, not the complete
+`vendored-node` bundle — per that section, getting every file the
+profile requires needs a full `idd-skill` clone (not just the
+`idd-template/` subtree), checked out at the same `<tag-or-sha>`, with
+this run from it:
+
+```sh
+node scripts/idd-onboard.mjs --import \
+  --source "$CLONE_DIR" --target "$TARGET_REPO" --profile vendored-node
+```
+
+`--import` rejects calls without an explicit `--source`, and since the
+natural place to run this command is from inside that same clone,
+`--target` also needs to be explicit (its default is the current
+directory, which without an explicit value would import into the
+clone itself instead of the adopter repository). `$CLONE_DIR` and
+`$TARGET_REPO` are shell variables the executor sets at run time, not
+angle-bracket author-time fills — keep them as shell variables (never
+angle brackets) in the generated issue body, since the issue-authoring
+release contract's checklist requires no unsubstituted placeholder
+remain before the authoring hold is released
+(`skills/issue-authoring/references/contract.md`, "Authoring hold and
+release"), and this value has nothing to substitute until the
+executor actually runs the command. Direct the issue's process
+section to that full-clone path rather than the single-file download,
+so this issue's own acceptance criterion below ("every file required
+by the selected helper runtime profile") is actually satisfiable.
+
+### The status:authoring hold still applies
+
+The issue-authoring skill's normal authoring-hold/release contract
+still governs this draft: while the `status:authoring` label is present,
+no session should treat the draft as ready, and removing the label is
+what releases it for execution. That contract keeps working pre-import
+because the label lives on the GitHub issue itself, not in the
+repository tree — it needs no local IDD instructions to be present yet.
+
+### Fill-in bootstrap-issue body template
+
+Use this as the starting shape so an onboarding agent does not have to
+improvise a self-contained body from scratch each time. It follows the
+issue-authoring skill's orphan-issue schema (`## Background`,
+`## Proposed change`, `## Acceptance criteria`, plus the
+autopilot-suitability footer). Fill in every bracketed value before
+publishing, but not all of them come from the same source: the named
+`<value>` fields (repository name, marker prefix, and so on) come from
+the Steps 1A-1C hearing; `<tag-or-sha>` is chosen separately, at pin
+time, not derived from the hearing itself; and the `vendored-node`
+clone/target path placeholders are executor run-time values, not
+author-time fills — they apply only when `vendored-node` is the
+confirmed helper runtime profile, so delete that entire conditional
+sentence and command block when a different profile was selected,
+rather than leaving unresolved placeholders or a command that does not
+apply behind:
+
+````markdown
+## Background
+
+This repository has not yet imported the IDD (Issue-Driven Development)
+workflow. The operator chose the issue-mediated bootstrap path over the
+direct-import default: this issue is the reviewable record of that
+import instead of an unreviewed direct commit.
+
+## Proposed change
+
+Import the IDD template into this repository by following
+`idd-template/ONBOARDING.md` Steps 2, 4, 5, and 6, pinned to
+[<tag-or-sha>](https://raw.githubusercontent.com/kurone-kito/idd-skill/<tag-or-sha>/idd-template/ONBOARDING.md)
+— never the unpinned `/main/` reference. This pin covers the
+instructions themselves; also pin the actual file fetch in Step 2, all
+three of: append `?ref=<tag-or-sha>` to the `gh api` loop's Contents
+API endpoint (the recommended default — it has no `ref` and otherwise
+always resolves the default branch regardless of the curl base URL),
+use `<tag-or-sha>` (not `main`) in the `curl` fallback's base URL, and
+check out `<tag-or-sha>` in the local clone before running Option B. If
+the confirmed helper runtime profile is `vendored-node`, its complete
+helper bundle needs a full `idd-skill` clone checked out at
+`<tag-or-sha>`, with this run from it:
+
+```sh
+node scripts/idd-onboard.mjs --import \
+  --source "$CLONE_DIR" --target "$TARGET_REPO" --profile vendored-node
+```
+
+Both `--source` and an explicit `--target` are required — `--target`
+defaults to the current directory, which would import into the clone
+itself if left unset while running from inside it. `$CLONE_DIR` and
+`$TARGET_REPO` stay shell variables (never angle brackets) in the
+published issue body: the release checklist requires no unsubstituted
+placeholder remain before the authoring hold is released, and these
+have nothing to substitute until the executor runs the command. The
+single-file direct download documented in `template-distribution.md`'s
+"Profile-conditional helper files" section supplies only
+`minimize-superseded-markers.mjs`, not the rest of the profile's
+bundle, so it alone does not satisfy this issue's acceptance criterion
+below.
+
+Use these operator-confirmed values, already collected during the
+hearing (Steps 1A-1C), instead of re-deriving them:
+
+- Repository name: <value>
+- Marker prefix: <value>
+- Trusted marker actor: <value>
+- Fix-validate commands: <value>
+- Pre-push-validate commands: <value>
+- Post-fix-validate commands: <value>
+- Install-deps command: <value>
+
+And these confirmed Step 1B policy decisions — record them per Step 3
+alongside the Steps 2/4/5/6 import above, since Step 3 is a local
+recording action rather than a pinned remote-fetch step:
+
+- Merge policy: <value>
+- PR review policy profile: <value>
+- Review-thread resolution policy: <value>
+- Critique-loop profile: <value>
+- Credential scope: <value>
+- Claim-timing defaults: <value>
+- CI wait policy defaults: <value>
+- Issue-author approval gate: <value>
+- Maintainer approval actor policy: <value>
+- Issue-authoring companion status (core-bootstrap, temporary): not
+  installed (always, regardless of the operator's real choice below —
+  see the note below)
+- Issue-authoring companion target state (the operator's real Step 1B
+  choice, for the companion follow-up issue to read later): <installed,
+  native destination `<value>` | not installed>
+- Helper runtime profile: <value>
+- IDD label names: <value>
+- Up-to-date-head ruleset check: <value>
+- Bootstrap execution mode: issue-mediated (this issue's own execution
+  path)
+
+This is a single, atomically-reviewable change: the core import,
+placeholder substitution, and agent-entry-file updates land together,
+and Step 6 verification confirms the result before merge. Worktree
+guard activation, the `idd-doctor` CI health gate, and the
+`idd-advisory-convergence` required-check workflow are explicitly out
+of scope here and may follow later as separate issues, at the
+operator's discretion, once this one merges. The issue-authoring
+companion install follows as its own separate issue **only when the
+companion target state above is `installed`** — do not draft a
+companion-install follow-up for an operator who chose `not installed`.
+
+Once this issue merges, also draft a welcome/next-steps issue by
+default — unlike the optional add-ons above, this one is not left to
+the operator's discretion. Give it the same autopilot-suitability
+score `1` and confirmed blocked-by-human label this issue carries (it
+must stay off the Discover -> Claim -> Work loop too), and derive its
+2-3 example next-step prompts from a fresh post-merge
+repository-evidence read, not the pre-import dry-run report.
+
+**Record `not installed` here even when the operator wants the
+companion — and explicitly defer the matching Step 6 item, not just
+the recorded value.** `ONBOARDING.md`'s Step 6 checklist item
+("If the operator opted into issue authoring, the companion skill
+files are present…") triggers on the operator's **real hearing
+decision**, not on whatever this issue's policy field happens to
+record — recording `not installed` alone does not make that checklist
+item pass for an operator who genuinely opted in, since the files
+still won't be there. This issue's own acceptance criteria therefore
+explicitly exclude that one Step 6 item when the operator opted in (see
+below); do not claim "every Step 6 item passes" in that case without
+that carve-out. Once the follow-up issue installs the companion, it
+also updates the recorded policy value to `installed`.
+
+Execution for this issue is issue -> branch -> PR -> (a human or a
+narrowly-scoped, pre-authorized agent) merge — not the full autonomous
+Discover -> Claim -> Work loop. Discover cannot select this issue: no
+`.github/instructions/idd-*.instructions.md` or `.github/idd/config.json`
+exist in this repository's tree yet to route it. IDD's own CI and
+advisory-review checks (`idd-doctor`, `idd-advisory-convergence`) are
+not yet configured in this repository at this stage — that is expected,
+not a skipped gate. This repository may already have its own CI,
+branch protection, or review bot from before choosing IDD; those keep
+gating this PR normally and are not affected by this note.
+
+## Acceptance criteria
+
+- Every file listed in `idd-template/ONBOARDING.md` Step 2's core
+  `### File list` (plus any file required by the selected helper
+  runtime profile) is present in this repository — not the optional
+  issue-authoring companion files, which this issue defers (see above).
+- No onboarding placeholder strings remain, per Step 4 (outside the
+  meta-docs that intentionally keep them literal).
+- Root agent entry files exist and reference the IDD workflow, per Step 5.
+- Every Step 6 verification checklist item passes, **except** the
+  issue-authoring-companion item when the operator opted into the
+  companion during the hearing — that one item is intentionally
+  deferred to the companion follow-up issue and does not gate this
+  issue's completion.
+- The confirmed Step 1B policy decisions are recorded in the imported
+  repository per Step 3.
+
+---
+
+_Autopilot suitability: 1 / 5 -- higher is more autopilot-suitable;
+below the configured floor is human-oriented. This issue is not
+Discover-routable before import completes; a human or a
+narrowly-scoped, pre-authorized agent executes it directly instead._
+
+<!-- <marker-prefix>-autopilot-suitability: 1 -->
+````
+
+Replace `<marker-prefix>` in the marker with the confirmed marker-prefix
+value from the hearing before publishing — see the `PROJECT_MARKER_PREFIX`
+placeholder in
+[Onboarding Reference — Placeholder Values](placeholders.md) for how
+that value is derived. The suitability score of `1` reflects that
+Discover structurally cannot route this issue pre-import, not a quality
+judgment about the change itself; per the issue-authoring skill's
+contract, a score of `1` also carries the `status:blocked-by-human`
+label, which correctly signals that this issue needs a human or a
+narrowly-scoped, pre-authorized agent rather than the ordinary
+autonomous loop. Use the operator-confirmed `labels.blockedByHumanLabelName`
+value from Step 1B for both issue publication and label creation below —
+default to `status:blocked-by-human` only when that default was actually
+selected, never unconditionally. A pre-import repository may not have
+that label yet — create it first if `gh issue create --label
+"<confirmed-label-name>"` fails because the label is missing:
+`gh label create "<confirmed-label-name>"`.
+
+## Scope: exactly one issue
+
+Keep the core import as a single issue: the template file copy,
+placeholder substitution, and agent-entry-file updates, together with
+Step 6 verification, all land as one cohesive, atomically-reviewable
+change. A half-imported tree fails `--verify` — for example, agent entry
+files that reference an IDD workflow whose instruction files were never
+copied — so this work cannot be safely split across multiple issues or
+merged in a partial state (preventive; no observed incident yet).
+
+## Optional add-ons stay separate follow-ups
+
+Draft any of the following as separate follow-up issues instead of
+folding them into the core bootstrap issue, when the operator wants
+them:
+
+- worktree guard activation
+- the `idd-doctor` CI health gate
+- the `idd-advisory-convergence` required-check workflow
+- the issue-authoring companion install — **only** when the operator's
+  Step 1B companion decision was `installed`; do not draft this
+  follow-up for an operator who chose `not installed`, since there is
+  nothing for it to do
+- a welcome/next-steps issue — unlike its sibling bullets above, which
+  are drafted only on request, draft this one **by default** whenever
+  the operator chose issue-mediated bootstrap (details below)
+
+None of these are required for the repository to become
+IDD-operational, and unlike the core import, each one can run through
+the real Discover -> Claim -> Work loop once the core bootstrap issue
+merges — the local IDD instructions and policy files that Discover needs
+already exist by then — with one exception: the welcome/next-steps issue
+must not run through that loop at all (see below).
+
+**Welcome/next-steps issue, in detail.** Once the core bootstrap issue
+merges, draft it automatically — do not wait for a separate request, the
+way its four sibling bullets do. The whole premise of choosing the
+guided path over theirs-flow is that the operator is less likely to
+already know IDD, so gating this one add-on on a separate ask would
+defeat the point.
+
+This is also the one add-on that must stay off the Discover -> Claim ->
+Work loop entirely, unlike its four sibling bullets above: its whole
+body is a reference to read, not something to build, so an autopilot
+agent selecting it would attempt to "implement" prose that describes
+nothing (preventive; no observed incident yet). Give it the same
+autopilot-suitability score `1` and the
+operator-confirmed `labels.blockedByHumanLabelName` value the core
+bootstrap issue itself carries (Step 1B item 12) — never the
+distributed default label name unconditionally.
+
+Draft its body as 2-3 example prompts the operator can literally copy
+and try next, phrased as concrete requests mirroring the operator's own
+examples ("start issue authoring to implement {inferred gap}", "run the
+IDD loop"). Derive `{inferred gap}` and the other prompt content using
+the same repository-evidence-read method the optional Dry-run readiness
+report already performs
+([Dry-run — Readiness assessment](../../ONBOARDING.md#dry-run--readiness-assessment))
+— detected package manager, missing prerequisites, and so on — rather
+than inventing a new inference mechanism. Run that read **fresh, after
+this merge**, not reused from the pre-import dry-run's stored output:
+the repository's package manager, test commands, and missing
+prerequisites can differ once the bootstrap import lands, and a stale
+pre-import finding can prompt the operator to fix a gap the import
+already closed. Condition the prompt set on
+the recorded Step 1B companion decision: only include an issue-authoring
+prompt (e.g. "start issue authoring to implement {inferred gap}") when
+that decision was `installed`; for `not installed`, substitute a prompt
+that does not depend on the companion skill (e.g. "run the IDD loop" or
+a repository-evidence-derived task prompt), so every welcome issue's
+prompts are ones the operator can actually run.
+
+## Execution: issue -> branch -> PR -> merge, not the full loop
+
+Executing the bootstrap issue itself is issue -> branch ->
+PR -> (a human or a narrowly-scoped, pre-authorized agent) merge —
+explicitly not the full autonomous Discover -> Claim -> Work loop:
+
+- **Discover cannot select the issue.** No
+  `.github/instructions/idd-*.instructions.md` or
+  `.github/idd/config.json` exist in the target repository's tree yet to
+  route it — there is nothing for Discover to read.
+- **IDD's own CI and advisory-review gates are structurally
+  inapplicable at this stage, not silently skipped** — only the
+  IDD-specific checks (`idd-doctor`, `idd-advisory-convergence`) have
+  nothing to run against yet, since the instruction and config files
+  they depend on don't exist pre-import. Name that explicitly in the PR
+  description rather than leaving it implicit, so a reviewer does not
+  mistake the absence of those specific checks for a skipped gate on an
+  otherwise-normal PR. This does **not** extend to any CI, branch
+  protection, or review bot the target repository already had before
+  choosing IDD — those keep gating the bootstrap PR exactly as they did
+  before, and this note is never grounds for disregarding them.
+
+Once this PR merges, the repository is IDD-operational and every
+subsequent change — including the optional add-ons above — runs through
+the normal claim -> work -> PR -> CI -> merge loop, with the one
+exception already noted above: the welcome/next-steps issue is not
+executed as code at all. Unlike this bootstrap issue's own
+issue -> branch -> PR -> merge execution, the welcome issue has nothing
+to implement, so a human (or the same narrowly-scoped, pre-authorized
+agent) reads it and closes it directly once acknowledged — no branch,
+PR, or merge.

--- a/docs/onboarding/issue-mediated-bootstrap.md
+++ b/docs/onboarding/issue-mediated-bootstrap.md
@@ -100,7 +100,7 @@ you read were pinned.
 **If the confirmed helper runtime profile is `vendored-node`**, its
 profile-conditional helper bundle needs more than a pin. The
 single-file direct download in upstream's
-[Profile-conditional helper files](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/docs/onboarding/template-distribution.md#profile-conditional-helper-files-vendored-node)
+[Profile-conditional helper files](https://github.com/kurone-kito/idd-skill/blob/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e/idd-template/docs/onboarding/template-distribution.md#profile-conditional-helper-files-vendored-node)
 section (not carried into this repository's own copy of
 `template-distribution.md`, which does not use `vendored-node`) supplies
 only `minimize-superseded-markers.mjs`, not the complete `vendored-node`
@@ -381,7 +381,7 @@ examples ("start issue authoring to implement {inferred gap}", "run the
 IDD loop"). Derive `{inferred gap}` and the other prompt content using
 the same repository-evidence-read method the optional Dry-run readiness
 report already performs
-([Dry-run — Readiness assessment](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#dry-run--readiness-assessment))
+([Dry-run — Readiness assessment](https://github.com/kurone-kito/idd-skill/blob/cac92e3eb21d978e1e039a8d88cb7d50fd9d640e/idd-template/ONBOARDING.md#dry-run--readiness-assessment))
 — detected package manager, missing prerequisites, and so on — rather
 than inventing a new inference mechanism. Run that read **fresh, after
 this merge**, not reused from the pre-import dry-run's stored output:

--- a/docs/onboarding/issue-mediated-bootstrap.md
+++ b/docs/onboarding/issue-mediated-bootstrap.md
@@ -87,7 +87,10 @@ independent fetch loops that each need pinning separately:
   `?ref=<tag-or-sha>` to that endpoint;
 - the `curl` fallback loop uses a hardcoded `Base URL:`
   (`https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/`)
-  — pin it by replacing `main` with the same `<tag-or-sha>` there.
+  — pin it by replacing `main` with the same `<tag-or-sha>` there, i.e.
+  `https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/`
+  becomes
+  `https://raw.githubusercontent.com/kurone-kito/idd-skill/<tag-or-sha>/idd-template/`.
 
 Option B copies whatever revision is currently checked out in the local
 clone — pin it by checking out that exact tag or SHA before running

--- a/docs/onboarding/issue-mediated-bootstrap.md
+++ b/docs/onboarding/issue-mediated-bootstrap.md
@@ -99,13 +99,14 @@ you read were pinned.
 
 **If the confirmed helper runtime profile is `vendored-node`**, its
 profile-conditional helper bundle needs more than a pin. The
-single-file direct download in
-[Profile-conditional helper files](template-distribution.md#profile-conditional-helper-files-vendored-node)
-supplies only `minimize-superseded-markers.mjs`, not the complete
-`vendored-node` bundle — per that section, getting every file the
-profile requires needs a full `idd-skill` clone (not just the
-`idd-template/` subtree), checked out at the same `<tag-or-sha>`, with
-this run from it:
+single-file direct download in upstream's
+[Profile-conditional helper files](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/docs/onboarding/template-distribution.md#profile-conditional-helper-files-vendored-node)
+section (not carried into this repository's own copy of
+`template-distribution.md`, which does not use `vendored-node`) supplies
+only `minimize-superseded-markers.mjs`, not the complete `vendored-node`
+bundle — per that section, getting every file the profile requires
+needs a full `idd-skill` clone (not just the `idd-template/` subtree),
+checked out at the same `<tag-or-sha>`, with this run from it:
 
 ```sh
 node scripts/idd-onboard.mjs --import \
@@ -380,7 +381,7 @@ examples ("start issue authoring to implement {inferred gap}", "run the
 IDD loop"). Derive `{inferred gap}` and the other prompt content using
 the same repository-evidence-read method the optional Dry-run readiness
 report already performs
-([Dry-run — Readiness assessment](../../ONBOARDING.md#dry-run--readiness-assessment))
+([Dry-run — Readiness assessment](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#dry-run--readiness-assessment))
 — detected package manager, missing prerequisites, and so on — rather
 than inventing a new inference mechanism. Run that read **fresh, after
 this merge**, not reused from the pre-import dry-run's stored output:

--- a/docs/onboarding/issue-mediated-bootstrap.md
+++ b/docs/onboarding/issue-mediated-bootstrap.md
@@ -121,7 +121,7 @@ clone itself instead of the adopter repository). `$CLONE_DIR` and
 `$TARGET_REPO` are shell variables the executor sets at run time, not
 angle-bracket author-time fills — keep them as shell variables (never
 angle brackets) in the generated issue body, since the issue-authoring
-release contract's checklist requires no unsubstituted placeholder
+release contract's checklist requires no unsubstituted placeholders
 remain before the authoring hold is released
 (`.claude/skills/issue-authoring/references/contract.md`, "Authoring
 hold and release" — this repository's install location, matching the
@@ -194,7 +194,7 @@ defaults to the current directory, which would import into the clone
 itself if left unset while running from inside it. `$CLONE_DIR` and
 `$TARGET_REPO` stay shell variables (never angle brackets) in the
 published issue body: the release checklist requires no unsubstituted
-placeholder remain before the authoring hold is released, and these
+placeholders remain before the authoring hold is released, and these
 have nothing to substitute until the executor runs the command. The
 single-file direct download documented in `template-distribution.md`'s
 "Profile-conditional helper files" section supplies only


### PR DESCRIPTION
## Summary

Bumps the vendored `kurone-kito/idd-skill` template pin from
`4e8c7043edcb00dd8447dee83e7a17e5b2604d5d` (2026-07-24) to the current
upstream `main` HEAD `cac92e3eb21d978e1e039a8d88cb7d50fd9d640e`,
closing a 3-week / 121-commit gap, via a named-gap import (per
`docs/idd-policy.md`'s Upstream pin procedure) rather than a blind
resync.

- **Instruction files** (`.github/instructions/*.instructions.md`,
  including `lite/`): files identical to the old-pin template were
  replaced wholesale with the new-pin version (18 files). Files with a
  repo-local adaptation were three-way merged (`git merge-file`,
  base = old-pin template, ours = repo's prior file, theirs = new-pin
  template) to apply upstream's changes while preserving the local
  adaptation (7 files: `idd-discover`, `idd-overview-core`,
  `idd-resume-stall`, `idd-roadmap-audit`, `idd-suitability`,
  `idd-work`, and lite sibling `idd-resume-stall-lite`). Six merged
  cleanly; `idd-resume-stall-lite` had one real conflict (upstream
  added a new S4 step while this repo's `claim-stale-age: 12h`
  override collided with upstream's `24h` example text), resolved by
  keeping upstream's new step and this repo's `12h` value.
- **`.github/idd/config.json`**: only `iddVersion` changed
  (`0.4.0` → `0.6.0`), matching the only change in upstream's template
  config between the two pins. All 8 recorded policy fields
  (`mergePolicy`, `reviewPolicy`, `threadResolutionPolicy`,
  `claimTiming.*`, `ciWait.*`, `ciGate.*`) are byte-identical
  before/after.
- **Pin references**: updated all 5 known locations to the new SHA —
  `docs/idd-policy.md` (3 places), `.github/workflows/idd-advisory-convergence.yml`,
  `.github/workflows/post-merge-cleanup.yml`.
- **`scripts/minimize-superseded-markers.mjs`** also changed upstream,
  but this repo's `helperRuntime.profile` is `ephemeral-npx`, which
  does not vendor `scripts/` — no repository file to update; the new
  pin already governs helper resolution through the
  `npx --package .../tar.gz/<pin>` invocations.
- **New manifest files**: `idd-onboard --verify` against the new pin
  reported `blocking: true` because the template manifest gained two
  files since the old pin (`docs/index.md`,
  `docs/onboarding/issue-mediated-bootstrap.md`) that this repo never
  had — confirmed (by re-running the same `--verify` under the *old*
  pin against the same tree) that this repo was not blocking under the
  old pin, i.e. a genuinely new manifest requirement, not pre-existing
  drift. Imported both, stripped their OKF YAML frontmatter block to
  match this repo's existing plain-`# Heading` docs convention
  (confirmed via markdownlint's MD025 rule, which has no frontmatter
  override configured here), and fixed three resulting dead
  cross-references found by a follow-up self-review pass (imported the
  small self-contained "Authoring Language" section into
  `docs/customization.md` since `idd-pr-submit.instructions.md` now
  links to it; rewrote `docs/index.md`'s now-inaccurate OKF-convention
  claim; repointed two links in `issue-mediated-bootstrap.md` that only
  resolve inside `idd-skill`'s own repo layout to full upstream URLs).
- Added `dedup` to `.cspell.config.yml`'s word list (new upstream
  content in `idd-ci.instructions.md`).

## Verification

- `idd-onboard --verify` (new pin, this repo as target): exit 0,
  `blocking: false`.
- `idd-doctor` (new pin): `result: passed (7 warning(s))`; no
  `worktreeGuard` enabled-but-inert warning (`core.hooksPath` is
  already configured in this worktree). Cross-checked the same 7
  warnings against the *old* pin's `idd-doctor` on the same tree —
  identical set (markdownlint-cli2 "toolchain residue" false positives
  from this repo's deliberate tool choice, and one unrelated issue #112
  autopilot-suitability/label mismatch), confirming they predate this
  change. The new pin's doctor additionally resolved two old-pin-only
  warnings (`review policy signal not found`,
  `branch protection not readable`) — a net improvement.
- `pre-push-validate` (markdownlint-cli2, cspell, PSScriptAnalyzer,
  Pester): all pass, both before and after the D1 rebase onto the
  latest `master`.
- A mechanical local-link/anchor checker run against every changed
  Markdown file found no broken links introduced by this change (one
  pre-existing, out-of-scope dead anchor in `docs/customization.md` →
  `docs/idd-workflow.md`, unrelated to any file this PR touches, was
  left as-is).

## Known out-of-scope gap

This PR intentionally does not perform a full `docs/*.md` bundle
resync (per `docs/idd-policy.md`'s named-gap-import policy and issue
#120's own scoped proposal) — only the two newly-manifested files plus
the minimal content needed to fix the dead links they created. Several
other `docs/*.md` files have diverged further from the upstream
template over the 3-week gap; a full docs-bundle sync remains a
separate, larger decision for a future issue if desired.

Closes #120

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SZPhtJExbhjUAHSfndMMXM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a documentation index and an opt-in guide for issue-mediated onboarding.
  * Documented authoring-language configuration and behavior.
  * Clarified review, CI, claim management, merge, resume, and worktree procedures.

* **Workflow Improvements**
  * Improved guidance for advisory waits, CI polling, review triage, claim handling, cleanup, and stalled sessions.
  * Added clearer handling for conflicts, duplicate references, and roadmap cycles.
  * Updated automation to use the latest validated tooling.

* **Maintenance**
  * Updated configuration and spelling support for newly recognized terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->