### PR TITLE
feat(setup): add Cursor CLI post-install installer

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -29,6 +29,7 @@ version: "0.2"
 words:
   - ajeetdsouza
   - antlr
+  - aquaproj
   - bbwe
   - chafa
   - chezmoi
@@ -57,6 +58,7 @@ words:
   - oldj
   - ollama
   - pixiv
+  - pkgs
   - posh
   - psmux
   - psscriptanalyzer

--- a/README.ja.md
+++ b/README.ja.md
@@ -119,9 +119,9 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 - **VPM CLI**（dotnet tool 経由）: VRChat パッケージマネージャー
 - **CodeRabbit CLI**（公式 `install.ps1` 経由）: AI コードレビュー CLI。
   バージョン固定はせず常に最新版へ更新する。Git for Windows が必須
-- **Cursor CLI**（公式 `install.ps1` 経由）: 単体バイナリの AI コーディング
-  エージェント CLI（`cursor-agent`）。バージョン固定はせず常に最新版へ
-  更新する。前提コマンドは不要
+- **Cursor CLI**（公式インストールスクリプト経由）: 単体バイナリの AI
+  コーディングエージェント CLI（`cursor-agent`）。バージョン固定はせず
+  常に最新版へ更新する。前提コマンドは不要
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA
 - **Docker イメージ**: ベースイメージ (alpine, debian, ubuntu, node 各種)
@@ -165,8 +165,8 @@ tealdeer, mkcert）。
 CodeRabbit CLI インストーラ、Cursor CLI インストーラです
 （`libs/unity-cli-installer.ps1` が Unity 公式の `install.ps1` を、
 `libs/coderabbit-cli-installer.ps1` が CodeRabbit 公式の `install.ps1`
-を、`libs/cursor-cli-installer.ps1` が Cursor 公式の `install.ps1` を
-それぞれ呼び出し、各インストーラ自身の既知の副作用として User PATH へ
+を、`libs/cursor-cli-installer.ps1` が Cursor 公式のインストール
+スクリプトをそれぞれ呼び出し、各インストーラ自身の既知の副作用として User PATH へ
 エントリを追加します — 本リポジトリのコードが直接書き込むものでは
 ありません）。それ以外の
 User PATH の所有権は dotfiles の管理対象パス reconciler にあります。

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,7 @@ setup.cmd                        ← 唯一のエントリーポイント
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
+            │    ├─ install.ps1 → Cursor CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
             │    └─ Docker Desktop → イメージ pull
@@ -118,6 +119,9 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 - **VPM CLI**（dotnet tool 経由）: VRChat パッケージマネージャー
 - **CodeRabbit CLI**（公式 `install.ps1` 経由）: AI コードレビュー CLI。
   バージョン固定はせず常に最新版へ更新する。Git for Windows が必須
+- **Cursor CLI**（公式 `install.ps1` 経由）: 単体バイナリの AI コーディング
+  エージェント CLI（`cursor-agent`）。バージョン固定はせず常に最新版へ
+  更新する。前提コマンドは不要
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA
 - **Docker イメージ**: ベースイメージ (alpine, debian, ubuntu, node 各種)
@@ -157,12 +161,14 @@ dotfiles は別プロジェクト
 tealdeer, mkcert）。
 
 本リポジトリ自身のスクリプトは Windows の User PATH を管理・書き込み
-しません。例外は 2 つ、サードパーティ製の Unity CLI インストーラと
-CodeRabbit CLI インストーラです（`libs/unity-cli-installer.ps1` が
-Unity 公式の `install.ps1` を、`libs/coderabbit-cli-installer.ps1` が
-CodeRabbit 公式の `install.ps1` をそれぞれ呼び出し、各インストーラ自身の
-既知の副作用として User PATH へエントリを追加します — 本リポジトリの
-コードが直接書き込むものではありません）。それ以外の
+しません。例外は 3 つ、サードパーティ製の Unity CLI インストーラ、
+CodeRabbit CLI インストーラ、Cursor CLI インストーラです
+（`libs/unity-cli-installer.ps1` が Unity 公式の `install.ps1` を、
+`libs/coderabbit-cli-installer.ps1` が CodeRabbit 公式の `install.ps1`
+を、`libs/cursor-cli-installer.ps1` が Cursor 公式の `install.ps1` を
+それぞれ呼び出し、各インストーラ自身の既知の副作用として User PATH へ
+エントリを追加します — 本リポジトリのコードが直接書き込むものでは
+ありません）。それ以外の
 User PATH の所有権は dotfiles の管理対象パス reconciler にあります。
 dotfiles の
 `docs/winget-user-path.md` がその仕組みを、

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ setup.cmd                        ← 唯一のエントリーポイント
             ├─ Phase 5: インストール後セットアップ (libs/post-install.ps1)
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
-            │    ├─ install.ps1 → Cursor CLI
+            │    ├─ install script → Cursor CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
             │    └─ Docker Desktop → イメージ pull
@@ -166,7 +166,7 @@ CodeRabbit CLI インストーラ、Cursor CLI インストーラです
 （`libs/unity-cli-installer.ps1` が Unity 公式の `install.ps1` を、
 `libs/coderabbit-cli-installer.ps1` が CodeRabbit 公式の `install.ps1`
 を、`libs/cursor-cli-installer.ps1` が Cursor 公式のインストール
