### PR TITLE
refactor(setup): drop UniGetUI/X, swap Remote Desktop for Windows App

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,7 +65,7 @@ setup.cmd                        ← 唯一のエントリーポイント
 
 1. **Chocolatey** と **Boxstarter** が未インストールならインストール
 2. `Install-BoxstarterPackage` 経由で `boxstarter.ps1` を起動（再起動耐性あり）
-3. **WinGet Configuration (DSC)** で 102 個のパッケージを宣言的にインストール
+3. **WinGet Configuration (DSC)** で 100 個のパッケージを宣言的にインストール
    （利用できない場合は **`winget import`**（縮退モード）にフォール
    バックし、適用できなかったリソースを報告）
 4. Chocolatey で残りのパッケージ（フォント、オーディオドライバ）をインストール

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The script will:
 
 1. Install **Chocolatey** and **Boxstarter** if not already present
 2. Launch `boxstarter.ps1` via `Install-BoxstarterPackage` (reboot-resilient)
-3. Apply the **WinGet Configuration (DSC)** to install 102 packages
+3. Apply the **WinGet Configuration (DSC)** to install 100 packages
    declaratively when available, otherwise fall back to
    **`winget import`** (degraded mode) and report any resources it
    could not apply

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -465,14 +465,6 @@ properties:
         source: msstore
 
     - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.unigetui
-      directives:
-        description: UniGetUI (formerly WingetUI)
-      settings:
-        id: MartiCliment.UniGetUI
-        source: winget
-
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: pkg.mise
       directives:
         description: mise-en-place (mise)
@@ -1266,11 +1258,11 @@ properties:
         source: winget
 
     - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.rdp
+      id: pkg.windowsApp
       directives:
-        description: Microsoft Remote Desktop
+        description: Windows App
       settings:
-        id: "9WZDNCRFJ3PS"
+        id: "9N1F85V9T8BN"
         source: msstore
 
     - resource: Microsoft.WinGet.DSC/WinGetPackage
@@ -1314,14 +1306,6 @@ properties:
         description: Threads by Instagram
       settings:
         id: "9MXBP1FB84CQ"
-        source: msstore
-
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.x
-      directives:
-        description: X (formerly Twitter)
-      settings:
-        id: "9WZDNCRFJ140"
         source: msstore
 
     - resource: Microsoft.WinGet.DSC/WinGetPackage

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -23,12 +23,11 @@
         { "PackageIdentifier": "XPDC2RH70K22MN" },
         { "PackageIdentifier": "XP99J3KP4XZ4VV" },
         { "PackageIdentifier": "XPFFZHVGQWWLHB" },
-        { "PackageIdentifier": "9WZDNCRFJ3PS" },
+        { "PackageIdentifier": "9N1F85V9T8BN" },
         { "PackageIdentifier": "XP99DVCPGKTXNJ" },
         { "PackageIdentifier": "9WZDNCRFJ2WL" },
         { "PackageIdentifier": "9NBLGGH5L9XT" },
         { "PackageIdentifier": "9MXBP1FB84CQ" },
-        { "PackageIdentifier": "9WZDNCRFJ140" },
         { "PackageIdentifier": "9N0DX20HK701" },
         { "PackageIdentifier": "9P1J8S7CCWWT" }
       ],
@@ -41,7 +40,6 @@
     },
     {
       "Packages": [
-        { "PackageIdentifier": "MartiCliment.UniGetUI" },
         { "PackageIdentifier": "jdx.mise" },
         { "PackageIdentifier": "Microsoft.DirectX" },
         { "PackageIdentifier": "Microsoft.XNARedist" },


### PR DESCRIPTION
## Summary

Three stale winget entries in the full profile (`configurations/packages.dsc.yaml`), found in the same package-inventory pass, bundled into one change per the precedent in issue #107:

- Removed the `pkg.unigetui` (`MartiCliment.UniGetUI`) `WinGetPackage` resource (`Package managers & dependencies` section). The repository relies on the winget CLI directly, so a GUI package manager on top of it is unneeded.
- Removed the `pkg.x` (msstore `9WZDNCRFJ140`, "X (formerly Twitter)") `WinGetPackage` resource (`GUI — Social` section). The Microsoft Store listing is delisted — `https://apps.microsoft.com/detail/9WZDNCRFJ140` now returns HTTP 410 Gone.
- Replaced the `pkg.rdp` resource (`GUI — Remote` section) with `pkg.windowsApp`: `directives.description` changed from `Microsoft Remote Desktop` to `Windows App`, `settings.id` changed from msstore `9WZDNCRFJ3PS` to `9N1F85V9T8BN`, `settings.source` stays `msstore`. Windows App is Microsoft's official successor to the old Remote Desktop Store app (released September 2024; old listing removed from the Store on 2025-05-27). `pkg.teamviewer` and `pkg.realvnc` are untouched — different tools, different use cases.
- Regenerated `configurations/packages.import.json` via `./scripts/Build-Configurations.ps1` (`packages.unapplied.json` and the `min` profile's generated files are unaffected — confirmed by rerunning the generator for both profiles and diffing).
- Updated the installed-package count in `README.md` and `README.ja.md` from 102 to the actual regenerated total, **100** (2 fewer: UniGetUI and X removed; Remote Desktop → Windows App is a 1:1 swap with no net count change).

`docs/dsc-migration-notes.md`'s UniGetUI-specific note (issue #63/#64 migration history) is out of scope — it records a past decision, not this issue's current package list.

## Verification

- `./scripts/Build-Configurations.ps1` re-run against both `packages.dsc.yaml` and `packages.min.dsc.yaml` → zero working-tree diff (`configuration-drift` parity).
- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit` → exit 0.
- `Invoke-Pester -Path ./tests/powershell -CI` → 143 passed, 0 failed.
- `pre-push-validate` (markdownlint-cli2, cspell, ScriptAnalyzer, Pester) → clean.

Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows App to the available Microsoft Store package configuration.

* **Bug Fixes**
  * Updated the documented package count from 102 to 100.
  * Removed discontinued UniGetUI, Microsoft Remote Desktop, and X package entries from the configuration lists.
  * Updated the Microsoft Store identifier for the Windows App package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->