### PR TITLE
chore(idd): trust github-actions[bot] for F4 dedup markers

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -9,7 +9,7 @@
     "staleAge": "PT12H",
     "heartbeatInterval": "PT6H"
   },
-  "trustedMarkerActors": ["kurone-kito"],
+  "trustedMarkerActors": ["kurone-kito", "github-actions[bot]"],
   "advisoryBotLogins": [
     "copilot-pull-request-reviewer[bot]",
     "coderabbitai[bot]"

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -188,6 +188,25 @@ configured.
 elevated merge-only credential set exists; any session holding a valid
 claim may carry it through to merge.
 
+### Trusted Marker Actors
+
+**Current value** (`trustedMarkerActors` in
+[`.github/idd/config.json`](../.github/idd/config.json)):
+`["kurone-kito", "github-actions[bot]"]`.
+
+`github-actions[bot]` is included because
+[`.github/workflows/post-merge-cleanup.yml`](../.github/workflows/post-merge-cleanup.yml)
+posts its F4 server-side-fallback `idd-cleanup-evidence` comments using
+the workflow's `GITHUB_TOKEN`, which always authors as
+`github-actions[bot]`. The workflow's own duplicate-prevention logic
+already hardcodes this login as trusted, but the agent-side F4 dedup
+check reads only `trustedMarkerActors` from
+`.github/idd/config.json` — without this entry, an agent running F4
+after the workflow already posted evidence cannot recognize that
+comment as trusted and reposts a duplicate. This duplication was
+observed for issue #129 (PR #131) on 2026-09-01 before this entry was
+added (#132).
+
 ### Helper Runtime Profile
 
 **Profile**: `ephemeral-npx`


### PR DESCRIPTION
## Summary

- Add `github-actions[bot]` to `trustedMarkerActors` in
  `.github/idd/config.json`, matching the login
  `post-merge-cleanup.yml` already hardcodes as trusted for its own
  duplicate-prevention check when it posts `idd-cleanup-evidence` F4
  fallback comments via `GITHUB_TOKEN`.
- Record the same change and its rationale in a new
  `### Trusted Marker Actors` subsection of `docs/idd-policy.md`
  (placed after `### Credential Scope`).

Closes #132

## Background

The agent-side F4 dedup check reads only `trustedMarkerActors` from
`.github/idd/config.json`. Before this change that array was
`["kurone-kito"]`, so when `post-merge-cleanup.yml` had already
posted its own `idd-cleanup-evidence` comment (authored as
`github-actions[bot]`), an agent subsequently running F4 could not
recognize that comment as trusted and would repost a duplicate. This
was observed for issue #129 (PR #131) on 2026-09-01.

## Test plan

- [x] `npx -y markdownlint-cli2 "**/*.md"` — clean
- [x] `npx -y cspell lint "**" --no-progress` — clean
- [x] `pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit"` — clean
- [x] `pwsh -c "Invoke-Pester -Path ./tests/powershell -CI"` — 143 passed, 0 failed
- [x] `idd-doctor` — `PASS  .github/idd/config.json validates against policy.schema.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented trusted marker actors and workflow-generated cleanup comments.
* **Chores**
  * Updated trusted actor recognition to include automated workflow comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->