### PR TITLE
docs(setup): document git commit-ssh fallback for everyday commits

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -279,6 +279,14 @@ reordering, and run the C1 critique pass against the completed diff.
 Implement the plan, running **fix-validate** before each atomic commit
 (one logical change per commit).
 
+**Commit signing block**: if the configured primary commit signer blocks
+non-interactively (pinentry / TTY EOF / hardware-touch timeout), see
+`docs/idd-helper-scripts.md`'s
+[Signed-Commit Merge Wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
+section, which also covers the everyday `git commit` case, before
+falling back to `--no-gpg-sign` per
+`idd-overview-appendix.instructions.md`'s "Commit signing" section.
+
 **De-duplication refactors**: when consolidating a wrapper function used
 at multiple call sites, check whether any call site's old delegate path
 added behavior (timeouts, stdio handling, error translation, etc.) that

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2591,6 +2591,66 @@ complement to the recovery-path re-signing in
 `idd-pr-submit.instructions.md` (Post-rebase verification) and
 `idd-overview-core.instructions.md` (cwd-vs-claim cherry-pick recovery).
 
+### Everyday `git commit` (and `git commit --amend`) fallback
+
+The merge wrapper above covers the occasional `main`-sync merge; B3
+authors far more plain `git commit` calls than merges, and the same
+non-interactive-hostile primary signer blocks those exactly the same
+way. The paragraph above notes that a commit-only alias such as `git
+commit-ssh` cannot run `merge` — that is not a limitation to route
+around here, it is the positive complement: for plain `git commit` /
+`git commit --amend`, a commit-only signing alias is exactly the right
+tool.
+
+**When to switch**: only after the configured primary signer has
+already failed non-interactively on this commit (pinentry / TTY EOF /
+hardware-touch timeout). This is a documented recovery step, not an
+unconditional first attempt, and it does not change the signing ladder
+in `idd-overview-appendix.instructions.md`'s "Commit signing" section:
+try the configured primary signer first, fall back to this wrapper on a
+non-interactive block, and keep `--no-gpg-sign` as the final,
+last-resort fallback — used only after this wrapper has also failed or
+is unavailable, never as the first move.
+
+**Check for a configured alias first** — a commit-signing alias is
+scoped to whatever git config level defines it (often the operator's
+global config, not this repository), so its presence varies by
+environment and must not be assumed:
+
+```sh
+git config --get alias.commit-ssh
+```
+
+If that prints a wrapper function, the current environment has a
+commit-only signing alias configured — this repository's IDD loop has
+run with exactly one such alias, `git commit-ssh` (wrapping `git -c
+gpg.format=ssh -c user.signingkey=<path-to-ssh-public-key> -c
+commit.gpgsign=true commit`), across every commit in issues #136-#139
+after the primary GPG signer blocked non-interactively in each case.
+When an alias is present, invoke it by name instead of reconstructing
+the raw `-c` flags:
+
+```sh
+git commit-ssh -m "type(scope): subject"
+git commit-ssh --amend
+```
+
+If `git config --get alias.commit-ssh` (or an equivalent
+locally-configured alias) prints nothing — a different operator's
+machine, a fresh clone, or a CI runner without this global alias — use
+the same raw `-c` form as the merge wrapper above, applied to `commit`
+instead of `merge`:
+
+```sh
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit -m "type(scope): subject"
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit --amend
+```
+
+Report which signing path was used (configured primary signer, this
+wrapper — alias or raw form — or the `--no-gpg-sign` last resort) for
+every commit, per `idd-overview-appendix.instructions.md`'s "Commit
+signing" section.
+
 ## Friction Inventory
 
 The workflow areas most likely to benefit from optional helpers are:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2621,18 +2621,21 @@ environment and must not be assumed:
 git config --get alias.commit-ssh
 ```
 
-If that prints a wrapper function, the current environment has a
-commit-only signing alias configured — this repository's IDD loop has
-run with exactly one such alias, `git commit-ssh` (wrapping `git -c
-gpg.format=ssh -c user.signingkey=<path-to-ssh-public-key> -c
-commit.gpgsign=true commit`), across every commit in issues #136-#139
-after the primary GPG signer blocked non-interactively in each case.
-When an alias is present, invoke it by name instead of reconstructing
-the raw `-c` flags:
+If that prints a value (a shell function or a plain command string),
+the current environment has a commit-only signing alias configured. In
+issues #136-#139, this repository's IDD loop used exactly one such
+alias, `git commit-ssh` (wrapping `git -c gpg.format=ssh -c
+user.signingkey=<path-to-ssh-public-key> -c commit.gpgsign=true
+commit`), after the primary GPG signer blocked non-interactively in
+each case. When an alias is present, invoke it by name instead of
+reconstructing the raw `-c` flags — pass `--no-edit` on `--amend` so a
+missing `-m` reuses the existing message instead of launching
+`$EDITOR`, which can hang in the same non-interactive session this
+fallback targets:
 
 ```sh
 git commit-ssh -m "type(scope): subject"
-git commit-ssh --amend
+git commit-ssh --amend --no-edit
 ```
 
 If `git config --get alias.commit-ssh` (or an equivalent
@@ -2643,13 +2646,14 @@ instead of `merge`:
 
 ```sh
 git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit -m "type(scope): subject"
-git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit --amend
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true commit --amend --no-edit
 ```
 
-Report which signing path was used (configured primary signer, this
-wrapper — alias or raw form — or the `--no-gpg-sign` last resort) for
-every commit, per `idd-overview-appendix.instructions.md`'s "Commit
-signing" section.
+Record a non-default signing outcome — this wrapper (alias or raw
+form) or the `--no-gpg-sign` last resort — per
+`idd-overview-appendix.instructions.md`'s "Commit signing" section,
+which already limits that reporting duty to non-default outcomes; the
+default configured primary signer needs no separate report.
 
 ## Friction Inventory
 


### PR DESCRIPTION
## Summary

Expands `docs/idd-helper-scripts.md`'s existing "Signed-Commit Merge
Wrapper" section (H2 heading and anchor unchanged — two other
instruction files link to it) with a new subsection covering the
everyday `git commit` / `git commit --amend` case, which the section
previously did not address at all (it only covered `git merge`/
`rebase`). Also adds a one-paragraph generic cross-reference from
`.github/instructions/idd-work.instructions.md`'s B3 section (where
`git commit` actually runs) to that expanded content.

Closes #145

## Background

Issues #136-#139's delegated-worker retrospective found that every
commit across all four PRs hit the same non-interactive GPG pinentry
block, and the fallback that worked (`git commit-ssh`) was documented
only ad hoc by the human operator in each delegation brief — not in
this repo's own IDD docs. Upstream `kurone-kito/idd-skill#2067`
("add SSH-signing discovery before `--no-gpg-sign`") was closed
`wontfix` with the explicit position that each adopter repo documents
its own fallback locally; this PR is that local documentation.

## What changed

- `docs/idd-helper-scripts.md`: new `### Everyday git commit (and git
  commit --amend) fallback` subsection under the existing H2. States
  the switch condition explicitly (only after the configured primary
  signer has already failed non-interactively — not an unconditional
  first attempt), keeps `--no-gpg-sign` as the last resort by
  cross-referencing `idd-overview-appendix.instructions.md`'s "Commit
  signing" ladder instead of duplicating it, and gives runnable
  examples.
- `.github/instructions/idd-work.instructions.md`: one generic pointer
  paragraph in B3 to the expanded section (see "Vendored-file decision"
  below for why this file was edited directly).

### One factual correction made mid-implementation

The issue's proposed change describes `git commit-ssh` as "this
repository's actual configured alias." Verifying with `git config
--show-origin --get alias.commit-ssh` shows it resolves from
`file:~/.config/git/config` — this operator's **global** git config,
not anything `git config --local` or `--system` in this repository
provisions, and no tracked file in this repo defines it. So the new
subsection does not assert the alias as an unconditional repository
fact (which would break for a different operator, a fresh clone, or a
CI runner without this global alias). It opens with an explicit
presence check (`git config --get alias.commit-ssh`), names the alias
concretely as the fallback this repo's IDD loop has actually run with
across issues #136-#139, and keeps the existing generic `<abs-path>`
raw `-c` form as the fallback-of-the-fallback when no such alias is
configured. It intentionally does not hardcode the operator's absolute
SSH key path in checked-in docs (avoids stale-path drift and
unnecessary personal-path disclosure); `git config --get
alias.commit-ssh` is the durable way to inspect the real definition.

## Vendored-file decision

The issue asked for a judgment call: whether to also cross-reference
`docs/idd-helper-scripts.md` from `.github/instructions/idd-work.instructions.md`
B3, given that file's `.github/instructions/idd-*.instructions.md`
files originated from an upstream `idd-skill` template import.

**Decision: yes, added a one-paragraph generic cross-reference** (no
repo-specific alias name inside the vendored file, to minimize drift
at the next `idd-skill` pin bump). Rationale, investigated before
implementing:

- No `idd-template/` directory exists in this repository, so this repo
  is a pure **adopter**, not the source of a reusable IDD distribution
  — `docs/customization.md`'s "Exception: this repository is the
  source of a reusable IDD distribution" carve-out does not apply.
- `docs/customization.md`'s own adopter-repo guidance ("When editing
  canonical sources") explicitly names
  `.github/instructions/idd-*.instructions.md` as this repo's
  canonical location to edit directly — it is not a forbidden
  vendor-only file here.
- Direct precedent: commit `3f0c3c1` ("fix(idd): align resume-stall
  takeover threshold with overridden claimTiming") already edited
  `.github/instructions/idd-resume-stall.instructions.md` (and its
  lite variant) directly to reflect a repo-local policy fact that the
  generic template text didn't capture — a related, though not
  identical, precedent (it corrected an existing stale value rather
  than adding new cross-reference prose).
- The most recent pin-bump commit (`c1c84a2`, "reconcile template
  drift") frames re-import as a reviewed reconciliation, not a silent
  overwrite, so this local edit surfaces as reviewable drift at the
  next pin bump rather than being silently clobbered.

## Commit signing

Both commits, and the D1 rebase onto a newly-advanced `origin/master`
(PR #143 landed mid-session), hit the configured GPG signer's
non-interactive pinentry/TTY-EOF block (`gpg: 署名に失敗しました: ファイル終端`)
on every attempt — the same failure mode as issues #136-#139, and now
live evidence for exactly what this PR documents. Fallback path used
for all of them: `git commit-ssh` for the two commits, and this repo's
`rebase-ssh` alias (plus a manual `git commit-ssh --no-edit` to finish
one paused pick) for the rebase. No `--no-gpg-sign` fallback was
needed.

## Validation

- `npx -y markdownlint-cli2 "**/*.md"` — 0 issues (74 files)
- `npx -y cspell lint "**" --no-progress` — 0 issues (130 files)
- Full `pre-push-validate` (adds PSScriptAnalyzer + Pester, unaffected
  by this doc-only change): PSScriptAnalyzer clean,
  `Invoke-Pester -Path ./tests/powershell -CI` — 156 passed, 0 failed,
  0 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for recovering from non-interactive commit-signing failures, including the shared signed-commit merge procedure.
  * Documented preferred signed-commit workflows, including configured aliases and equivalent manual commands.
  * Added `--no-edit` to fallback amend commands to prevent editor prompts.
  * Clarified alias detection for shell functions and command strings.
  * Refined reporting requirements for non-default signing outcomes.
* **Chores**
  * Updated contributor instructions with commit-signing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->