### PR TITLE
feat(setup): install and update the CodeRabbit CLI via post-install

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,6 +23,7 @@ setup.cmd                        ← 唯一のエントリーポイント
             ├─ Phase 4: アーキテクチャ依存パッケージ
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
             │    ├─ dotnet tool → VPM CLI
+            │    ├─ install.ps1 → CodeRabbit CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
             │    └─ Docker Desktop → イメージ pull
@@ -115,6 +116,8 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 ### インストール後スクリプト経由
 
 - **VPM CLI**（dotnet tool 経由）: VRChat パッケージマネージャー
+- **CodeRabbit CLI**（公式 `install.ps1` 経由）: AI コードレビュー CLI。
+  バージョン固定はせず常に最新版へ更新する。Git for Windows が必須
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA
 - **Docker イメージ**: ベースイメージ (alpine, debian, ubuntu, node 各種)
@@ -154,10 +157,12 @@ dotfiles は別プロジェクト
 tealdeer, mkcert）。
 
 本リポジトリ自身のスクリプトは Windows の User PATH を管理・書き込み
-しません。唯一の例外はサードパーティ製の Unity CLI インストーラです
-（`libs/unity-cli-installer.ps1` が Unity 公式の `install.ps1` を呼び出し、
-そのインストーラ自身の既知の副作用として User PATH へエントリを追加します
-— 本リポジトリのコードが直接書き込むものではありません）。それ以外の
+しません。例外は 2 つ、サードパーティ製の Unity CLI インストーラと
+CodeRabbit CLI インストーラです（`libs/unity-cli-installer.ps1` が
+Unity 公式の `install.ps1` を、`libs/coderabbit-cli-installer.ps1` が
+CodeRabbit 公式の `install.ps1` をそれぞれ呼び出し、各インストーラ自身の
+既知の副作用として User PATH へエントリを追加します — 本リポジトリの
+コードが直接書き込むものではありません）。それ以外の
 User PATH の所有権は dotfiles の管理対象パス reconciler にあります。
 dotfiles の
 `docs/winget-user-path.md` がその仕組みを、

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ setup.cmd                        ← single entry point
             ├─ Phase 4: Architecture-conditional packages
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
             │    ├─ dotnet tool → VPM CLI
+            │    ├─ install.ps1 → CodeRabbit CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
             │    └─ Docker Desktop → image pulls
@@ -115,6 +116,8 @@ the full list. Key categories:
 ### Via Post-Install Scripts
 
 - **VPM CLI** (via dotnet tool): VRChat package manager
+- **CodeRabbit CLI** (via official `install.ps1`): AI code review CLI,
+  always updated to latest (no version pin); requires Git for Windows
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)
@@ -153,10 +156,13 @@ repository still installs many other CLI tools directly via winget
 above, e.g. 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert).
 
 This repository's own scripts do not manage or write the Windows User
