### PR TITLE
fix(ci): limit lint.yml push trigger to master only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Linting workflow
 on:
   push:
-    branches: ["**"]
+    branches: ["master"]
     tags: ["**"]
   pull_request:
 permissions:


### PR DESCRIPTION
<!--
🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/setup.windows/blob/master/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/setup.windows/blob/master/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/setup.windows/blob/master/.github/CONTRIBUTING.zh.md
-->

## Summary

- Narrow `.github/workflows/lint.yml`'s `push.branches` from `["**"]`
  to `["master"]` only, so a push to a PR branch no longer fires the
  `Linting workflow` twice (once via `push`, once via `pull_request`)
  for the same HEAD SHA.
- `push.tags` (`["**"]`) and the `pull_request:` trigger are unchanged.
  Direct pushes to `master` (a merge-commit landing — this repo's
  ruleset restricts `allowed_merge_methods` to `["merge"]`, no
  squash/rebase — or an admin push) still run the workflow.

## Background

Before this change, a push to any branch (`branches: ["**"]`) plus
`pull_request:` both triggered `Linting workflow` for the same HEAD
SHA on a PR branch. `concurrency.group` resolves to the same string
for both events on the same SHA, so `cancel-in-progress: true`
cancels one of the two runs — but the CANCELLED run stays visible on
GitHub's required-check rollup, which `idd-skill`'s
`discarded-required-check-siblings` diagnosis has to work around. This
already blocked a merge once on this repo (issue #128 / PR #130),
requiring a manual `gh run rerun` recovery.

Closes #133

## Verification observed

- **Bootstrap push** (this branch's own fix commit,
  `6512a38`): pushed to
  `issue/133-fix-ci-lint-yml-push-master-pull-request` before any PR
  existed. `gh run list --branch issue/133-fix-ci-lint-yml-push-master-pull-request --workflow "Linting workflow"`
  returned **zero runs** for that push — consistent with the fix
  working as designed (the pushed ref's own workflow file already has
  `branches: ["master"]`, so a push to a non-`master` branch no longer
  matches the trigger at all; `pull_request` had nothing to fire yet
  since no PR was open). This is the expected "no race, and also no
  run yet" bootstrap outcome documented in the issue, distinct from
  (but not contradicting) the "one raced-then-cancelled run" outcome
  the issue also called out as an acceptable observation for this
  specific bootstrap SHA.
- **Historical confirmation of the pre-fix bug**: the immediately
  prior sibling PR's branch push (`issue/132-...`,
  2026-09-01T08:07Z) shows exactly the described duplicate-trigger
  pattern under the *old* config — a `push`-triggered `Linting
  workflow` run (databaseId `33485427269`) and a separate
  `pull_request`-triggered run (databaseId `33485457296`) for the same
  branch, minutes apart.
- Local **pre-push-validate** (markdownlint, cspell, PSScriptAnalyzer,
  Pester) passed clean on this branch's HEAD before the push: 143
  Pester tests passed, 0 PSScriptAnalyzer findings, 0 markdownlint/
  cspell issues.
- Branch protection / required status checks
  (`gh api repos/kurone-kito/setup.windows/rulesets`) were confirmed
  unaffected: required checks are plain name-based contexts (`lint`,
  `powershell-analyzer`, `pester`, `configuration-drift`,
  `idd-advisory-convergence`), event-agnostic, and no `merge_group`
  rule exists in this repo (so the narrowed `push.branches` cannot
  break a merge-queue path that doesn't exist here).
- A follow-up empty verification commit (`29003d7`,
  `ci: verify push-trigger narrowing on feature branch`) was pushed
  after PR creation to observe a push strictly after the fix commit is
  already the branch tip. Result, posted with full `gh run list`
  evidence as a
  [PR comment](https://github.com/kurone-kito/setup.windows/pull/135#issuecomment-5491428735)
  and reconfirmed independently below: both this branch's `Linting
  workflow` runs (`6512a38` and `29003d7`) were triggered by
  `pull_request` only — zero `push`-triggered runs for either SHA.
- The `master`-push-still-triggers criterion (AC3) will be confirmed
  at merge time by observing `Linting workflow` fire on the merge
  commit SHA landing on `master` (this repo's ruleset permits only the
  `merge` method, not squash or rebase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated lint checks to run on pushes to the master branch.
  * Pull request and tag-based lint checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