-スクリプトをそれぞれ呼び出し、各インストーラ自身の既知の副作用として User PATH へ
+スクリプトをそれぞれ呼び出し、各インストーラ自身の副作用として User PATH へ
 エントリを追加します — 本リポジトリのコードが直接書き込むものでは
 ありません）。それ以外の
 User PATH の所有権は dotfiles の管理対象パス reconciler にあります。

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ setup.cmd                        ← single entry point
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
-            │    ├─ install.ps1 → Cursor CLI
+            │    ├─ install script → Cursor CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
             │    └─ Docker Desktop → image pulls
@@ -166,9 +166,9 @@ third-party CodeRabbit CLI installer
 (`libs/coderabbit-cli-installer.ps1` invokes CodeRabbit's own
 `install.ps1`), and the third-party Cursor CLI installer
 (`libs/cursor-cli-installer.ps1` invokes Cursor's own official install
-script), which each persist an entry there as their own documented
-side effect, not something this repository's code does directly. User
-PATH ownership
+script), which each persist an entry there as their own side effect,
+not something this repository's code does directly. User PATH
+ownership
 otherwise belongs to dotfiles' managed-path reconciler: dotfiles'
 `docs/winget-user-path.md` documents the mechanism, and
 `home/dot_config/powershell/lib/managed-paths.ps1` is its single

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ third-party CodeRabbit CLI installer
 (`libs/coderabbit-cli-installer.ps1` invokes CodeRabbit's own
 `install.ps1`), and the third-party Cursor CLI installer
 (`libs/cursor-cli-installer.ps1` invokes Cursor's own official install
-script), which each persist an entry there as their own documented side
-effect,
-not something this repository's code does directly. User PATH ownership
+script), which each persist an entry there as their own documented
+side effect, not something this repository's code does directly. User
+PATH ownership
 otherwise belongs to dotfiles' managed-path reconciler: dotfiles'
 `docs/winget-user-path.md` documents the mechanism, and
 `home/dot_config/powershell/lib/managed-paths.ps1` is its single

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ setup.cmd                        ← single entry point
             ├─ Phase 5: Post-install             (libs/post-install.ps1)
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
+            │    ├─ install.ps1 → Cursor CLI
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
             │    └─ Docker Desktop → image pulls
@@ -118,6 +119,9 @@ the full list. Key categories:
 - **VPM CLI** (via dotnet tool): VRChat package manager
 - **CodeRabbit CLI** (via official `install.ps1`): AI code review CLI,
   always updated to latest (no version pin); requires Git for Windows
+- **Cursor CLI** (via official `install.ps1`): standalone `cursor-agent`
+  AI coding agent CLI, always updated to latest (no version pin); no
+  prerequisite command required
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)
@@ -156,13 +160,14 @@ repository still installs many other CLI tools directly via winget
 above, e.g. 7-Zip, FFmpeg, fzf, jq, yq, chezmoi, tealdeer, mkcert).
 
 This repository's own scripts do not manage or write the Windows User
