### PR TITLE
fix(setup): quote the temp script path in Unity CLI installer

### DIFF
--- a/libs/unity-cli-installer.ps1
+++ b/libs/unity-cli-installer.ps1
@@ -80,8 +80,15 @@ function Invoke-UnityCliInstaller {
       return 1
     }
     $shell = (Get-Process -Id $PID).Path
+    # Start-Process -ArgumentList joins array elements with a bare
+    # space and does not quote them itself (this is documented
+    # Start-Process behavior, not a bug) -- an unquoted $tempScript
+    # would truncate at the first space in a TEMP path containing
+    # one, so it's quoted explicitly here. -Target/-Channel stay
+    # unquoted: they're version/channel strings, not filesystem
+    # paths, so they carry no embedded-space risk.
     $process = Start-Process -FilePath $shell -ArgumentList @(
-      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $tempScript,
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$tempScript`"",
       '-Target', $Target, '-Channel', $Channel
     ) -NoNewWindow -Wait -PassThru
     return $process.ExitCode

--- a/tests/powershell/unity-cli-installer.Tests.ps1
+++ b/tests/powershell/unity-cli-installer.Tests.ps1
@@ -82,6 +82,21 @@ Describe 'Invoke-UnityCliInstaller' {
 
     Should -Invoke Remove-Item -Times 1
   }
+
+  It 'quotes the -File argument so a TEMP path containing spaces is not truncated by Start-Process argument joining' {
+    $script:capturedArgumentList = $null
+    Mock Invoke-WebRequest { }
+    Mock Start-Process {
+      $script:capturedArgumentList = $ArgumentList
+      [pscustomobject]@{ ExitCode = 0 }
+    }
+
+    Invoke-UnityCliInstaller -Target '1.0.0-beta.3' -Channel 'beta' | Out-Null
+
+    $fileIndex = [array]::IndexOf($script:capturedArgumentList, '-File')
+    $fileIndex | Should -BeGreaterThan -1
+    $script:capturedArgumentList[$fileIndex + 1] | Should -Match '^".*"$'
+  }
 }
 
 Describe 'Sync-UnityCli' {


### PR DESCRIPTION
## Summary

`Invoke-UnityCliInstaller` (`libs/unity-cli-installer.ps1`) passed
`$tempScript` as a bare, unquoted array element to `Start-Process
-ArgumentList`. `Start-Process -ArgumentList` joins array elements with
a plain space and does not quote them itself, so a TEMP directory path
containing a space truncates `-File`'s value at the first space when
the child `pwsh` process parses its command line, breaking the
installer launch.

The identical pattern was already fixed for the sibling function
`Invoke-CoderabbitCliInstaller` (`libs/coderabbit-cli-installer.ps1`)
in #127 / commit ca98f49, which reproduced the failure locally (exit
code 64 / "is not recognized as the name of a script file") but left
this file's occurrence out of scope. This PR applies the same fix here.

- `libs/unity-cli-installer.ps1`: quotes the `-File` array element
  (`"`"$tempScript`""`, same pattern as ca98f49); `-Target`/`-Channel`
  stay unquoted since they're version/channel strings, not filesystem
  paths.
- `tests/powershell/unity-cli-installer.Tests.ps1`: adds a regression
  case mirroring the one added for `Invoke-CoderabbitCliInstaller` —
  mocks `Start-Process`, captures `-ArgumentList`, and asserts the
  element after `-File` is fully double-quoted.

Verified locally against a clean tree with the full `pre-push-validate`
chain: `markdownlint-cli2`, `cspell lint`, `Invoke-ScriptAnalyzer
-EnableExit` (0 findings), and `Invoke-Pester -Path ./tests/powershell
-CI` (134 passed, 0 failed).

Fixes #128.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Unity CLI installation when the temporary installer path contains spaces.
  - Installer script paths are now passed correctly to the process launcher, preventing truncated paths and installation failures.

- **Tests**
  - Added coverage to verify installer paths containing spaces are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->