### PR TITLE
refactor(setup): remove Cursor AI editor from full profile

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,7 +65,7 @@ setup.cmd                        ← 唯一のエントリーポイント
 
 1. **Chocolatey** と **Boxstarter** が未インストールならインストール
 2. `Install-BoxstarterPackage` 経由で `boxstarter.ps1` を起動（再起動耐性あり）
-3. **WinGet Configuration (DSC)** で 104 個のパッケージを宣言的にインストール
+3. **WinGet Configuration (DSC)** で 102 個のパッケージを宣言的にインストール
    （利用できない場合は **`winget import`**（縮退モード）にフォール
    バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール
@@ -93,7 +93,7 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 - **ランタイム:** .NET SDK 8/10, Rust, Visual C++ 再頒布可能パッケージ
 - **開発:** Git, Android Studio
 - **VRChat:** Unity Hub, VRChat Creator Companion, VRCX
-- **エディタ:** VS Code, Cursor, Sublime Text 4, Vim, Neovim
+- **エディタ:** VS Code, Sublime Text 4, Vim, Neovim
 - **CLI ツール:** 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert
 - **ブラウザ:** Chrome, Firefox ESR, Tor Browser
 - **ゲーミング:** Steam, Epic Games, EA Desktop, Minecraft, StepMania

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The script will:
 
 1. Install **Chocolatey** and **Boxstarter** if not already present
 2. Launch `boxstarter.ps1` via `Install-BoxstarterPackage` (reboot-resilient)
-3. Apply the **WinGet Configuration (DSC)** to install 104 packages
+3. Apply the **WinGet Configuration (DSC)** to install 102 packages
    declaratively when available, otherwise fall back to
    **`winget import`** (degraded mode) and report any resources it
    could not apply
@@ -93,7 +93,7 @@ the full list. Key categories:
 - **Runtimes:** .NET SDK 8/10, Rust, Visual C++ Redistributable
 - **Development:** Git, Android Studio
 - **VRChat:** Unity Hub, VRChat Creator Companion, VRCX
-- **Editors:** VS Code, Cursor, Sublime Text 4, Vim, Neovim
+- **Editors:** VS Code, Sublime Text 4, Vim, Neovim
 - **CLI Tools:** 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert
 - **Browsers:** Chrome, Firefox ESR, Tor Browser
 - **Gaming:** Steam, Epic Games, EA Desktop, Minecraft, StepMania

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -1201,14 +1201,6 @@ properties:
     # GUI — IDE / Editors
     # ================================================================
     - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.cursor
-      directives:
-        description: Cursor AI
-      settings:
-        id: Anysphere.Cursor
-        source: winget
-
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: pkg.sublimeText
       directives:
         description: Sublime Text 4

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -107,7 +107,6 @@
         { "PackageIdentifier": "Mojang.MinecraftLauncher" },
         { "PackageIdentifier": "Valve.Steam" },
         { "PackageIdentifier": "StepMania.StepMania" },
-        { "PackageIdentifier": "Anysphere.Cursor" },
         { "PackageIdentifier": "SublimeHQ.SublimeText.4" },
         { "PackageIdentifier": "TeamViewer.TeamViewer" },
         { "PackageIdentifier": "oldj.switchhosts" },


### PR DESCRIPTION
## Summary

Cursor is a VS Code fork with a near-identical editing engine and
extension ecosystem. This repository standardizes on VS Code as the
primary editor, so keeping the GUI `Cursor` package installed
alongside it in the winget `full` profile no longer serves a purpose.

- Removed the `pkg.cursor` (`Anysphere.Cursor`) `WinGetPackage`
  resource from `configurations/packages.dsc.yaml` (`GUI — IDE /
  Editors` section).
- Regenerated `configurations/packages.import.json` via
  `./scripts/Build-Configurations.ps1` (`packages.unapplied.json` and
  the `min` profile's generated files are unaffected — confirmed by
  rerunning the generator for both profiles and diffing).
- Removed `Cursor` from the `Editors:` list in `README.md` and
  `README.ja.md`.
- Corrected the installed-package count in both READMEs from 104 to
  the actual regenerated total, **102** — not the naively expected
  103. The pre-existing "104" was already stale by one from an
  earlier, unrelated full-profile package removal that never updated
  this line; this PR's count fix absorbs that drift in addition to
  the one package this PR itself removes.

`cursor-cli` migration is out of scope, per the issue.

## Verification

- `./scripts/Build-Configurations.ps1` re-run against both
  `packages.dsc.yaml` and `packages.min.dsc.yaml` → zero working-tree
  diff (`configuration-drift` parity).
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings
  ./PSScriptAnalyzerSettings.psd1 -EnableExit` → exit 0.
- `Invoke-Pester -Path ./tests/powershell -CI` → 143 passed, 0 failed.
- `pre-push-validate` (markdownlint-cli2, cspell, ScriptAnalyzer,
  Pester) → clean.

Closes #137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed Cursor from the available GUI editor package list.
  - Updated package source configuration to no longer include Cursor.

- **Documentation**
  - Updated English and Japanese documentation to reflect the package count changing from 104 to 102.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->