-PATH — the two exceptions are the third-party Unity CLI installer
-(`libs/unity-cli-installer.ps1` invokes Unity's own `install.ps1`) and
-the third-party CodeRabbit CLI installer
+PATH — the three exceptions are the third-party Unity CLI installer
+(`libs/unity-cli-installer.ps1` invokes Unity's own `install.ps1`), the
+third-party CodeRabbit CLI installer
 (`libs/coderabbit-cli-installer.ps1` invokes CodeRabbit's own
-`install.ps1`), which each persist an entry there as their own
-documented side effect, not something this repository's code does
-directly. User PATH ownership
+`install.ps1`), and the third-party Cursor CLI installer
+(`libs/cursor-cli-installer.ps1` invokes Cursor's own `install.ps1`),
+which each persist an entry there as their own documented side effect,
+not something this repository's code does directly. User PATH ownership
 otherwise belongs to dotfiles' managed-path reconciler: dotfiles'
 `docs/winget-user-path.md` documents the mechanism, and
 `home/dot_config/powershell/lib/managed-paths.ps1` is its single

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ the full list. Key categories:
 - **VPM CLI** (via dotnet tool): VRChat package manager
 - **CodeRabbit CLI** (via official `install.ps1`): AI code review CLI,
   always updated to latest (no version pin); requires Git for Windows
-- **Cursor CLI** (via official `install.ps1`): standalone `cursor-agent`
-  AI coding agent CLI, always updated to latest (no version pin); no
-  prerequisite command required
+- **Cursor CLI** (via official install script): standalone
+  `cursor-agent` AI coding agent CLI, always updated to latest (no
+  version pin); no prerequisite command required
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)
@@ -165,8 +165,9 @@ PATH — the three exceptions are the third-party Unity CLI installer
 third-party CodeRabbit CLI installer
 (`libs/coderabbit-cli-installer.ps1` invokes CodeRabbit's own
 `install.ps1`), and the third-party Cursor CLI installer
-(`libs/cursor-cli-installer.ps1` invokes Cursor's own `install.ps1`),
-which each persist an entry there as their own documented side effect,
+(`libs/cursor-cli-installer.ps1` invokes Cursor's own official install
+script), which each persist an entry there as their own documented side
+effect,
 not something this repository's code does directly. User PATH ownership
 otherwise belongs to dotfiles' managed-path reconciler: dotfiles'
 `docs/winget-user-path.md` documents the mechanism, and

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -174,7 +174,7 @@ else {
 }
 
 ###########################################################################
-### Phase 5 — Post-install setup (VPM CLI, CodeRabbit CLI, Unity, mkcert, Docker)
+### Phase 5 — Post-install setup (VPM CLI, CodeRabbit CLI, Cursor CLI, Unity, mkcert, Docker)
 ###########################################################################
 # Unity CLI must be in place before post-install.ps1's own Unity Editor
 # install step (issue #76) -- installed here, ahead of that step, rather

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1070,14 +1070,15 @@ both from this issue's AI-summary research into the vendor installer:
   (`Win32_ComputerSystem.SystemType`) and fetch a native ARM64 build,
   unlike CodeRabbit CLI's ARM64 x64-emulation behavior recorded above.
 
-### `install.ps1` itself is not pinned
+### The vendor installer script itself is not pinned
 
 Same trust model as the Unity CLI and CodeRabbit CLI installers above:
-the script fetched from `https://cursor.com/install?win32=true` is not
-pinned by hash or version. A compromise of that endpoint could serve a
-different script. Recorded here as a known, accepted risk, consistent
-with how the other two vendor installers' own unpinned scripts are
-recorded.
+the script fetched from `https://cursor.com/install?win32=true` -- note
+this endpoint's URL, unlike Unity's and CodeRabbit's, does not actually
+end in `install.ps1` -- is not pinned by hash or version. A compromise
+of that endpoint could serve a different script. Recorded here as a
+known, accepted risk, consistent with how the other two vendor
+installers' own unpinned scripts are recorded.
 
 ### No version pin; always installs latest
 

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1038,9 +1038,10 @@ outright that "CLI is not published on npm" -- the `cursor-agent` and
 unrelated third-party packages (a Cursor-AI-agent task-sequence tool and
 a deprecated terminal-cursor-display toggle library, respectively), not
 Anysphere's CLI; this repository's code deliberately never runs `npm
-install` against either name. `getcursor/cursor` (Cursor's GitHub
-organization) has zero Releases, and no `anysphere`-owned repository
-named `cursor-agent` exists, so no `github:`/`ubi:` backend applies
+install` against either name. The `cursor` repository in Cursor's
+`getcursor` GitHub organization (`getcursor/cursor`) has zero Releases,
+and no `anysphere`-owned repository named `cursor-agent` exists, so no
+`github:`/`ubi:` backend applies
 either, and a code search of `aquaproj/aqua-registry` found no
 `anysphere` package definition, ruling out an `aqua:` backend too. The
 only distribution path is Cursor's own installer script
@@ -1092,10 +1093,16 @@ and CodeRabbit CLI sections of `libs/post-install.ps1`.
 
 The installer's install directory
 (`%LocalAppData%\cursor-agent\versions\<version>\`), the commands it
-adds (`agent.exe`/`agent.cmd`/`agent.ps1` as the primary name,
-`cursor-agent.exe`/`cursor-agent.cmd`/`cursor-agent.ps1` as aliases of
-the original name), its User-scope PATH update mechanism, and its
-ARM64-native behavior were established from an AI-generated summary of
+adds (both `agent.exe`/`agent.cmd`/`agent.ps1` and
+`cursor-agent.exe`/`cursor-agent.cmd`/`cursor-agent.ps1` -- which of the
+two names is primary and which is the alias could not be pinned down
+with confidence; this section's opening paragraph's "official command
+name `cursor-agent`, alias `agent`" framing matches how Cursor's own
+docs refer to the tool, while the installer research behind this list
+suggested the reverse, so treat the primary/alias distinction itself as
+unresolved, not just the mechanics below), its User-scope PATH update
+mechanism, and its ARM64-native behavior were established from an
+AI-generated summary of
 the vendor's documentation and script content, not from reading the
 script's source end to end the way issue #76 read Unity's `install.ps1`.
 Whether the installer shows an interactive login prompt, calls `exit`

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1025,3 +1025,96 @@ verified against a real `coderabbit` binary from this Linux development
 environment, for the same reason recorded above for the Unity CLI: this
 repository never executes `libs/post-install.ps1` or `boxstarter.ps1`
 directly in this environment, even for smoke-testing.
+
+## Installing the Cursor CLI (issue #139)
+
+Cursor CLI (official command name `cursor-agent`, alias `agent`) ships
+the AI coding agent from the Cursor editor as a standalone binary. It
+has no winget package -- `Anysphere.Cursor` in `winget-pkgs` is the GUI
+editor (removed from this repository by issue #137), not the CLI. Its
+own documentation (<https://cursor.com/docs/cli/installation>) states
+outright that "CLI is not published on npm" -- the `cursor-agent` and
+`cursor-cli` packages that do exist on the public npm registry are
+unrelated third-party packages (a Cursor-AI-agent task-sequence tool and
+a deprecated terminal-cursor-display toggle library, respectively), not
+Anysphere's CLI; this repository's code deliberately never runs `npm
+install` against either name. `getcursor/cursor` (Cursor's GitHub
+organization) has zero Releases, and no `anysphere`-owned repository
+named `cursor-agent` exists, so no `github:`/`ubi:` backend applies
+either, and a code search of `aquaproj/aqua-registry` found no
+`anysphere` package definition, ruling out an `aqua:` backend too. The
+only distribution path is Cursor's own installer script
+(`https://cursor.com/install?win32=true` on Windows), the same
+"no winget/npm/Releases/aqua-registry entry" exception shape already
+recorded above for the CodeRabbit CLI (issue #126), so
+`libs/cursor-cli-installer.ps1` follows that same installer pattern:
+downloads the vendor's own install script to a temp file and runs it
+via `Start-Process` in a separate process, for the same reason recorded
+above -- an in-process invocation would let the downloaded script's own
+`exit` terminate the calling process instead of just itself.
+
+### Differences from the CodeRabbit CLI installer
+
+Two concrete differences from `libs/coderabbit-cli-installer.ps1`,
+both from this issue's AI-summary research into the vendor installer:
+
+- **No external-command prerequisite.** CodeRabbit CLI's installer
+  requires Git; Cursor CLI's installer has no such dependency, so
+  `Sync-CursorCli` does not gate on a prerequisite check the way
+  `Sync-CoderabbitCli` gates on `git`, and consequently has no need to
+  call `libs/process-path-sync.ps1`'s `Sync-ProcessPath` either (that
+  call exists in `Sync-CoderabbitCli` solely to make its `git` check see
+  a tool installed earlier in the same process, issue #129).
+- **ARM64 gets a native binary, not x64 emulation.** The installer is
+  summarized to detect architecture via WMI
+  (`Win32_ComputerSystem.SystemType`) and fetch a native ARM64 build,
+  unlike CodeRabbit CLI's ARM64 x64-emulation behavior recorded above.
+
+### `install.ps1` itself is not pinned
+
+Same trust model as the Unity CLI and CodeRabbit CLI installers above:
+the script fetched from `https://cursor.com/install?win32=true` is not
+pinned by hash or version. A compromise of that endpoint could serve a
+different script. Recorded here as a known, accepted risk, consistent
+with how the other two vendor installers' own unpinned scripts are
+recorded.
+
+### No version pin; always installs latest
+
+Unlike the Unity CLI (pinned via `configurations/runtime-versions.psd1`),
+`Sync-CursorCli` does not pin a target version -- every call re-runs the
+official installer and relies on its own idempotent staging/rollback
+behavior, the same "always update" policy already used for the VPM CLI
+and CodeRabbit CLI sections of `libs/post-install.ps1`.
+
+### Environment-variable, PATH, and prompt behavior is an unverified AI summary
+
+The installer's install directory
+(`%LocalAppData%\cursor-agent\versions\<version>\`), the commands it
+adds (`agent.exe`/`agent.cmd`/`agent.ps1` as the primary name,
+`cursor-agent.exe`/`cursor-agent.cmd`/`cursor-agent.ps1` as aliases of
+the original name), its User-scope PATH update mechanism, and its
+ARM64-native behavior were established from an AI-generated summary of
+the vendor's documentation and script content, not from reading the
+script's source end to end the way issue #76 read Unity's `install.ps1`.
+Whether the installer shows an interactive login prompt, calls `exit`
+explicitly, or exposes any CI-equivalent suppression environment
+variable could not be confirmed from that summary at all -- unlike
+CodeRabbit CLI's summary, which specifically named `CI` as its
+suppression variable.
+`libs/cursor-cli-installer.ps1`'s `Invoke-CursorCliInstaller` therefore
+deliberately does **not** set any environment variable before launching
+the installer: inventing an unverified suppression variable (e.g. a
+generic `CI=1`) against a script this repository has not read risks
+changing other unverified behavior, such as whether the User PATH write
+happens at all. If real invocation later shows the installer needs
+explicit suppression, that can be added then. No authentication
+credential (API key, token) is set, saved, or output by this
+repository's code -- `cursor-agent login` (or its equivalent) stays a
+manual step for the user, the same boundary already drawn for
+CodeRabbit CLI's `coderabbit auth login`. This Windows-only script
+could not be verified against a real `cursor-agent` binary from this
+Linux development environment, for the same reason recorded above for
+the Unity CLI and CodeRabbit CLI: this repository never executes
+`libs/post-install.ps1` or `boxstarter.ps1` directly in this
+environment, even for smoke-testing.

--- a/libs/cursor-cli-installer.ps1
+++ b/libs/cursor-cli-installer.ps1
@@ -1,0 +1,220 @@
+<#
+.SYNOPSIS
+Installs and updates the Cursor CLI (`cursor-agent` / `agent` binaries),
+idempotently delegating to Cursor's own official install script.
+
+This file is dot-sourced (not imported as a module) from
+libs/post-install.ps1 -- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+$Script:CursorCliInstallScriptUrl = 'https://cursor.com/install?win32=true'
+# $env:LOCALAPPDATA is Windows-only and absent on the Linux CI runner
+# that runs this file's Pester tests -- guarded so dot-sourcing this
+# file doesn't fail there. Every real caller runs on Windows, where
+# LOCALAPPDATA is always set.
+#
+# This points at the *versions* directory
+# (%LocalAppData%\cursor-agent\versions), not a fixed install directory
+# like CodeRabbit CLI's -- per the issue's AI-summary research, Cursor's
+# installer lays binaries out under a per-version subdirectory
+# (...\versions\<version>\), which this repository has not verified by
+# reading the vendor script. Adding this parent directory to PATH is the
+# best defensive approximation available without asserting an unverified
+# exact layout; see Add-CursorCliToProcessPath below and
+# docs/dsc-migration-notes.md for the full caveat.
+$Script:CursorCliInstallDir = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'cursor-agent\versions' } else { $null }
+
+function Add-CursorCliToProcessPath {
+  param (
+    [string]$InstallDir = $Script:CursorCliInstallDir
+  )
+  if ([string]::IsNullOrEmpty($InstallDir)) {
+    return
+  }
+  $current = @($env:Path -split ';' | Where-Object { $_ -ne '' })
+  $target = $InstallDir.TrimEnd('\', '/')
+  $seenTarget = $false
+  $deduped = @(
+    foreach ($entry in $current) {
+      $isTarget = [string]::Equals($entry.TrimEnd('\', '/'), $target, [System.StringComparison]::OrdinalIgnoreCase)
+      if ($isTarget) {
+        if ($seenTarget) {
+          continue
+        }
+        $seenTarget = $true
+      }
+      $entry
+    }
+  )
+  if ($seenTarget) {
+    $env:Path = $deduped -join ';'
+  }
+  else {
+    $env:Path = (@($deduped) + $InstallDir) -join ';'
+  }
+  <#
+  .SYNOPSIS
+  Adds the Cursor CLI install directory to the *current process's*
+  $env:Path.
+
+  .DESCRIPTION
+  The official installer is documented (AI-summary, unverified -- see
+  docs/dsc-migration-notes.md) to persist the User-scope PATH and
+  reflect that into the calling process's own $env:Path. This function
+  is added defensively, mirroring
+  libs/coderabbit-cli-installer.ps1's Add-CoderabbitCliToProcessPath, so
+  a `cursor-agent` / `agent` call later in the same boxstarter.ps1 run
+  works even if the vendor installer does not update the current
+  process -- not to support a version-match check, since this installer
+  does not pin or compare versions.
+
+  Unlike CodeRabbit CLI's install directory, the default InstallDir here
+  ($Script:CursorCliInstallDir) is the *versions* parent directory, not
+  a directory that directly contains the executables -- the AI-summary
+  research behind this issue was unable to confirm whether the real
+  binaries live directly under it or one level deeper, under a
+  per-version subdirectory. This function is a defensive backup, not
+  the primary PATH mechanism: the vendor installer's own persistent
+  User-PATH write (also unverified) is expected to reference whatever
+  the correct concrete path actually is.
+
+  A null/empty InstallDir (e.g. the default on a machine without
+  $env:LOCALAPPDATA, such as this file's own Linux Pester run) is a
+  no-op rather than an error -- there is nothing to add.
+
+  Also normalizes away any pre-existing duplicate entries for
+  InstallDir (case/trailing-separator insensitive), keeping the first
+  occurrence's position and dropping the rest, so repeated calls
+  converge on exactly one entry even if duplicates existed before this
+  function's first call in the current process.
+  #>
+}
+
+function Invoke-CursorCliInstaller {
+  [CmdletBinding()]
+  [OutputType([int])]
+  param (
+    [string]$InstallScriptUrl = $Script:CursorCliInstallScriptUrl
+  )
+  $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) "cursor-cli-install-$([guid]::NewGuid().ToString('N')).ps1"
+  try {
+    try {
+      Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $tempScript -UseBasicParsing -ErrorAction Stop
+    }
+    catch {
+      Write-Error "Failed to download the Cursor CLI installer from ${InstallScriptUrl}: $_"
+      return 1
+    }
+    $shell = (Get-Process -Id $PID).Path
+    # Start-Process -ArgumentList joins array elements with a bare
+    # space and does not quote them itself (this is documented
+    # Start-Process behavior, not a bug) -- an unquoted $tempScript
+    # would truncate at the first space in a TEMP path containing
+    # one, so it's quoted explicitly here.
+    $process = Start-Process -FilePath $shell -ArgumentList @(
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$tempScript`""
+    ) -NoNewWindow -Wait -PassThru
+    return $process.ExitCode
+  }
+  finally {
+    Remove-Item -Path $tempScript -Force -ErrorAction SilentlyContinue
+  }
+  <#
+  .SYNOPSIS
+  Downloads Cursor's own install script and runs it to install or
+  update the CLI to its latest version.
+
+  .DESCRIPTION
+  Runs the installer in a SEPARATE process via Start-Process, never
+  in-process -- mirrors libs/coderabbit-cli-installer.ps1's
+  Invoke-CoderabbitCliInstaller and libs/unity-cli-installer.ps1's
+  Invoke-UnityCliInstaller (docs/dsc-migration-notes.md): an in-process
+  scriptblock invocation of downloaded content lets that script's own
+  `exit` terminate the *entire calling PowerShell process*, not just
+  the scriptblock, which would silently abort the rest of
+  boxstarter.ps1's phases. A separate process confines that risk to the
+  child, so its exit code can be inspected and handled by the caller
+  instead.
+
+  Unlike Invoke-CoderabbitCliInstaller, this function does not set any
+  CI-suppression environment variable before launching the child
+  process. CodeRabbit's own AI-summary research specifically named `CI`
+  as the variable its installer checks to suppress an interactive login
+  prompt; this issue's AI-summary research for Cursor's installer could
+  not confirm whether an equivalent suppression variable exists at all,
+  let alone its name. Setting an unverified environment variable (e.g.
+  a generic `CI=1`) against a script this repository has not read end
+  to end risks changing other unverified behavior too -- for example,
+  some vendor installers skip persisting the User PATH, or alter their
+  install layout, specifically when they detect a CI environment. Doing
+  nothing is the conservative choice here; if this script does have an
+  interactive prompt that blocks non-interactive execution, that will
+  surface as a hang or non-zero exit at real invocation time and can be
+  addressed then, per the issue's own documented fallback ("if
+  unnecessary, leave a note in a code comment").
+
+  install.ps1 itself is not pinned by hash or version, the same trust
+  model as any curl-pipe-to-shell bootstrap (Chocolatey, Scoop,
+  CodeRabbit CLI, Unity CLI); see docs/dsc-migration-notes.md for the
+  recorded risk.
+
+  The download itself is wrapped in its own try/catch (mirrors issue
+  #98's Unity CLI fix and Invoke-CoderabbitCliInstaller): a network
+  failure (DNS, connection refused, non-2xx status) throws a
+  terminating error from Invoke-WebRequest that would otherwise
+  propagate uncaught past this function and into Sync-CursorCli. Caught
+  here and turned into a non-zero return instead.
+
+  .OUTPUTS
+  The child process's exit code, or a non-zero value (currently 1) if
+  the installer script itself could not be downloaded. Callers cannot
+  distinguish a download failure from an install script failure by exit
+  code value alone -- only by whether it's zero.
+  #>
+}
+
+function Sync-CursorCli {
+  [CmdletBinding()]
+  param ()
+
+  Add-CursorCliToProcessPath
+
+  Write-Host '[cursor-cli] Installing/updating Cursor CLI...' -ForegroundColor Cyan
+  $exitCode = Invoke-CursorCliInstaller
+  if ($exitCode -ne 0) {
+    Write-Error "Cursor CLI installer exited with code ${exitCode}."
+    return
+  }
+
+  Add-CursorCliToProcessPath
+  Write-Host '[cursor-cli] Cursor CLI installation complete.' -ForegroundColor Green
+  <#
+  .SYNOPSIS
+  Idempotent entry point: installs or updates the Cursor CLI to its
+  latest version on every call.
+
+  .DESCRIPTION
+  Unlike libs/coderabbit-cli-installer.ps1's Sync-CoderabbitCli, this
+  function does not check for any prerequisite external command before
+  installing (no `git`-equivalent check) -- the issue's AI-summary
+  research found Cursor's official installer has no external-command
+  dependency, unlike CodeRabbit CLI's installer, which requires Git.
+  Because there is no such check, this function also does not call
+  libs/process-path-sync.ps1's Sync-ProcessPath: that call exists in
+  Sync-CoderabbitCli solely to make its `git` Get-Command check see a
+  tool installed earlier in the same process (issue #129) -- with no
+  prerequisite check here, calling it would have no effect.
+
+  Like Sync-CoderabbitCli, this function does not pin a target version
+  or skip when a matching version is already installed -- Cursor CLI
+  intentionally always tracks latest here (same "always update" policy
+  as the VPM CLI and CodeRabbit CLI sections of
+  libs/post-install.ps1), so every call re-runs the official installer
+  and relies on its own idempotent staging/rollback behavior.
+
+  No authentication step is invoked or scripted here: `cursor-agent
+  login` (or its equivalent) stays a manual step for the user, the same
+  boundary already drawn for CodeRabbit CLI's `coderabbit auth login`.
+  #>
+}

--- a/libs/cursor-cli-installer.ps1
+++ b/libs/cursor-cli-installer.ps1
@@ -154,10 +154,11 @@ function Invoke-CursorCliInstaller {
   addressed then, per the issue's own documented fallback ("if
   unnecessary, leave a note in a code comment").
 
-  install.ps1 itself is not pinned by hash or version, the same trust
-  model as any curl-pipe-to-shell bootstrap (Chocolatey, Scoop,
-  CodeRabbit CLI, Unity CLI); see docs/dsc-migration-notes.md for the
-  recorded risk.
+  The installer script itself (fetched from a URL that, unlike
+  CodeRabbit's or Unity's, does not actually end in `install.ps1`) is
+  not pinned by hash or version, the same trust model as any
+  curl-pipe-to-shell bootstrap (Chocolatey, Scoop, CodeRabbit CLI, Unity
+  CLI); see docs/dsc-migration-notes.md for the recorded risk.
 
   The download itself is wrapped in its own try/catch (mirrors issue
   #98's Unity CLI fix and Invoke-CoderabbitCliInstaller): a network

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -78,6 +78,18 @@ else {
 Sync-CoderabbitCli
 
 ###########################################################################
+### Cursor CLI — no winget package; official installer has no
+### external-command prerequisite, unlike CodeRabbit CLI's Git
+### requirement above (issue #139). Sync-CursorCli therefore does not
+### need its own prerequisite check the way Sync-CoderabbitCli does. See
+### libs/cursor-cli-installer.ps1 for the install script
+### download/execution details and docs/dsc-migration-notes.md for the
+### recorded remote-script-execution risk.
+###########################################################################
+. (Join-Path -Path $PSScriptRoot -ChildPath 'cursor-cli-installer.ps1')
+Sync-CursorCli
+
+###########################################################################
 ### Vagrant plugins
 ###########################################################################
 if (Test-CommandExists vagrant) {

--- a/tests/powershell/cursor-cli-installer.Tests.ps1
+++ b/tests/powershell/cursor-cli-installer.Tests.ps1
@@ -1,0 +1,136 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'cursor-cli-installer.ps1')
+}
+
+Describe 'Add-CursorCliToProcessPath' {
+  BeforeEach {
+    $script:originalPath = $env:Path
+  }
+
+  AfterEach {
+    $env:Path = $script:originalPath
+  }
+
+  It 'appends the install dir when not already present' {
+    $env:Path = '/existing/one;/existing/two'
+
+    Add-CursorCliToProcessPath -InstallDir '/cursor-agent/versions'
+
+    $env:Path | Should -Match ([regex]::Escape('/cursor-agent/versions'))
+  }
+
+  It 'does not duplicate an entry that only differs by case or a trailing slash' {
+    $env:Path = '/Existing/CURSOR-AGENT/VERSIONS/;/existing/two'
+
+    Add-CursorCliToProcessPath -InstallDir '/existing/cursor-agent/versions'
+
+    ($env:Path -split ';' | Where-Object { $_ -ne '' }).Count | Should -Be 2
+  }
+
+  It 'no-ops instead of throwing when InstallDir is null or empty' {
+    $env:Path = '/existing/one'
+
+    { Add-CursorCliToProcessPath -InstallDir $null } | Should -Not -Throw
+    { Add-CursorCliToProcessPath -InstallDir '' } | Should -Not -Throw
+    $env:Path | Should -Be '/existing/one'
+  }
+
+  It 'removes pre-existing duplicate entries, keeping the first occurrence in place' {
+    $env:Path = '/existing/one;/cursor-agent/versions;/existing/two;/CURSOR-AGENT/VERSIONS/;/existing/three'
+
+    Add-CursorCliToProcessPath -InstallDir '/cursor-agent/versions'
+
+    $env:Path | Should -Be '/existing/one;/cursor-agent/versions;/existing/two;/existing/three'
+  }
+}
+
+Describe 'Invoke-CursorCliInstaller' {
+  It 'returns a non-zero exit code instead of throwing when the download fails' {
+    Mock Invoke-WebRequest { throw [System.Net.WebException]::new('Name or service not known') }
+    Mock Start-Process { }
+
+    $exitCode = Invoke-CursorCliInstaller -ErrorAction SilentlyContinue
+    $exitCode | Should -Be 1
+
+    Should -Invoke Start-Process -Times 0
+  }
+
+  It 'removes the temp script even when the download fails' {
+    Mock Invoke-WebRequest { throw [System.Net.WebException]::new('Name or service not known') }
+    Mock Start-Process { }
+    Mock Remove-Item { }
+
+    Invoke-CursorCliInstaller -ErrorAction SilentlyContinue | Out-Null
+
+    Should -Invoke Remove-Item -Times 1
+  }
+
+  It 'returns the child process exit code on success' {
+    Mock Invoke-WebRequest { }
+    Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+    Invoke-CursorCliInstaller | Should -Be 0
+  }
+
+  It 'removes the temp script after a successful install too' {
+    Mock Invoke-WebRequest { }
+    Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+    Mock Remove-Item { }
+
+    Invoke-CursorCliInstaller | Out-Null
+
+    Should -Invoke Remove-Item -Times 1
+  }
+
+  It 'quotes the -File argument so a TEMP path containing spaces is not truncated by Start-Process argument joining' {
+    $script:capturedArgumentList = $null
+    Mock Invoke-WebRequest { }
+    Mock Start-Process {
+      $script:capturedArgumentList = $ArgumentList
+      [pscustomobject]@{ ExitCode = 0 }
+    }
+
+    Invoke-CursorCliInstaller | Out-Null
+
+    $fileIndex = [array]::IndexOf($script:capturedArgumentList, '-File')
+    $fileIndex | Should -BeGreaterThan -1
+    $script:capturedArgumentList[$fileIndex + 1] | Should -Match '^".*"$'
+  }
+}
+
+Describe 'Sync-CursorCli' {
+  It 'installs on every call, with no prerequisite command check gating it' {
+    Mock Add-CursorCliToProcessPath { }
+    Mock Invoke-CursorCliInstaller { 0 }
+
+    Sync-CursorCli
+    Sync-CursorCli
+
+    Should -Invoke Invoke-CursorCliInstaller -Times 2
+  }
+
+  It 'adds the install dir to PATH both before and after a successful install' {
+    Mock Add-CursorCliToProcessPath { }
+    Mock Invoke-CursorCliInstaller { 0 }
+
+    Sync-CursorCli
+
+    Should -Invoke Add-CursorCliToProcessPath -Times 2
+  }
+
+  It 'writes a non-terminating error and does not throw when the installer exits non-zero' {
+    Mock Add-CursorCliToProcessPath { }
+    Mock Invoke-CursorCliInstaller { 1 }
+
+    { Sync-CursorCli -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'does not add the install dir to PATH a second time when the installer fails' {
+    Mock Add-CursorCliToProcessPath { }
+    Mock Invoke-CursorCliInstaller { 1 }
+
+    Sync-CursorCli -ErrorAction SilentlyContinue
+
+    Should -Invoke Add-CursorCliToProcessPath -Times 1
+  }
+}


### PR DESCRIPTION
## Summary

Adds Cursor CLI (`cursor-agent`) as a new post-install-installed tool, following the exact pattern already established for the CodeRabbit CLI (issue #126): a research pass at issue-triage time confirmed Cursor CLI has no winget package (the GUI editor `Anysphere.Cursor` in `winget-pkgs` is a different product, already scheduled for removal in issue #137), no npm entry (npm's `cursor-agent`/`cursor-cli` names are unrelated third-party packages, deliberately never `npm install`ed), no GitHub Releases, and no `aqua-registry` entry -- the only distribution path is Cursor's own official installer script.

- `libs/cursor-cli-installer.ps1` (new): downloads the installer to a temp file via `Invoke-WebRequest` and runs it via `Start-Process` in a separate process, mirroring `libs/coderabbit-cli-installer.ps1`. Two deliberate differences from that sibling, both from this issue's AI-summary research: no external-command prerequisite check (Cursor's installer, unlike CodeRabbit's, has no `git` dependency, so there's also no `Sync-ProcessPath` call), and no `$env:CI`-style suppression variable (CodeRabbit's AI summary specifically named `CI`; this issue's summary could not confirm Cursor's installer has any equivalent variable at all, so none was invented). No authentication/API-key code exists -- `cursor-agent login` stays a manual step for the user.
- `tests/powershell/cursor-cli-installer.Tests.ps1` (new): Pester suite mocking `Invoke-WebRequest`/`Start-Process` throughout, covering PATH-dedup, download-failure handling, exit-code propagation, and `-File` argument quoting. The vendor script is never fetched or executed for real, in code or in this PR's own verification.
- `libs/post-install.ps1` / `boxstarter.ps1`: wires `Sync-CursorCli` in immediately after the CodeRabbit CLI block, and updates the Phase 5 heading comment to match.
- `README.md` / `README.ja.md`: adds Cursor CLI to the Phase 5 architecture diagram and the "Via Post-Install Scripts" list, and updates the User PATH exception count from two installers to three (Unity, CodeRabbit, Cursor).
- `docs/dsc-migration-notes.md`: new "Installing the Cursor CLI (issue #139)" section recording the winget/npm/Releases/aqua-registry dead ends, the two behavioral differences from CodeRabbit's installer (no Git dependency; native ARM64 instead of x64 emulation), the unpinned-installer-script trust model, the always-latest version policy, and an explicit note that the env-var/PATH/prompt behavior is an AI summary this implementation deliberately avoids asserting as fact.

### Known limitation (documented, not fixed)

`Add-CursorCliToProcessPath`'s default install directory is `%LocalAppData%\cursor-agent\versions` -- the *parent* of where the AI-summary research says the vendor installer actually places version-specific binaries (`...\versions\<version>\`). Building logic to resolve the newest version subfolder would assert an unverified directory layout as fact, which this issue's own verification guidance says to avoid; the code comments call this out explicitly as a best-effort defensive backup, not the primary PATH mechanism (the vendor installer's own persistent User-PATH write is primary, and is also unverified).

## Verification

- `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit` -> exit 0.
- `Invoke-Pester -Path ./tests/powershell -CI` -> 156 passed, 0 failed (including 13 new Cursor CLI tests).
- `pre-push-validate` (markdownlint-cli2, cspell, ScriptAnalyzer, Pester) -> clean.
- Two independent critique passes ran against this diff; findings disposed: one Low-severity doc-accuracy issue fixed (the vendor endpoint doesn't actually end in `install.ps1`, unlike Unity's/CodeRabbit's), one Medium-severity finding about the PATH-directory-level tradeoff above reviewed and deliberately not changed (see "Known limitation"), and one trivial line-wrap cosmetic fix.
- The vendor installer (`https://cursor.com/install?win32=true`) was never fetched or executed for real at any point in this branch's development -- per repository policy for this class of installer, verification is Pester/PSScriptAnalyzer/lint only.

Closes #139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic installation and updating of the Cursor CLI during Windows post-install setup.
  * Added PATH integration so the Cursor CLI is available immediately after installation.
  * Cursor CLI installation uses the latest available version without requiring prerequisite commands.

* **Documentation**
  * Documented Cursor CLI setup, installer behavior, PATH ownership, and known environment considerations.
  * Updated English and Japanese installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->