### PR TITLE
fix(setup): refresh PATH from registry before tool checks

### DIFF
--- a/libs/coderabbit-cli-installer.ps1
+++ b/libs/coderabbit-cli-installer.ps1
@@ -8,6 +8,8 @@ libs/post-install.ps1 -- do not add Export-ModuleMember here.
 #>
 Set-StrictMode -Version Latest
 
+. (Join-Path -Path $PSScriptRoot -ChildPath 'process-path-sync.ps1')
+
 $Script:CoderabbitCliInstallScriptUrl = 'https://cli.coderabbit.ai/install.ps1'
 # $env:LOCALAPPDATA is Windows-only and absent on the Linux CI runner
 # that runs this file's Pester tests -- guarded so dot-sourcing this
@@ -157,6 +159,7 @@ function Sync-CoderabbitCli {
   [CmdletBinding()]
   param ()
 
+  Sync-ProcessPath
   if ($null -eq (Get-Command git -ErrorAction SilentlyContinue)) {
     Write-Warning '[coderabbit-cli] git not found -- skipping CodeRabbit CLI.'
     return
@@ -184,7 +187,12 @@ function Sync-CoderabbitCli {
   sections of libs/post-install.ps1 do -- this keeps the check
   independently testable via
   tests/powershell/coderabbit-cli-installer.Tests.ps1 without dot-
-  sourcing post-install.ps1's Test-CommandExists helper.
+  sourcing post-install.ps1's Test-CommandExists helper. It does,
+  however, share libs/process-path-sync.ps1's Sync-ProcessPath with
+  Test-CommandExists (called above, before the git check) so a `git`
+  installed earlier in this same process -- e.g. by WinGet
+  Configuration in Phase 2 -- is reliably detected here too, instead of
+  only after a reboot (issue #129).
 
   Unlike libs/unity-cli-installer.ps1's Sync-UnityCli, this function
   does not pin a target version or skip when a matching version is

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -29,16 +29,25 @@ $runtimeVersionsFile = $PSScriptRoot `
 ###########################################################################
 ### Helper — correct command existence check (fixes the Out-Null bug)
 ###########################################################################
+. (Join-Path -Path $PSScriptRoot -ChildPath 'process-path-sync.ps1')
+
 function Test-CommandExists {
   param (
     [Parameter(Mandatory)][string]$Name
   )
+  Sync-ProcessPath
   $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
   <#
   .SYNOPSIS
   Returns $true if a command exists on PATH, $false otherwise.
   This avoids the historic `Get-Command ... | Out-Null` bug where the
   pipeline always evaluates to $null ($false).
+
+  .DESCRIPTION
+  Calls Sync-ProcessPath first so a tool installed earlier in this same
+  process (e.g. by WinGet Configuration in Phase 2) but not yet
+  reflected in this process's own $env:Path is still detected here
+  (issue #129) -- see libs/process-path-sync.ps1.
   #>
 }
 

--- a/libs/process-path-sync.ps1
+++ b/libs/process-path-sync.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+Refreshes the current process's $env:Path from the persisted
+Machine/User PATH values, so a tool installed earlier in this same
+PowerShell process (e.g. by WinGet Configuration in Phase 2) is
+reliably detected by a later Get-Command-based check in the same
+process (e.g. Phase 5's dotnet/vagrant/mkcert/git checks) without
+waiting for a reboot or a fresh process (issue #129).
+
+This file is dot-sourced (not imported as a module) from both
+libs/post-install.ps1 and libs/coderabbit-cli-installer.ps1 -- do not
+add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+function Get-RegistryPathValue {
+  [CmdletBinding()]
+  [OutputType([string])]
+  param (
+    [Parameter(Mandatory)]
+    [ValidateSet('Machine', 'User')]
+    [string]$Scope
+  )
+  [System.Environment]::GetEnvironmentVariable('Path', $Scope)
+  <#
+  .SYNOPSIS
+  Reads the persisted PATH value for the given scope -- the same value
+  Windows installers themselves write to (Machine backs onto HKLM's
+  ...\Session Manager\Environment, User onto HKCU's Environment) -- via
+  .NET's [System.Environment]::GetEnvironmentVariable(name, target)
+  overload.
+
+  .DESCRIPTION
+  Isolated into its own one-line function purely so Pester's Mock can
+  intercept it -- Mock cannot intercept a bare static .NET method call.
+  This mirrors the existing pattern already used elsewhere in this
+  repository for the same reason (e.g.
+  libs/unity-editor-installer.ps1's Invoke-UnityEditorsListCommand,
+  libs/unity-cli-installer.ps1's Get-InstalledUnityCliVersion).
+
+  Verified empirically that on the non-Windows runner this file's own
+  Pester suite executes on, the Machine/User overload does not throw --
+  it returns $null -- so no platform guard is added here; an
+  accidentally-unmocked call in a new test fails on a clear assertion
+  mismatch instead of an unrelated platform exception. A guard keyed on
+  $IsWindows is deliberately avoided too: libs/post-install.ps1 and
+  libs/coderabbit-cli-installer.ps1 (this file's two callers) are
+  intentionally kept compatible with Windows PowerShell 5.1 (no
+  #Requires -Version 7.0, unlike scripts/*.ps1 -- see
+  docs/dsc-migration-notes.md's "PowerShell 7+ requirement" section),
+  where $IsWindows does not exist and would itself throw under this
+  repository's blanket Set-StrictMode -Version Latest.
+
+  .OUTPUTS
+  String, or $null if the scope has no persisted PATH value.
+  #>
+}
+
+function Sync-ProcessPath {
+  [CmdletBinding()]
+  param ()
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $existing = @($env:Path -split ';' | Where-Object { $_ -ne '' })
+  $additions = @(
+    (Get-RegistryPathValue -Scope Machine), (Get-RegistryPathValue -Scope User)
+  ) `
+    | Where-Object { $_ } `
+    | ForEach-Object { $_ -split ';' } `
+    | Where-Object { $_ -ne '' }
+  $merged = @(
+    foreach ($entry in @($existing) + @($additions)) {
+      $normalized = $entry.TrimEnd('\', '/')
+      if ($seen.Add($normalized)) {
+        $entry
+      }
+    }
+  )
+  $env:Path = $merged -join ';'
+  <#
+  .SYNOPSIS
+  Rebuilds the current process's $env:Path by merging the Machine-scope
+  and User-scope PATH values read live from the registry (via
+  Get-RegistryPathValue) on top of whatever is already in $env:Path.
+
+  .DESCRIPTION
+  A child installer (WinGet Configuration in Phase 2, or an msi/exe run
+  from Phase 2/3/4) only ever updates the persisted Machine/User PATH --
+  it cannot reach back into boxstarter.ps1's own already-running
+  process to update *its* $env:Path, and only a brand-new process picks
+  up a persisted PATH change. Call this immediately before any
+  Get-Command-based tool-existence check that must reliably detect a
+  tool installed earlier in the same process (issue #129).
+
+  Existing $env:Path entries are preserved, never replaced, so a
+  process-only PATH addition that is not registry-backed -- for
+  example libs/coderabbit-cli-installer.ps1's own
+  Add-CoderabbitCliToProcessPath appending its install dir directly --
+  is never dropped by this merge. Entries are deduplicated case- and
+  trailing-separator-insensitively, keeping each entry's first
+  occurrence and its original relative order (existing entries first,
+  then any new Machine-scope entries, then any new User-scope entries)
+  -- the same dedup semantics Add-CoderabbitCliToProcessPath already
+  uses, for consistency.
+  #>
+}

--- a/tests/powershell/coderabbit-cli-installer.Tests.ps1
+++ b/tests/powershell/coderabbit-cli-installer.Tests.ps1
@@ -156,6 +156,30 @@ Describe 'Invoke-CoderabbitCliInstaller' {
 Describe 'Sync-CoderabbitCli' {
   BeforeEach {
     Mock Get-Command -ParameterFilter { $Name -eq 'git' } { [pscustomobject]@{ Name = 'git' } }
+    # Sync-ProcessPath (libs/process-path-sync.ps1) is mocked away here
+    # for the same reason Add-CoderabbitCliToProcessPath already is
+    # below -- it mutates real $env:Path, and these tests only care
+    # that Sync-CoderabbitCli calls it, not what it actually does (that
+    # behavior is covered by tests/powershell/process-path-sync.Tests.ps1).
+    Mock Sync-ProcessPath { }
+  }
+
+  It 'refreshes the process PATH before checking for git, so a tool installed earlier in the same process is detected (issue #129)' {
+    Mock Add-CoderabbitCliToProcessPath { }
+    Mock Invoke-CoderabbitCliInstaller { 0 }
+
+    Sync-CoderabbitCli
+
+    Should -Invoke Sync-ProcessPath -Times 1
+  }
+
+  It 'refreshes the process PATH even when git turns out not to be found' {
+    Mock Get-Command -ParameterFilter { $Name -eq 'git' } { $null }
+    Mock Invoke-CoderabbitCliInstaller { 0 }
+
+    Sync-CoderabbitCli -WarningAction SilentlyContinue
+
+    Should -Invoke Sync-ProcessPath -Times 1
   }
 
   It 'skips installation and does not touch PATH when git is not found' {

--- a/tests/powershell/coderabbit-cli-installer.Tests.ps1
+++ b/tests/powershell/coderabbit-cli-installer.Tests.ps1
@@ -165,12 +165,21 @@ Describe 'Sync-CoderabbitCli' {
   }
 
   It 'refreshes the process PATH before checking for git, so a tool installed earlier in the same process is detected (issue #129)' {
+    # Records actual call order (not just call counts) so this test
+    # fails if Sync-ProcessPath is ever moved after the git check --
+    # which would silently reintroduce issue #129's stale-PATH bug.
+    $script:callOrder = [System.Collections.Generic.List[string]]::new()
+    Mock Sync-ProcessPath { $script:callOrder.Add('Sync-ProcessPath') }
+    Mock Get-Command -ParameterFilter { $Name -eq 'git' } {
+      $script:callOrder.Add('Get-Command-git')
+      [pscustomobject]@{ Name = 'git' }
+    }
     Mock Add-CoderabbitCliToProcessPath { }
     Mock Invoke-CoderabbitCliInstaller { 0 }
 
     Sync-CoderabbitCli
 
-    Should -Invoke Sync-ProcessPath -Times 1
+    $script:callOrder | Should -Be @('Sync-ProcessPath', 'Get-Command-git')
   }
 
   It 'refreshes the process PATH even when git turns out not to be found' {

--- a/tests/powershell/coderabbit-cli-installer.Tests.ps1
+++ b/tests/powershell/coderabbit-cli-installer.Tests.ps1
@@ -182,7 +182,7 @@ Describe 'Sync-CoderabbitCli' {
     Should -Invoke Sync-ProcessPath -Times 1
   }
 
-  It 'skips installation and does not touch PATH when git is not found' {
+  It 'skips installation and does not add the CodeRabbit CLI install dir to PATH when git is not found' {
     Mock Get-Command -ParameterFilter { $Name -eq 'git' } { $null }
     Mock Add-CoderabbitCliToProcessPath { }
     Mock Invoke-CoderabbitCliInstaller { 0 }

--- a/tests/powershell/process-path-sync.Tests.ps1
+++ b/tests/powershell/process-path-sync.Tests.ps1
@@ -1,0 +1,134 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'process-path-sync.ps1')
+}
+
+Describe 'Sync-ProcessPath' {
+  BeforeEach {
+    $script:originalPath = $env:Path
+  }
+
+  AfterEach {
+    $env:Path = $script:originalPath
+  }
+
+  It 'merges Machine- and User-scope registry PATH values into the current process PATH' {
+    $env:Path = '/existing/one'
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'Machine' } { '/machine/dir' }
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'User' } { '/user/dir' }
+
+    Sync-ProcessPath
+
+    $entries = @($env:Path -split ';' | Where-Object { $_ -ne '' })
+    $entries | Should -Contain '/existing/one'
+    $entries | Should -Contain '/machine/dir'
+    $entries | Should -Contain '/user/dir'
+  }
+
+  It 'splits a multi-entry registry PATH value on the separator' {
+    $env:Path = '/existing/one'
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'Machine' } { '/machine/one;/machine/two' }
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'User' } { $null }
+
+    Sync-ProcessPath
+
+    $entries = @($env:Path -split ';' | Where-Object { $_ -ne '' })
+    $entries | Should -Contain '/machine/one'
+    $entries | Should -Contain '/machine/two'
+  }
+
+  It 'does not duplicate an entry that only differs by case or a trailing slash' {
+    $env:Path = '/Existing/DIR/'
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'Machine' } { '/existing/dir' }
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'User' } { $null }
+
+    Sync-ProcessPath
+
+    @($env:Path -split ';' | Where-Object { $_ -ne '' }).Count | Should -Be 1
+  }
+
+  It 'keeps the first occurrence of a duplicate and preserves relative order' {
+    $env:Path = '/existing/one;/shared/dir;/existing/two'
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'Machine' } { '/SHARED/DIR/;/machine/new' }
+    Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'User' } { $null }
+
+    Sync-ProcessPath
+
+    $env:Path | Should -Be '/existing/one;/shared/dir;/existing/two;/machine/new'
+  }
+
+  It 'no-ops safely (existing PATH unchanged) when both registry scopes are null' {
+    $env:Path = '/existing/one;/existing/two'
+    Mock Get-RegistryPathValue { $null }
+
+    { Sync-ProcessPath } | Should -Not -Throw
+    $env:Path | Should -Be '/existing/one;/existing/two'
+  }
+
+  It 'no-ops safely when both registry scopes are empty strings' {
+    $env:Path = '/existing/one'
+    Mock Get-RegistryPathValue { '' }
+
+    { Sync-ProcessPath } | Should -Not -Throw
+    $env:Path | Should -Be '/existing/one'
+  }
+
+  It 'reproduces the issue #129 same-process detection gap: a real tool installed only into a directory reported by the registry read becomes part of $env:Path -- the mechanism Get-Command-based checks rely on -- after Sync-ProcessPath runs, and was absent before' {
+    # A real file (not just a string) is used for this tool directory so
+    # the scenario matches the real one: a genuine binary landed on disk
+    # earlier in this process (e.g. Phase 2's WinGet Configuration) in a
+    # directory this process's own $env:Path doesn't include yet, while
+    # the Machine-scope registry PATH (mocked here) already does.
+    $toolDir = Join-Path ([System.IO.Path]::GetTempPath()) "process-path-sync-test-$([guid]::NewGuid().ToString('N'))"
+    New-Item -Path $toolDir -ItemType Directory -Force | Out-Null
+    try {
+      $toolName = 'fake-newly-installed-tool-129'
+      if ($IsWindows) {
+        $toolPath = Join-Path $toolDir "$toolName.cmd"
+        Set-Content -Path $toolPath -Value '@echo off' -Encoding ascii
+      }
+      else {
+        $toolPath = Join-Path $toolDir $toolName
+        $shellScript = @'
+#!/bin/sh
+exit 0
+'@
+        Set-Content -Path $toolPath -Value $shellScript -Encoding ascii
+        & chmod +x $toolPath
+      }
+
+      $env:Path = '/existing/one'
+      Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'Machine' } { $toolDir }
+      Mock Get-RegistryPathValue -ParameterFilter { $Scope -eq 'User' } { $null }
+
+      # Content-based assertions (not a live Get-Command probe): $env:Path
+      # and the OS-level PATH environment variable Get-Command actually
+      # resolves against are the same case-insensitive variable on
+      # Windows (this function's only real target), but distinct,
+      # case-sensitive variables on Linux/macOS -- so a real Get-Command
+      # round-trip through $env:Path here would be meaningless on the
+      # non-Windows runner this suite's CI job actually executes on. This
+      # mirrors the existing repo convention: Add-CoderabbitCliToProcessPath
+      # / Add-UnityCliToProcessPath's own Pester tests likewise only ever
+      # assert on $env:Path's string content, never on a live Get-Command
+      # resolution.
+      @($env:Path -split ';' | Where-Object { $_ -ne '' }) | Should -Not -Contain $toolDir
+
+      Sync-ProcessPath
+
+      @($env:Path -split ';' | Where-Object { $_ -ne '' }) | Should -Contain $toolDir
+
+      # Bonus real-world confirmation, Windows-only: on Windows,
+      # $env:Path IS the case-insensitive OS-level PATH Get-Command
+      # resolves against, so this genuinely proves end-to-end detection
+      # there. Skipped everywhere else (including this suite's actual CI
+      # runner) rather than silently no-op'd, so it's visible in the
+      # Pester summary as skipped, not counted as a pass.
+      if ($IsWindows) {
+        Get-Command $toolName -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+      }
+    }
+    finally {
+      Remove-Item -Path $toolDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `libs/process-path-sync.ps1`, a shared `Sync-ProcessPath` helper that
  rebuilds the current process's `$env:Path` by merging the Machine- and
  User-scope PATH values read live from the registry (via a new,
  independently mockable `Get-RegistryPathValue` wrapper) on top of
  whatever is already in `$env:Path`, deduplicating case-/trailing-
  separator-insensitively.
- Call `Sync-ProcessPath` as the first statement inside
  `libs/post-install.ps1`'s `Test-CommandExists` and
  `libs/coderabbit-cli-installer.ps1`'s `Sync-CoderabbitCli`, so a tool
  installed earlier in the same PowerShell process (e.g. by WinGet
  Configuration in Phase 2) is reliably detected by a `Get-Command`-based
  check later in the same process (e.g. Phase 5's dotnet/vagrant/mkcert/
  git checks), instead of only after a reboot.
- Add `tests/powershell/process-path-sync.Tests.ps1` and extend
  `tests/powershell/coderabbit-cli-installer.Tests.ps1`'s `Sync-CoderabbitCli`
  block with a `Sync-ProcessPath` mock/assertion.

Closes #129

## Background

A child installer launched during Phase 2 (WinGet Configuration) only
ever persists PATH changes to the Machine/User registry — it cannot
reach back into `boxstarter.ps1`'s already-running process to update
that process's own `$env:Path`, and only a brand-new process picks up a
persisted PATH change. Phase 5 (`libs/post-install.ps1`'s
`Test-CommandExists` calls for dotnet/vagrant/mkcert, and
`libs/coderabbit-cli-installer.ps1`'s own `git` check inside
`Sync-CoderabbitCli`) runs in that same process, so a tool installed in
Phase 2 could be misreported as "not found" and its dependent step
skipped, until the next reboot/process restart. This was raised during
PR #127's review (issue #126) and deliberately deferred to this
follow-up issue.

## Judgment call: unification scope (acceptance criterion #2)

**Unified**: `Sync-ProcessPath` is called from both `Test-CommandExists`
(covering all three of its call sites — dotnet, vagrant, mkcert — without
touching each site individually) and `Sync-CoderabbitCli` (its `git`
check), because Phase 2's WinGet Configuration can install any of
dotnet/git/vagrant/mkcert equally — there's no technical reason to
special-case the `git` check.

**Not merged**: `Test-CommandExists` itself is not folded into
`Sync-CoderabbitCli`'s `git` check to create one single shared
existence-check function. `coderabbit-cli-installer.ps1`'s existing
docstring explains it intentionally keeps its `git` check independent of
`post-install.ps1`'s `Test-CommandExists`, so `Sync-CoderabbitCli` stays
testable via `tests/powershell/coderabbit-cli-installer.Tests.ps1` without
dot-sourcing `post-install.ps1`. Only the PATH-refresh mechanism is
unified; each file keeps its own existence-check implementation.

**Excluded**: `libs/unity-editor-installer.ps1`'s `Test-UnityCliAvailable`
and `libs/unity-cli-installer.ps1`'s own `Get-Command unity` checks. The
Unity CLI is never installed via Phase 2 WinGet Configuration (only
`Unity.UnityHub` — the GUI hub, not the `unity` CLI binary — is a
declared winget package); the CLI itself is installed via its own
direct-download `install.ps1`, and `libs/unity-cli-installer.ps1` already
ships its own dedicated `Add-UnityCliToProcessPath` process-PATH refresh
around that install call. So Unity doesn't have the stale-registry-vs-
process-PATH gap this issue addresses. `libs/strategy.ps1`'s
`Test-ConfigurationStrategy` also checks `Get-Command winget`, but that
check runs as Phase 2's own first gate — `winget` must already resolve
before Phase 2 (the phase this issue is about) can run at all, so it
isn't a "just installed earlier in this same process" case either.

## Notes on the new test

`tests/powershell/process-path-sync.Tests.ps1`'s end-to-end test creates
a real (temporary) executable to model a tool Phase 2 "just installed,"
then asserts via `$env:Path`'s string content — not a live `Get-Command`
round-trip — that the tool's directory is absent before `Sync-ProcessPath`
and present after. This mirrors the existing
`Add-CoderabbitCliToProcessPath`/`Add-UnityCliToProcessPath` Pester tests
in this repo, which likewise only assert on `$env:Path` content: on
Windows (this function's only real target), `$env:Path` and the OS-level
`PATH` variable `Get-Command` actually resolves against are the same
case-insensitive variable, but on Linux/macOS they are distinct,
case-sensitive variables — so a real `Get-Command` round-trip through
`$env:Path` would be meaningless on the non-Windows runner this repo's
Pester CI job (`ubuntu-latest`) actually executes on. A best-effort real
`Get-Command` assertion is still included, gated on `$IsWindows` (skipped
everywhere else, including this repo's CI).

## Test plan

- [x] `npx -y markdownlint-cli2 "**/*.md"` — clean
- [x] `npx -y cspell lint "**" --no-progress` — clean
- [x] `pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit"` — 0 findings
- [x] `pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"` — 143 passed, 0 failed
- [ ] CI (this PR's own checks)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newly installed command-line tools are now detected immediately without restarting the current shell or process.
  * Installer and post-install checks refresh the active PATH before verifying required commands.
  * PATH synchronization preserves existing entries, removes duplicates, and consistently combines system and user settings.

* **Tests**
  * Added coverage for PATH merging, command detection, duplicate handling, ordering, environment restoration, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->