-PATH — the one exception is the third-party Unity CLI installer
-(`libs/unity-cli-installer.ps1` invokes Unity's own `install.ps1`),
-which persists an entry there as its own documented side effect, not
-something this repository's code does directly. User PATH ownership
+PATH — the two exceptions are the third-party Unity CLI installer
+(`libs/unity-cli-installer.ps1` invokes Unity's own `install.ps1`) and
+the third-party CodeRabbit CLI installer
+(`libs/coderabbit-cli-installer.ps1` invokes CodeRabbit's own
+`install.ps1`), which each persist an entry there as their own
+documented side effect, not something this repository's code does
+directly. User PATH ownership
 otherwise belongs to dotfiles' managed-path reconciler: dotfiles'
 `docs/winget-user-path.md` documents the mechanism, and
 `home/dot_config/powershell/lib/managed-paths.ps1` is its single

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -174,7 +174,7 @@ else {
 }
 
 ###########################################################################
-### Phase 5 — Post-install setup (VPM CLI, Unity, mkcert, Docker)
+### Phase 5 — Post-install setup (VPM CLI, CodeRabbit CLI, Unity, mkcert, Docker)
 ###########################################################################
 # Unity CLI must be in place before post-install.ps1's own Unity Editor
 # install step (issue #76) -- installed here, ahead of that step, rather

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -975,3 +975,53 @@ affected devices; the Explorer/Taskbar/Search/sageset resources above
 are convenience UI/cleanup preferences with no functional necessity.
 Keeping the min profile limited to packages plus that one
 hardware-enablement exception preserves its "minimal" intent.
+
+## Installing the CodeRabbit CLI (issue #126)
+
+CodeRabbit CLI is officially supported on native Windows (x64, no WSL,
+no admin rights required — confirmed via
+<https://docs.coderabbit.ai/cli> and <https://docs.coderabbit.ai/cli/windows>),
+but has no winget package and no GitHub Releases, `aqua-registry`, or
+npm entry, so it cannot be delegated to dotfiles' `mise` the way the
+first-wave CLI tools were (roadmap #111). `libs/coderabbit-cli-installer.ps1`
+follows the same installer pattern as `libs/unity-cli-installer.ps1`
+(issue #76): downloads the vendor's own `install.ps1` to a temp file
+and runs it via `Start-Process` in a separate process, for the same
+reason recorded above -- an in-process invocation would let the
+downloaded script's own `exit` terminate the calling process instead of
+just itself.
+
+### `install.ps1` itself is not pinned
+
+Same trust model as the Unity CLI installer above: the binary CodeRabbit's
+`install.ps1` downloads is Authenticode-signed and verified by the
+script itself, but the script fetched from `https://cli.coderabbit.ai/install.ps1`
+is not pinned by hash or version. A compromise of that CDN could serve
+a different script. Recorded here as a known, accepted risk, consistent
+with how the Unity CLI installer's own unpinned `install.ps1` is
+recorded.
+
+### No version pin; always installs latest
+
+Unlike the Unity CLI (pinned via `configurations/runtime-versions.psd1`),
+`Sync-CoderabbitCli` does not pin a target version -- every call
+re-runs the official installer and relies on its own idempotent
+staging/rollback behavior, the same "always update" policy already used
+for the VPM CLI section of `libs/post-install.ps1`.
+
+### Environment-variable and PATH behavior is an unverified AI summary
+
+The installer's environment-variable handling (`CODERABBIT_VERSION` for
+pinning, `CI` for suppressing the interactive login prompt,
+`CODERABBIT_API_KEY` for skipping browser login), its lack of an
+explicit `exit` call, its User-scope PATH update mechanism, and its
+ARM64 x64-emulation behavior were established from an AI-generated
+summary of the vendor's documentation and script content, not from
+reading the script's source end to end the way issue #76 read Unity's
+`install.ps1`. `CODERABBIT_API_KEY` is deliberately never set by this
+repository's code -- authentication (`coderabbit auth login`) stays a
+manual step for the user. This Windows-only script could not be
+verified against a real `coderabbit` binary from this Linux development
+environment, for the same reason recorded above for the Unity CLI: this
+repository never executes `libs/post-install.ps1` or `boxstarter.ps1`
+directly in this environment, even for smoke-testing.

--- a/libs/coderabbit-cli-installer.ps1
+++ b/libs/coderabbit-cli-installer.ps1
@@ -24,11 +24,24 @@ function Add-CoderabbitCliToProcessPath {
   }
   $current = @($env:Path -split ';' | Where-Object { $_ -ne '' })
   $target = $InstallDir.TrimEnd('\', '/')
-  $alreadyPresent = $current | Where-Object {
-    [string]::Equals($_.TrimEnd('\', '/'), $target, [System.StringComparison]::OrdinalIgnoreCase)
+  $seenTarget = $false
+  $deduped = @(
+    foreach ($entry in $current) {
+      $isTarget = [string]::Equals($entry.TrimEnd('\', '/'), $target, [System.StringComparison]::OrdinalIgnoreCase)
+      if ($isTarget) {
+        if ($seenTarget) {
+          continue
+        }
+        $seenTarget = $true
+      }
+      $entry
+    }
+  )
+  if ($seenTarget) {
+    $env:Path = $deduped -join ';'
   }
-  if (-not $alreadyPresent) {
-    $env:Path = (@($current) + $InstallDir) -join ';'
+  else {
+    $env:Path = (@($deduped) + $InstallDir) -join ';'
   }
   <#
   .SYNOPSIS
@@ -50,6 +63,12 @@ function Add-CoderabbitCliToProcessPath {
   A null/empty InstallDir (e.g. the default on a machine without
   $env:LOCALAPPDATA, such as this file's own Linux Pester run) is a
   no-op rather than an error -- there is nothing to add.
+
+  Also normalizes away any pre-existing duplicate entries for
+  InstallDir (case/trailing-separator insensitive), keeping the first
+  occurrence's position and dropping the rest, so repeated calls
+  converge on exactly one entry even if duplicates existed before this
+  function's first call in the current process.
   #>
 }
 
@@ -77,8 +96,13 @@ function Invoke-CoderabbitCliInstaller {
       # here, so auth stays a manual post-install step for the user.
       $env:CI = '1'
       $shell = (Get-Process -Id $PID).Path
+      # Start-Process -ArgumentList joins array elements with a bare
+      # space and does not quote them itself (this is documented
+      # Start-Process behavior, not a bug) -- an unquoted $tempScript
+      # would truncate at the first space in a TEMP path containing
+      # one, so it's quoted explicitly here.
       $process = Start-Process -FilePath $shell -ArgumentList @(
-        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $tempScript
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$tempScript`""
       ) -NoNewWindow -Wait -PassThru
       return $process.ExitCode
     }

--- a/libs/coderabbit-cli-installer.ps1
+++ b/libs/coderabbit-cli-installer.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Installs and updates the CodeRabbit CLI (`coderabbit` / `cr` binaries),
+idempotently delegating to CodeRabbit's own official install script.
+
+This file is dot-sourced (not imported as a module) from
+libs/post-install.ps1 -- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+$Script:CoderabbitCliInstallScriptUrl = 'https://cli.coderabbit.ai/install.ps1'
+# $env:LOCALAPPDATA is Windows-only and absent on the Linux CI runner
+# that runs this file's Pester tests -- guarded so dot-sourcing this
+# file doesn't fail there. Every real caller runs on Windows, where
+# LOCALAPPDATA is always set.
+$Script:CoderabbitCliInstallDir = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'Programs\coderabbit' } else { $null }
+
+function Add-CoderabbitCliToProcessPath {
+  param (
+    [string]$InstallDir = $Script:CoderabbitCliInstallDir
+  )
+  if ([string]::IsNullOrEmpty($InstallDir)) {
+    return
+  }
+  $current = @($env:Path -split ';' | Where-Object { $_ -ne '' })
+  $target = $InstallDir.TrimEnd('\', '/')
+  $alreadyPresent = $current | Where-Object {
+    [string]::Equals($_.TrimEnd('\', '/'), $target, [System.StringComparison]::OrdinalIgnoreCase)
+  }
+  if (-not $alreadyPresent) {
+    $env:Path = (@($current) + $InstallDir) -join ';'
+  }
+  <#
+  .SYNOPSIS
+  Adds the CodeRabbit CLI install directory to the *current process's*
+  $env:Path.
+
+  .DESCRIPTION
+  The official install.ps1 persists the user-scope PATH but never
+  touches the calling process's own $env:Path. This function exists so
+  a `coderabbit` / `cr` call later in the same boxstarter.ps1 run works
+  without opening a new shell -- not to support a version-match check,
+  since this installer does not pin or compare versions.
+
+  A null/empty InstallDir (e.g. the default on a machine without
+  $env:LOCALAPPDATA, such as this file's own Linux Pester run) is a
+  no-op rather than an error -- there is nothing to add.
+  #>
+}
+
+function Invoke-CoderabbitCliInstaller {
+  param (
+    [string]$InstallScriptUrl = $Script:CoderabbitCliInstallScriptUrl
+  )
+  $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) "coderabbit-cli-install-$([guid]::NewGuid().ToString('N')).ps1"
+  try {
+    try {
+      Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $tempScript -UseBasicParsing -ErrorAction Stop
+    }
+    catch {
+      Write-Error "Failed to download the CodeRabbit CLI installer from ${InstallScriptUrl}: $_"
+      return 1
+    }
+    $originalCi = $env:CI
+    try {
+      # Suppresses the installer's interactive login prompt (unverified
+      # AI-summary behavior of the vendor script; not read from its
+      # source directly, see docs/dsc-migration-notes.md). Scoped to
+      # this call only -- CODERABBIT_API_KEY is deliberately never set
+      # here, so auth stays a manual post-install step for the user.
+      $env:CI = '1'
+      $shell = (Get-Process -Id $PID).Path
+      $process = Start-Process -FilePath $shell -ArgumentList @(
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $tempScript
+      ) -NoNewWindow -Wait -PassThru
+      return $process.ExitCode
+    }
+    finally {
+      if ($null -eq $originalCi) {
+        Remove-Item -Path Env:\CI -ErrorAction SilentlyContinue
+      }
+      else {
+        $env:CI = $originalCi
+      }
+    }
+  }
+  finally {
+    Remove-Item -Path $tempScript -Force -ErrorAction SilentlyContinue
+  }
+  <#
+  .SYNOPSIS
+  Downloads CodeRabbit's own install.ps1 and runs it to install or
+  update the CLI to its latest version.
+
+  .DESCRIPTION
+  Runs install.ps1 in a SEPARATE process via Start-Process, never
+  in-process -- mirrors libs/unity-cli-installer.ps1's
+  Invoke-UnityCliInstaller and its documented reason
+  (docs/dsc-migration-notes.md): an in-process scriptblock invocation
+  of downloaded content lets that script's own `exit` terminate the
+  *entire calling PowerShell process*, not just the scriptblock, which
+  would silently abort the rest of boxstarter.ps1's phases. A separate
+  process confines that risk to the child, so its exit code can be
+  inspected and handled by the caller instead.
+
+  install.ps1's own script is not pinned by hash or version, the same
+  trust model as any curl-pipe-to-shell bootstrap (Chocolatey, Scoop);
+  see docs/dsc-migration-notes.md for the recorded risk.
+
+  The download itself is wrapped in its own try/catch (mirrors issue
+  #98's Unity CLI fix): a network failure (DNS, connection refused,
+  non-2xx status) throws a terminating error from Invoke-WebRequest
+  that would otherwise propagate uncaught past this function and into
+  Sync-CoderabbitCli. Caught here and turned into a non-zero return
+  instead.
+
+  .OUTPUTS
+  The child process's exit code, or a non-zero value (currently 1) if
+  the installer script itself could not be downloaded. Callers cannot
+  distinguish a download failure from an install.ps1 failure by exit
+  code value alone -- only by whether it's zero.
+  #>
+}
+
+function Sync-CoderabbitCli {
+  Add-CoderabbitCliToProcessPath
+
+  Write-Host '[coderabbit-cli] Installing/updating CodeRabbit CLI...' -ForegroundColor Cyan
+  $exitCode = Invoke-CoderabbitCliInstaller
+  if ($exitCode -ne 0) {
+    Write-Error "CodeRabbit CLI installer exited with code ${exitCode}."
+    return
+  }
+
+  Add-CoderabbitCliToProcessPath
+  Write-Host '[coderabbit-cli] CodeRabbit CLI installation complete.' -ForegroundColor Green
+  <#
+  .SYNOPSIS
+  Idempotent entry point: installs or updates the CodeRabbit CLI to its
+  latest version on every call.
+
+  .DESCRIPTION
+  Unlike libs/unity-cli-installer.ps1's Sync-UnityCli, this function
+  does not pin a target version or skip when a matching version is
+  already installed -- CodeRabbit CLI intentionally always tracks
+  latest here (same "always update" policy as the VPM CLI section of
+  libs/post-install.ps1), so every call re-runs the official installer
+  and relies on its own idempotent staging/rollback behavior.
+  #>
+}

--- a/libs/coderabbit-cli-installer.ps1
+++ b/libs/coderabbit-cli-installer.ps1
@@ -36,11 +36,16 @@ function Add-CoderabbitCliToProcessPath {
   $env:Path.
 
   .DESCRIPTION
-  The official install.ps1 persists the user-scope PATH but never
-  touches the calling process's own $env:Path. This function exists so
-  a `coderabbit` / `cr` call later in the same boxstarter.ps1 run works
-  without opening a new shell -- not to support a version-match check,
-  since this installer does not pin or compare versions.
+  The official install.ps1 is documented to persist the user-scope PATH
+  (per docs.coderabbit.ai/cli/windows), but -- unlike Unity's
+  install.ps1, whose PATH-update mechanics were confirmed by reading
+  its source end to end -- whether it also touches the calling
+  process's own $env:Path was not independently verified from
+  CodeRabbit's script source (see docs/dsc-migration-notes.md). This
+  function is added defensively so a `coderabbit` / `cr` call later in
+  the same boxstarter.ps1 run works even if it does not -- not to
+  support a version-match check, since this installer does not pin or
+  compare versions.
 
   A null/empty InstallDir (e.g. the default on a machine without
   $env:LOCALAPPDATA, such as this file's own Linux Pester run) is a
@@ -123,6 +128,11 @@ function Invoke-CoderabbitCliInstaller {
 }
 
 function Sync-CoderabbitCli {
+  if ($null -eq (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning '[coderabbit-cli] git not found -- skipping CodeRabbit CLI.'
+    return
+  }
+
   Add-CoderabbitCliToProcessPath
 
   Write-Host '[coderabbit-cli] Installing/updating CodeRabbit CLI...' -ForegroundColor Cyan
@@ -140,6 +150,13 @@ function Sync-CoderabbitCli {
   latest version on every call.
 
   .DESCRIPTION
+  Checks for `git` itself (the official installer's own prerequisite)
+  rather than relying on a caller-side guard the way the dotnet/mkcert
+  sections of libs/post-install.ps1 do -- this keeps the check
+  independently testable via
+  tests/powershell/coderabbit-cli-installer.Tests.ps1 without dot-
+  sourcing post-install.ps1's Test-CommandExists helper.
+
   Unlike libs/unity-cli-installer.ps1's Sync-UnityCli, this function
   does not pin a target version or skip when a matching version is
   already installed -- CodeRabbit CLI intentionally always tracks

--- a/libs/coderabbit-cli-installer.ps1
+++ b/libs/coderabbit-cli-installer.ps1
@@ -54,6 +54,8 @@ function Add-CoderabbitCliToProcessPath {
 }
 
 function Invoke-CoderabbitCliInstaller {
+  [CmdletBinding()]
+  [OutputType([int])]
   param (
     [string]$InstallScriptUrl = $Script:CoderabbitCliInstallScriptUrl
   )
@@ -128,6 +130,9 @@ function Invoke-CoderabbitCliInstaller {
 }
 
 function Sync-CoderabbitCli {
+  [CmdletBinding()]
+  param ()
+
   if ($null -eq (Get-Command git -ErrorAction SilentlyContinue)) {
     Write-Warning '[coderabbit-cli] git not found -- skipping CodeRabbit CLI.'
     return

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -57,17 +57,16 @@ else {
 
 ###########################################################################
 ### CodeRabbit CLI — no winget package; official installer requires Git
-### (issue #126). See libs/coderabbit-cli-installer.ps1 for the
-### install.ps1 download/execution details and docs/dsc-migration-notes.md
-### for the recorded remote-script-execution risk.
+### (issue #126). Sync-CoderabbitCli owns its own Git presence check
+### (unlike the dotnet/mkcert sections above) so it stays independently
+### testable in isolation via
+### tests/powershell/coderabbit-cli-installer.Tests.ps1. See
+### libs/coderabbit-cli-installer.ps1 for the install.ps1
+### download/execution details and docs/dsc-migration-notes.md for the
+### recorded remote-script-execution risk.
 ###########################################################################
-if (Test-CommandExists git) {
-  . (Join-Path -Path $PSScriptRoot -ChildPath 'coderabbit-cli-installer.ps1')
-  Sync-CoderabbitCli
-}
-else {
-  Write-Warning '[post-install] git not found — skipping CodeRabbit CLI.'
-}
+. (Join-Path -Path $PSScriptRoot -ChildPath 'coderabbit-cli-installer.ps1')
+Sync-CoderabbitCli
 
 ###########################################################################
 ### Vagrant plugins

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -56,6 +56,20 @@ else {
 }
 
 ###########################################################################
+### CodeRabbit CLI — no winget package; official installer requires Git
+### (issue #126). See libs/coderabbit-cli-installer.ps1 for the
+### install.ps1 download/execution details and docs/dsc-migration-notes.md
+### for the recorded remote-script-execution risk.
+###########################################################################
+if (Test-CommandExists git) {
+  . (Join-Path -Path $PSScriptRoot -ChildPath 'coderabbit-cli-installer.ps1')
+  Sync-CoderabbitCli
+}
+else {
+  Write-Warning '[post-install] git not found — skipping CodeRabbit CLI.'
+}
+
+###########################################################################
 ### Vagrant plugins
 ###########################################################################
 if (Test-CommandExists vagrant) {

--- a/tests/powershell/coderabbit-cli-installer.Tests.ps1
+++ b/tests/powershell/coderabbit-cli-installer.Tests.ps1
@@ -34,6 +34,14 @@ Describe 'Add-CoderabbitCliToProcessPath' {
     { Add-CoderabbitCliToProcessPath -InstallDir '' } | Should -Not -Throw
     $env:Path | Should -Be '/existing/one'
   }
+
+  It 'removes pre-existing duplicate entries, keeping the first occurrence in place' {
+    $env:Path = '/existing/one;/coderabbit/bin;/existing/two;/CODERABBIT/BIN/;/existing/three'
+
+    Add-CoderabbitCliToProcessPath -InstallDir '/coderabbit/bin'
+
+    $env:Path | Should -Be '/existing/one;/coderabbit/bin;/existing/two;/existing/three'
+  }
 }
 
 Describe 'Invoke-CoderabbitCliInstaller' {
@@ -127,6 +135,21 @@ Describe 'Invoke-CoderabbitCliInstaller' {
     { Invoke-CoderabbitCliInstaller } | Should -Throw
 
     $env:CI | Should -Be 'previous-value'
+  }
+
+  It 'quotes the -File argument so a TEMP path containing spaces is not truncated by Start-Process argument joining' {
+    $script:capturedArgumentList = $null
+    Mock Invoke-WebRequest { }
+    Mock Start-Process {
+      $script:capturedArgumentList = $ArgumentList
+      [pscustomobject]@{ ExitCode = 0 }
+    }
+
+    Invoke-CoderabbitCliInstaller | Out-Null
+
+    $fileIndex = [array]::IndexOf($script:capturedArgumentList, '-File')
+    $fileIndex | Should -BeGreaterThan -1
+    $script:capturedArgumentList[$fileIndex + 1] | Should -Match '^".*"$'
   }
 }
 

--- a/tests/powershell/coderabbit-cli-installer.Tests.ps1
+++ b/tests/powershell/coderabbit-cli-installer.Tests.ps1
@@ -78,6 +78,16 @@ Describe 'Invoke-CoderabbitCliInstaller' {
     Invoke-CoderabbitCliInstaller | Should -Be 0
   }
 
+  It 'removes the temp script after a successful install too' {
+    Mock Invoke-WebRequest { }
+    Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+    Mock Remove-Item { }
+
+    Invoke-CoderabbitCliInstaller | Out-Null
+
+    Should -Invoke Remove-Item -Times 1
+  }
+
   It 'sets $env:CI to 1 only while Start-Process is running, when CI was previously unset' {
     Remove-Item -Path Env:\CI -ErrorAction SilentlyContinue
 
@@ -121,6 +131,28 @@ Describe 'Invoke-CoderabbitCliInstaller' {
 }
 
 Describe 'Sync-CoderabbitCli' {
+  BeforeEach {
+    Mock Get-Command -ParameterFilter { $Name -eq 'git' } { [pscustomobject]@{ Name = 'git' } }
+  }
+
+  It 'skips installation and does not touch PATH when git is not found' {
+    Mock Get-Command -ParameterFilter { $Name -eq 'git' } { $null }
+    Mock Add-CoderabbitCliToProcessPath { }
+    Mock Invoke-CoderabbitCliInstaller { 0 }
+
+    Sync-CoderabbitCli -WarningAction SilentlyContinue
+
+    Should -Invoke Invoke-CoderabbitCliInstaller -Times 0
+    Should -Invoke Add-CoderabbitCliToProcessPath -Times 0
+  }
+
+  It 'writes a warning, not a terminating error, when git is not found' {
+    Mock Get-Command -ParameterFilter { $Name -eq 'git' } { $null }
+    Mock Invoke-CoderabbitCliInstaller { 0 }
+
+    { Sync-CoderabbitCli -WarningAction SilentlyContinue } | Should -Not -Throw
+  }
+
   It 'always invokes the installer, even on a second consecutive call' {
     Mock Add-CoderabbitCliToProcessPath { }
     Mock Invoke-CoderabbitCliInstaller { 0 }

--- a/tests/powershell/coderabbit-cli-installer.Tests.ps1
+++ b/tests/powershell/coderabbit-cli-installer.Tests.ps1
@@ -1,0 +1,158 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'coderabbit-cli-installer.ps1')
+}
+
+Describe 'Add-CoderabbitCliToProcessPath' {
+  BeforeEach {
+    $script:originalPath = $env:Path
+  }
+
+  AfterEach {
+    $env:Path = $script:originalPath
+  }
+
+  It 'appends the install dir when not already present' {
+    $env:Path = '/existing/one;/existing/two'
+
+    Add-CoderabbitCliToProcessPath -InstallDir '/coderabbit/bin'
+
+    $env:Path | Should -Match ([regex]::Escape('/coderabbit/bin'))
+  }
+
+  It 'does not duplicate an entry that only differs by case or a trailing slash' {
+    $env:Path = '/Existing/CODERABBIT/BIN/;/existing/two'
+
+    Add-CoderabbitCliToProcessPath -InstallDir '/existing/coderabbit/bin'
+
+    ($env:Path -split ';' | Where-Object { $_ -ne '' }).Count | Should -Be 2
+  }
+
+  It 'no-ops instead of throwing when InstallDir is null or empty' {
+    $env:Path = '/existing/one'
+
+    { Add-CoderabbitCliToProcessPath -InstallDir $null } | Should -Not -Throw
+    { Add-CoderabbitCliToProcessPath -InstallDir '' } | Should -Not -Throw
+    $env:Path | Should -Be '/existing/one'
+  }
+}
+
+Describe 'Invoke-CoderabbitCliInstaller' {
+  BeforeEach {
+    $script:hadOriginalCi = Test-Path Env:\CI
+    $script:originalCi = if ($script:hadOriginalCi) { $env:CI } else { $null }
+  }
+
+  AfterEach {
+    if ($script:hadOriginalCi) {
+      $env:CI = $script:originalCi
+    }
+    else {
+      Remove-Item -Path Env:\CI -ErrorAction SilentlyContinue
+    }
+  }
+
+  It 'returns a non-zero exit code instead of throwing when the download fails' {
+    Mock Invoke-WebRequest { throw [System.Net.WebException]::new('Name or service not known') }
+    Mock Start-Process { }
+
+    $exitCode = Invoke-CoderabbitCliInstaller -ErrorAction SilentlyContinue
+    $exitCode | Should -Be 1
+
+    Should -Invoke Start-Process -Times 0
+  }
+
+  It 'removes the temp script even when the download fails' {
+    Mock Invoke-WebRequest { throw [System.Net.WebException]::new('Name or service not known') }
+    Mock Start-Process { }
+    Mock Remove-Item { }
+
+    Invoke-CoderabbitCliInstaller -ErrorAction SilentlyContinue | Out-Null
+
+    Should -Invoke Remove-Item -Times 1
+  }
+
+  It 'returns the child process exit code on success' {
+    Mock Invoke-WebRequest { }
+    Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+    Invoke-CoderabbitCliInstaller | Should -Be 0
+  }
+
+  It 'sets $env:CI to 1 only while Start-Process is running, when CI was previously unset' {
+    Remove-Item -Path Env:\CI -ErrorAction SilentlyContinue
+
+    Mock Invoke-WebRequest { }
+    Mock Start-Process {
+      $script:ciDuringInstall = $env:CI
+      [pscustomobject]@{ ExitCode = 0 }
+    }
+
+    Invoke-CoderabbitCliInstaller | Out-Null
+
+    $script:ciDuringInstall | Should -Be '1'
+    (Test-Path Env:\CI) | Should -Be $false
+  }
+
+  It 'restores a pre-existing $env:CI value after Start-Process returns' {
+    $env:CI = 'previous-value'
+
+    Mock Invoke-WebRequest { }
+    Mock Start-Process {
+      $script:ciDuringInstall = $env:CI
+      [pscustomobject]@{ ExitCode = 0 }
+    }
+
+    Invoke-CoderabbitCliInstaller | Out-Null
+
+    $script:ciDuringInstall | Should -Be '1'
+    $env:CI | Should -Be 'previous-value'
+  }
+
+  It 'restores $env:CI even when Start-Process throws' {
+    $env:CI = 'previous-value'
+
+    Mock Invoke-WebRequest { }
+    Mock Start-Process { throw 'boom' }
+
+    { Invoke-CoderabbitCliInstaller } | Should -Throw
+
+    $env:CI | Should -Be 'previous-value'
+  }
+}
+
+Describe 'Sync-CoderabbitCli' {
+  It 'always invokes the installer, even on a second consecutive call' {
+    Mock Add-CoderabbitCliToProcessPath { }
+    Mock Invoke-CoderabbitCliInstaller { 0 }
+
+    Sync-CoderabbitCli
+    Sync-CoderabbitCli
+
+    Should -Invoke Invoke-CoderabbitCliInstaller -Times 2
+  }
+
+  It 'adds the install dir to PATH both before and after a successful install' {
+    Mock Add-CoderabbitCliToProcessPath { }
+    Mock Invoke-CoderabbitCliInstaller { 0 }
+
+    Sync-CoderabbitCli
+
+    Should -Invoke Add-CoderabbitCliToProcessPath -Times 2
+  }
+
+  It 'writes a non-terminating error and does not throw when the installer exits non-zero' {
+    Mock Add-CoderabbitCliToProcessPath { }
+    Mock Invoke-CoderabbitCliInstaller { 1 }
+
+    { Sync-CoderabbitCli -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'does not add the install dir to PATH a second time when the installer fails' {
+    Mock Add-CoderabbitCliToProcessPath { }
+    Mock Invoke-CoderabbitCliInstaller { 1 }
+
+    Sync-CoderabbitCli -ErrorAction SilentlyContinue
+
+    Should -Invoke Add-CoderabbitCliToProcessPath -Times 1
+  }
+}


### PR DESCRIPTION
## Summary

Adds `libs/coderabbit-cli-installer.ps1`, an idempotent installer for
the CodeRabbit CLI (`coderabbit` / `cr`), following the same pattern
already established for the Unity CLI (`libs/unity-cli-installer.ps1`,
#76): the vendor's own `install.ps1` is downloaded to a temp file and
run via `Start-Process` in a separate process, so its own `exit` path
cannot terminate the calling PowerShell host.

CodeRabbit CLI has no winget package and no GitHub Releases,
`aqua-registry`, or npm entry, so it cannot be delegated to dotfiles'
`mise` the way the first-wave CLI tools were (roadmap #111) — verified
before authoring the issue. Unlike the Unity CLI, no version is pinned:
`Sync-CoderabbitCli` always re-runs the official installer and relies
on its own idempotent staging/rollback behavior (same "always update"
policy as the VPM CLI section of `libs/post-install.ps1`).

- `libs/coderabbit-cli-installer.ps1` (new): `Sync-CoderabbitCli` owns
  its own `git` presence check (the installer's own prerequisite) so
  the skip path stays independently testable; `$env:CI` is set only
  around the `Start-Process` call to suppress the installer's
  interactive login prompt and restored to its prior value in a
  `finally` block; `CODERABBIT_API_KEY` is never set — auth
  (`coderabbit auth login`) stays a manual step for the user.
- `tests/powershell/coderabbit-cli-installer.Tests.ps1` (new): 16
  Pester cases mirroring `unity-cli-installer.Tests.ps1`'s mocking
  approach.
- `libs/post-install.ps1`: wires in `Sync-CoderabbitCli` next to the
  VPM CLI section.
- `boxstarter.ps1`: Phase 5 heading comment updated to name CodeRabbit
  CLI.
- `README.md` / `README.ja.md`: architecture diagram, "Via
  Post-Install Scripts" list, and the "two exceptions" User-PATH
  ownership note updated for both languages.
- `docs/dsc-migration-notes.md`: new section recording the unpinned
  `install.ps1` trust model (same as Unity CLI's) and flagging which
  vendor-script behaviors (env-var handling, PATH mechanics, ARM64
  x64-emulation) are an unverified AI summary rather than a read of
  the script's own source.

Verified locally against a clean tree: `markdownlint-cli2`, `cspell
lint`, `Invoke-ScriptAnalyzer -EnableExit` (0 findings), and
`Invoke-Pester -Path ./tests/powershell -CI` (131 passed, 0 failed).
This Windows-only script could not be exercised against a real
`coderabbit` binary or `install.ps1` invocation from this Linux
environment — consistent with this repository's existing practice
(`libs/post-install.ps1` / `boxstarter.ps1` are never executed
directly here even for smoke-testing).

## Follow-ups (not filed as issues)

- The vendor `install.ps1`'s exact environment-variable handling
  (`CODERABBIT_VERSION`, `CI`), PATH-update mechanics, and ARM64
  x64-emulation behavior are recorded as unverified in
  `docs/dsc-migration-notes.md` — a real-machine confirmation would
  strengthen those code comments the way issue #76 did for Unity's
  `install.ps1`.

Closes #126.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic installation and updating of the CodeRabbit CLI during post-install setup.
  * Supports native Windows x64 environments and updates the current session’s PATH.
  * Skips installation when Git for Windows is unavailable.

* **Documentation**
  * Documented installation behavior, requirements, PATH handling, and known limitations in the English and Japanese README files.
  * Added migration notes covering CodeRabbit CLI support and installation details.

* **Tests**
  * Added coverage for PATH management, installation failures, cleanup, environment restoration, and repeated setup runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->