### PR TITLE
chore(setup): migrate pwsh to machine-scope winget install

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -53,6 +53,7 @@ words:
   - kuroné
   - mikefarah
   - mojang
+  - msix
   - nektos
   - nvme
   - oldj

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@ setup.cmd                        ← 唯一のエントリーポイント
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
             │    ├─ install script → Cursor CLI
-            │    ├─ winget --scope machine → PowerShell 7 (pwsh)
+            │    ├─ winget --scope machine --installer-type wix → PowerShell 7 (pwsh)
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
             │    └─ Docker Desktop → イメージ pull
@@ -123,11 +123,16 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 - **Cursor CLI**（公式インストールスクリプト経由）: 単体バイナリの AI
   コーディングエージェント CLI（`cursor-agent`）。バージョン固定はせず
   常に最新版へ更新する。前提コマンドは不要
-- **PowerShell 7 (pwsh)**（`winget install --scope machine` 経由）:
-  WinGet Configuration（DSC）ではなく machine scope でインストールする。
-  `Microsoft.WinGet.DSC/WinGetPackage` が `--scope machine` を指定できな
-  いため。machine scope にすることで、将来 Windows OpenSSH Server の
-  `DefaultShell` として使えるだけの安定したパスになる
+- **PowerShell 7 (pwsh)**（
+  `winget install --scope machine --installer-type wix --version 7.6.*`
+  経由）: WinGet Configuration（DSC）ではなく machine scope でインストー
+  ルする。`Microsoft.WinGet.DSC/WinGetPackage` が `--scope machine` を
+  指定できないため。`--installer-type wix` は winget が既定で選ぶ MSIX
+  バンドルではなく WiX/MSI インストーラを強制し、バージョン固定は
+  WiX/MSI を廃止した可能性のある 7.7 系マニフェストを避けるためのもの
+  （詳細は `docs/dsc-migration-notes.md`）。machine scope にすることで、
+  将来 Windows OpenSSH Server の `DefaultShell` として使えるだけの安定
+  したパスになる
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA
 - **Docker イメージ**: ベースイメージ (alpine, debian, ubuntu, node 各種)

--- a/README.ja.md
+++ b/README.ja.md
@@ -124,13 +124,13 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
   コーディングエージェント CLI（`cursor-agent`）。バージョン固定はせず
   常に最新版へ更新する。前提コマンドは不要
 - **PowerShell 7 (pwsh)**（
-  `winget install --scope machine --installer-type wix --version 7.6.*`
-  経由）: WinGet Configuration（DSC）ではなく machine scope でインストー
-  ルする。`Microsoft.WinGet.DSC/WinGetPackage` が `--scope machine` を
-  指定できないため。`--installer-type wix` は winget が既定で選ぶ MSIX
-  バンドルではなく WiX/MSI インストーラを強制し、バージョン固定は
-  WiX/MSI を廃止した可能性のある 7.7 系マニフェストを避けるためのもの
-  （詳細は `docs/dsc-migration-notes.md`）。machine scope にすることで、
+  `winget install --scope machine --installer-type wix` 経由）:
+  WinGet Configuration（DSC）ではなく machine scope でインストールする。
+  `Microsoft.WinGet.DSC/WinGetPackage` が `--scope machine` を指定でき
+  ないため。`--installer-type wix` は winget が既定で選ぶ MSIX バンド
+  ルではなく WiX/MSI インストーラを強制する（WiX/MSI を廃止した可能性
+  のある 7.7 系マニフェストのリスクと、バージョン固定で対処しない理由
+  は `docs/dsc-migration-notes.md` 参照）。machine scope にすることで、
   将来 Windows OpenSSH Server の `DefaultShell` として使えるだけの安定
   したパスになる
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,7 @@ setup.cmd                        ← 唯一のエントリーポイント
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
             │    ├─ install script → Cursor CLI
+            │    ├─ winget --scope machine → PowerShell 7 (pwsh)
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → ローカル CA
             │    └─ Docker Desktop → イメージ pull
@@ -122,6 +123,11 @@ Boxstarter が自動的に再起動を処理します。再起動により処理
 - **Cursor CLI**（公式インストールスクリプト経由）: 単体バイナリの AI
   コーディングエージェント CLI（`cursor-agent`）。バージョン固定はせず
   常に最新版へ更新する。前提コマンドは不要
+- **PowerShell 7 (pwsh)**（`winget install --scope machine` 経由）:
+  WinGet Configuration（DSC）ではなく machine scope でインストールする。
+  `Microsoft.WinGet.DSC/WinGetPackage` が `--scope machine` を指定できな
+  いため。machine scope にすることで、将来 Windows OpenSSH Server の
+  `DefaultShell` として使えるだけの安定したパスになる
 - **Unity 2022.3.22f1**: VRChat SDK/VCC 必須バージョン
 - **mkcert**: HTTPS 開発用ローカル CA
 - **Docker イメージ**: ベースイメージ (alpine, debian, ubuntu, node 各種)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ setup.cmd                        ← single entry point
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
             │    ├─ install script → Cursor CLI
-            │    ├─ winget --scope machine → PowerShell 7 (pwsh)
+            │    ├─ winget --scope machine --installer-type wix → PowerShell 7 (pwsh)
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
             │    └─ Docker Desktop → image pulls
@@ -123,11 +123,16 @@ the full list. Key categories:
 - **Cursor CLI** (via official install script): standalone
   `cursor-agent` AI coding agent CLI, always updated to latest (no
   version pin); no prerequisite command required
-- **PowerShell 7 (pwsh)** (via `winget install --scope machine`):
+- **PowerShell 7 (pwsh)** (via
+  `winget install --scope machine --installer-type wix --version 7.6.*`):
   installed at machine scope, not through WinGet Configuration (DSC),
   because `Microsoft.WinGet.DSC/WinGetPackage` cannot request
-  `--scope machine`. Machine scope keeps pwsh's path stable enough to
-  later serve as Windows OpenSSH Server's `DefaultShell`
+  `--scope machine`. `--installer-type wix` forces the WiX/MSI
+  installer over the MSIX bundle winget would otherwise pick; the
+  version pin avoids a 7.7+ manifest that may drop WiX/MSI entirely
+  (see `docs/dsc-migration-notes.md`). Machine scope keeps pwsh's path
+  stable enough to later serve as Windows OpenSSH Server's
+  `DefaultShell`
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)

--- a/README.md
+++ b/README.md
@@ -124,15 +124,15 @@ the full list. Key categories:
   `cursor-agent` AI coding agent CLI, always updated to latest (no
   version pin); no prerequisite command required
 - **PowerShell 7 (pwsh)** (via
-  `winget install --scope machine --installer-type wix --version 7.6.*`):
-  installed at machine scope, not through WinGet Configuration (DSC),
-  because `Microsoft.WinGet.DSC/WinGetPackage` cannot request
-  `--scope machine`. `--installer-type wix` forces the WiX/MSI
-  installer over the MSIX bundle winget would otherwise pick; the
-  version pin avoids a 7.7+ manifest that may drop WiX/MSI entirely
-  (see `docs/dsc-migration-notes.md`). Machine scope keeps pwsh's path
-  stable enough to later serve as Windows OpenSSH Server's
-  `DefaultShell`
+  `winget install --scope machine --installer-type wix`): installed at
+  machine scope, not through WinGet Configuration (DSC), because
+  `Microsoft.WinGet.DSC/WinGetPackage` cannot request `--scope
+  machine`. `--installer-type wix` forces the WiX/MSI installer over
+  the MSIX bundle winget would otherwise pick (see
+  `docs/dsc-migration-notes.md` for the risk that a future manifest
+  drops WiX/MSI entirely, and why this isn't mitigated with a
+  `--version` pin). Machine scope keeps pwsh's path stable enough to
+  later serve as Windows OpenSSH Server's `DefaultShell`
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ setup.cmd                        ← single entry point
             │    ├─ dotnet tool → VPM CLI
             │    ├─ install.ps1 → CodeRabbit CLI
             │    ├─ install script → Cursor CLI
+            │    ├─ winget --scope machine → PowerShell 7 (pwsh)
             │    ├─ Unity Hub → Unity 2022.3.22f1
             │    ├─ mkcert → local CA
             │    └─ Docker Desktop → image pulls
@@ -122,6 +123,11 @@ the full list. Key categories:
 - **Cursor CLI** (via official install script): standalone
   `cursor-agent` AI coding agent CLI, always updated to latest (no
   version pin); no prerequisite command required
+- **PowerShell 7 (pwsh)** (via `winget install --scope machine`):
+  installed at machine scope, not through WinGet Configuration (DSC),
+  because `Microsoft.WinGet.DSC/WinGetPackage` cannot request
+  `--scope machine`. Machine scope keeps pwsh's path stable enough to
+  later serve as Windows OpenSSH Server's `DefaultShell`
 - **Unity 2022.3.22f1**: Required by VRChat SDK/VCC
 - **mkcert**: Local CA for HTTPS development
 - **Docker images**: Base images (alpine, debian, ubuntu, node variants)

--- a/boxstarter.ps1
+++ b/boxstarter.ps1
@@ -174,7 +174,7 @@ else {
 }
 
 ###########################################################################
-### Phase 5 — Post-install setup (VPM CLI, CodeRabbit CLI, Cursor CLI, Unity, mkcert, Docker)
+### Phase 5 — Post-install setup (VPM CLI, CodeRabbit CLI, Cursor CLI, pwsh, Unity, mkcert, Docker)
 ###########################################################################
 # Unity CLI must be in place before post-install.ps1's own Unity Editor
 # install step (issue #76) -- installed here, ahead of that step, rather

--- a/configurations/packages.dsc.yaml
+++ b/configurations/packages.dsc.yaml
@@ -862,13 +862,15 @@ properties:
     # ================================================================
     # CLI — Shell
     # ================================================================
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: pkg.pwsh
-      directives:
-        description: PowerShell 7
-      settings:
-        id: "9MZ1SNWT0N5D"
-        source: msstore
+    # PowerShell 7 (pwsh) is intentionally NOT declared here.
+    # Microsoft.WinGet.DSC/WinGetPackage cannot request `--scope
+    # machine`, so this DSC route can only reach the msstore
+    # `9MZ1SNWT0N5D` package, which installs to user scope (MSIX) --
+    # unsuitable as a future sshd DefaultShell target. pwsh is
+    # installed at machine scope imperatively instead, from
+    # libs/pwsh-installer.ps1 (Sync-Pwsh) during Phase 5 post-install.
+    # See docs/dsc-migration-notes.md (issue #147) for the full
+    # rationale.
 
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: pkg.starship

--- a/configurations/packages.import.json
+++ b/configurations/packages.import.json
@@ -6,7 +6,6 @@
         { "PackageIdentifier": "9NBLGGH4NNS1" },
         { "PackageIdentifier": "9PDSCC711RVF" },
         { "PackageIdentifier": "9N1W692FV4S1" },
-        { "PackageIdentifier": "9MZ1SNWT0N5D" },
         { "PackageIdentifier": "XPFM0TP2CXZ4PN" },
         { "PackageIdentifier": "9NZ3KLHXDJP5" },
         { "PackageIdentifier": "9PP3C07GTVRH" },

--- a/configurations/packages.min.dsc.yaml
+++ b/configurations/packages.min.dsc.yaml
@@ -307,13 +307,15 @@ properties:
 
     # =======================================================================
     # Install the CLI shell tools
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: powershell-v7
-      directives:
-        description: PowerShell v7
-      settings:
-        id: Microsoft.PowerShell
-        source: winget
+    # PowerShell 7 (pwsh) is intentionally NOT declared here.
+    # Microsoft.WinGet.DSC/WinGetPackage cannot request `--scope
+    # machine`, and this manifest's default installer-type precedence
+    # (MSIX > MSI/Wix) would otherwise select the user-scope MSIX
+    # build -- unsuitable as a future sshd DefaultShell target. pwsh
+    # is installed at machine scope imperatively instead, from
+    # libs/pwsh-installer.ps1 (Sync-Pwsh) during Phase 5 post-install.
+    # See docs/dsc-migration-notes.md (issue #147) for the full
+    # rationale.
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: starship
       directives:

--- a/configurations/packages.min.import.json
+++ b/configurations/packages.min.import.json
@@ -35,7 +35,6 @@
         { "PackageIdentifier": "JesseDuffield.lazygit" },
         { "PackageIdentifier": "marlocarlo.psmux" },
         { "PackageIdentifier": "Zellij.Zellij" },
-        { "PackageIdentifier": "Microsoft.PowerShell" },
         { "PackageIdentifier": "Starship.Starship" },
         { "PackageIdentifier": "dandavison.delta" },
         { "PackageIdentifier": "charmbracelet.glow" },

--- a/docs/dotfiles-boundary.md
+++ b/docs/dotfiles-boundary.md
@@ -326,7 +326,7 @@ point — `.claude/skills/issue-authoring/references/contract.md`,
 | --- | --- | --- | --- |
 | `npx` (Node.js) | `fix-validate`, `pre-push-validate`, `post-fix-validate`, every `idd-*` helper call | **Already delegated (#108, PR #117)** — this repository no longer installs Node.js at all, on either profile. Both profiles have `jdx.mise` via winget unconditionally, but Node.js itself only comes from `mise` reading dotfiles' `node = "latest"` entry, which needs `chezmoi apply` to deploy — see the Node.js subsection in [§1](#1-first-wave-targets-in-repo-dependencies) and the cross-cutting caveat in [§4](#4-operations-gated-on-chezmoi-apply) | N/A — already the target state |
 | `gh` | The IDD loop's own bootstrap (not `fix-validate`/`pre-push-validate` directly) | **Already delegated (#107, PR #118)** — neither profile installs `GitHub.cli` via winget anymore; `gh` now comes from dotfiles' `github:cli/cli` (mise) | N/A — already the target state |
-| `pwsh` (PowerShell 7) | `pre-push-validate`/`post-fix-validate` (`Invoke-ScriptAnalyzer`, `Invoke-Pester`) | Both profiles install PowerShell 7 today, via different package identities: full uses `pkg.pwsh` (Microsoft Store id `9MZ1SNWT0N5D`); min uses `Microsoft.PowerShell` (native winget id). Not a delegation-relevant gap — see [§3](#3-powershell-7-provisioning-in-the-full-profile-conclusion). | Unchanged — no first-wave track touches either `pwsh` package definition. |
+| `pwsh` (PowerShell 7) | `pre-push-validate`/`post-fix-validate` (`Invoke-ScriptAnalyzer`, `Invoke-Pester`) | **Changed by issue #147.** Neither profile declares `pwsh` via `WinGetPackage` (DSC/import) anymore — `libs/pwsh-installer.ps1` (`Sync-Pwsh`) installs it imperatively at machine scope during Phase 5 post-install instead, on both profiles identically. See [§3](#3-powershell-7-provisioning-in-the-full-profile-conclusion)'s update note for why. | Unchanged — no first-wave (winget→dotfiles) delegation track touches `pwsh`; issue #147 is a machine-scope packaging change, not a delegation move. |
 | `PSScriptAnalyzer`, `Pester`, `powershell-yaml` (PowerShell modules) | `pre-push-validate`/`post-fix-validate` (`Invoke-ScriptAnalyzer`/`Invoke-Pester`); `powershell-yaml` is also required by `scripts/Build-Configurations.ps1` / `scripts/Test-PackageIds.ps1` | **No automated winget or dotfiles provisioning on either profile, for any of the three.** `.github/workflows/lint.yml` runs `Install-Module -Name <module> -RequiredVersion <pinned> -Force -Scope CurrentUser -Repository PSGallery` fresh on every CI run for all three. `docs/testing.md` documents the manual command for **local** development for `Pester`; `scripts/Build-Configurations.ps1`'s and `scripts/Test-PackageIds.ps1`'s own help-comment headers document the same manual command for `powershell-yaml`. Only `PSScriptAnalyzer` has no local-install documentation anywhere in this repository — just its CI provisioning in `lint.yml`. Nothing automates any of the three for a fresh local machine (either profile). | Unchanged — out of scope for the winget/dotfiles boundary; these are PowerShell Gallery modules, not OS packages. |
 
 ## 3. PowerShell 7 provisioning in the full profile: conclusion
@@ -388,6 +388,20 @@ local-provisioning gap adjacent to this question is the PowerShell
 `pre-push-validate` also needs — see the last row of [§2](#2-tooling-required-by-install-deps--fix-validate--pre-push-validate)'s
 table, which affects both profiles equally and is unrelated to the
 winget/dotfiles delegation boundary this issue covers.
+
+**Update (issue #147).** The investigation above, and the `pkg.pwsh`
+resource block quoted in it, describe this repository's state *before*
+issue #147. Neither profile declares `pwsh` via `WinGetPackage`
+(DSC/import) anymore: `9MZ1SNWT0N5D` (msstore) and `Microsoft.PowerShell`
+(winget, unscoped) both resolve to a user-scope MSIX install, which is
+unsuitable as a future Windows OpenSSH Server `DefaultShell` target (a
+machine-wide setting). `libs/pwsh-installer.ps1` (`Sync-Pwsh`) now
+installs `pwsh` imperatively at machine scope during Phase 5 post-install
+instead, identically on both profiles — see `docs/dsc-migration-notes.md`
+for the full rationale. This section's own investigation methodology and
+conclusion (no full-profile gap, present-day at the time) remain accurate
+as a historical record; only the "both profiles install it via
+`WinGetPackage`" mechanism changed.
 
 ## 4. Operations gated on `chezmoi apply`
 

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1185,9 +1185,8 @@ pattern already established by `libs/coderabbit-cli-installer.ps1`
 
 ```text
 install --id Microsoft.PowerShell --source winget --scope machine
-  --installer-type wix --version 7.6.* --exact
-  --accept-package-agreements --accept-source-agreements
-  --disable-interactivity
+  --installer-type wix --exact --accept-package-agreements
+  --accept-source-agreements --disable-interactivity
 ```
 
 - `--scope machine` alone has a reported version-mismatch bug in some
@@ -1203,19 +1202,32 @@ install --id Microsoft.PowerShell --source winget --scope machine
   MSI/WiX installer format starting with 7.7-preview.1, moving to
   MSIX-only distribution -- this could not be independently confirmed
   against a live manifest from this Linux development environment (no
-  `winget` available here), but the claim is specific enough, and the
-  failure mode severe enough (an unpinned `--installer-type wix` would
-  simply fail to resolve once winget's "latest" moves past 7.6.x), that
-  `--version 7.6.*` was added to pin to the last minor line known (at
-  authoring time) to still ship a WiX/MSI installer. This trades
-  automatic updates for installability: `Sync-Pwsh` will not move past
-  7.6.x until this pin is revisited. Re-check `winget show --id
-  Microsoft.PowerShell --source winget` on a real Windows machine
-  before bumping or removing this pin, and update the argument list
-  accordingly (a later 7.6.x patch release, a confirmed WiX-capable
-  7.7+ release, or a switch to `--installer-type msix` plus a
-  `--scope machine` MSIX provisioning strategy if WiX/MSI is
-  confirmed gone for good).
+  `winget` available here). An unpinned `--installer-type wix` would
+  fail to resolve once winget's "latest" moves past 7.6.x, if that
+  report is accurate.
+- **A version pin was tried and reverted.** `--version 7.6.*` was
+  added during this round of review to neutralize the risk above, then
+  reverted after a follow-up self-review pass caught that
+  `winget install`'s `--version` requires an **exact** version string
+  -- unlike `winget pin add`'s `--version`, it does not accept a
+  wildcard or range (confirmed against `winget install`'s own command
+  documentation and an open, unimplemented winget-pkgs feature request
+  for wildcard install versions). `--version 7.6.*` would have made
+  every `Sync-Pwsh` call fail immediately, on every machine -- a
+  regression worse than the risk it targeted. Hardcoding a specific
+  exact version string (e.g. a literal `7.6.5.0`) was considered and
+  rejected too: it cannot be confirmed against a real winget/manifest
+  from this development environment, and would itself go stale as
+  soon as a newer 7.6.x patch superseded it. The 7.7+ WiX/MSI-
+  availability risk is therefore left unmitigated in the argument
+  list; `Test-PwshMachineScopeInstalled` (below) at least turns a
+  resulting failure into a clear error instead of a false "complete"
+  message. Re-check `winget show --id Microsoft.PowerShell --source
+  winget` on a real Windows machine to confirm the current manifest's
+  installer types before considering a fix here -- a hardcoded exact
+  `--version`, a switch to `--installer-type msix` plus a `--scope
+  machine` MSIX provisioning strategy if WiX/MSI is confirmed gone for
+  good, or some other approach once the real constraint is known.
 
 ### Existing user-scope MSIX installs are not automatically removed
 

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1126,3 +1126,117 @@ Linux development environment, for the same reason recorded above for
 the Unity CLI and CodeRabbit CLI: this repository never executes
 `libs/post-install.ps1` or `boxstarter.ps1` directly in this
 environment, even for smoke-testing.
+
+## Migrating PowerShell 7 (pwsh) from user scope (MSIX) to machine scope (MSI) (issue #147)
+
+### Motivation
+
+The user wants to set Windows OpenSSH Server's `DefaultShell` to `pwsh`.
+`DefaultShell` is a single machine-wide value at
+`HKLM:\SOFTWARE\OpenSSH\DefaultShell` -- there is no per-user default
+shell in Win32-OpenSSH. Before this issue, `pwsh` installed as MSIX
+(user scope) on both profiles: the full profile's `packages.dsc.yaml`
+explicitly pinned the msstore listing `9MZ1SNWT0N5D`; the min profile's
+`packages.min.dsc.yaml` referenced the winget-source `Microsoft.PowerShell`
+package with no `scope`/`installer-type`, which resolves to the same MSIX
+bundle under winget's own installer-type precedence (MSIX > MSI/Wix) when
+neither is specified.
+
+MSIX-installed `pwsh` is reached through
+`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe`, an App Execution Alias
+implemented as an NTFS reparse point (`IO_REPARSE_TAG_APPEXECLINK`).
+`docs/dotfiles-boundary.md`'s
+["winget `portable` packages cannot run over an SSH session"](dotfiles-boundary.md#winget-portable-packages-cannot-run-over-an-ssh-session)
+section already documents that OpenSSH's public-key-authenticated
+sessions use a network logon token that cannot traverse an NTFS reparse
+point (`ERROR_UNTRUSTED_MOUNT_POINT`, a real winget-`portable` failure
+cited there). Pointing `DefaultShell` at the MSIX execution-alias path
+risks the same failure class.
+
+### Why this could not be declared in `packages.dsc.yaml` / `packages.min.dsc.yaml`
+
+Neither of this repository's two winget-based configuration routes can
+request machine scope:
+
+- `Microsoft.WinGet.DSC/WinGetPackage` (the DSC resource used by both
+  `.dsc.yaml` files) has no working `scope` property -- setting one
+  fails with "The property 'scope' cannot be found on this object"
+  (microsoft/winget-cli#4993, #5722; an open, unimplemented feature
+  request as of this writing).
+- `winget import` (the degraded-mode fallback route selected by
+  `libs/strategy.ps1`, generating `packages.import.json` /
+  `packages.min.import.json`) has no `--scope` option at all
+  (microsoft/winget-cli#3850).
+
+`boxstarter.ps1`'s Phase 5 (post-install) runs unconditionally after
+Phase 2, regardless of whether Phase 2 took the `dsc` or `import` route,
+so an imperative post-install installer works uniformly for both.
+`libs/pwsh-installer.ps1` (`Sync-Pwsh`) follows the same
+"winget/DSC can't express this -- do it imperatively in post-install"
+pattern already established by `libs/coderabbit-cli-installer.ps1`
+(issue #126), `libs/cursor-cli-installer.ps1` (issue #139), and
+`libs/unity-editor-installer.ps1` (issue #74).
+
+### `winget install` argument choices and their caveats
+
+`Get-PwshInstallArguments` (pure, unit-tested directly -- mirrors
+`libs/winget-pin-sync.ps1`'s `Get-WinGetPinAddArguments` /
+`Invoke-WinGetPinAddCommand` split) builds:
+
+```text
+install --id Microsoft.PowerShell --source winget --scope machine
+  --installer-type wix --exact --accept-package-agreements
+  --accept-source-agreements --disable-interactivity
+```
+
+- `--scope machine` alone has a reported version-mismatch bug in some
+  winget versions (microsoft/winget-pkgs#95172 -- machine scope pulled
+  an older PowerShell version in one report), so it is paired with an
+  explicit `--installer-type wix` to force the WiX/MSI installer over
+  the MSIX bundle winget's own installer-type precedence would
+  otherwise select.
+- As of this writing, the `Microsoft.PowerShell` winget-pkgs manifest
+  (7.6.x) ships both an MSIX bundle and a WiX/MSI installer with no
+  top-level `InstallerType`. Community reports (surfaced while
+  researching issue #147) suggest 7.7+ manifests may drop the WiX/MSI
+  installer entirely; this could not be confirmed against a live
+  manifest from this Linux development environment (no `winget`
+  available here). If a future winget upgrade makes `--installer-type
+  wix` fail to resolve, re-check `winget show --id Microsoft.PowerShell
+  --source winget` on a real Windows machine and adjust the argument
+  list accordingly.
+
+### Existing user-scope MSIX installs are not automatically removed
+
+A machine that ran this repository's setup before issue #147 may already
+have the user-scope MSIX `pwsh` installed. `Sync-Pwsh` does not attempt
+to uninstall it: the full profile's msstore package id (`9MZ1SNWT0N5D`)
+and the min profile's winget-source `Microsoft.PowerShell` package (which
+also resolves to an MSIX bundle) are not necessarily the same winget
+package identity on a given machine's `winget list` output, and this
+repository could not verify which one to target for an automatic
+`winget uninstall` with confidence from this development environment.
+Instead, `Test-PwshUserScopeCoexistence` detects the pre-existing
+`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe` execution alias and
+`Sync-Pwsh` emits a `Write-Warning` noting that it may still take PATH
+precedence over the machine-scope install, depending on PATH ordering.
+Manual cleanup (`winget uninstall`) is left to the operator.
+
+### Verification
+
+Like the CodeRabbit CLI, Cursor CLI, and Unity CLI installers above,
+`libs/pwsh-installer.ps1` could not be verified against a real `winget`
+binary from this Linux development environment. `Get-PwshInstallArguments`
+(pure argument building) and `Test-PwshUserScopeCoexistence` (filesystem
+check) are unit-tested directly; `Invoke-PwshInstallCommand` (the thin
+`& winget @ArgumentList` wrapper) is deliberately left untested and only
+ever mocked by its callers' tests, mirroring
+`libs/winget-pin-sync.ps1`'s `Invoke-WinGetPinListCommand` /
+`Invoke-WinGetPinAddCommand` and `libs/unity-editor-installer.ps1`'s
+`Invoke-UnityEditorsListCommand` -- `winget` does not resolve via
+`Get-Command` on this Linux Pester-running environment, and Pester's
+`Mock` cannot intercept a command name `Get-Command` can't resolve at
+all. Real-machine behavior (does `--installer-type wix` still resolve on
+the winget version actually installed; does the machine-scope install
+actually land at the expected path) needs manual verification on a real
+Windows machine.

--- a/docs/dsc-migration-notes.md
+++ b/docs/dsc-migration-notes.md
@@ -1185,8 +1185,9 @@ pattern already established by `libs/coderabbit-cli-installer.ps1`
 
 ```text
 install --id Microsoft.PowerShell --source winget --scope machine
-  --installer-type wix --exact --accept-package-agreements
-  --accept-source-agreements --disable-interactivity
+  --installer-type wix --version 7.6.* --exact
+  --accept-package-agreements --accept-source-agreements
+  --disable-interactivity
 ```
 
 - `--scope machine` alone has a reported version-mismatch bug in some
@@ -1197,14 +1198,24 @@ install --id Microsoft.PowerShell --source winget --scope machine
   otherwise select.
 - As of this writing, the `Microsoft.PowerShell` winget-pkgs manifest
   (7.6.x) ships both an MSIX bundle and a WiX/MSI installer with no
-  top-level `InstallerType`. Community reports (surfaced while
-  researching issue #147) suggest 7.7+ manifests may drop the WiX/MSI
-  installer entirely; this could not be confirmed against a live
-  manifest from this Linux development environment (no `winget`
-  available here). If a future winget upgrade makes `--installer-type
-  wix` fail to resolve, re-check `winget show --id Microsoft.PowerShell
-  --source winget` on a real Windows machine and adjust the argument
-  list accordingly.
+  top-level `InstallerType`. During this PR's review, CodeRabbit
+  surfaced web research indicating PowerShell has deprecated the
+  MSI/WiX installer format starting with 7.7-preview.1, moving to
+  MSIX-only distribution -- this could not be independently confirmed
+  against a live manifest from this Linux development environment (no
+  `winget` available here), but the claim is specific enough, and the
+  failure mode severe enough (an unpinned `--installer-type wix` would
+  simply fail to resolve once winget's "latest" moves past 7.6.x), that
+  `--version 7.6.*` was added to pin to the last minor line known (at
+  authoring time) to still ship a WiX/MSI installer. This trades
+  automatic updates for installability: `Sync-Pwsh` will not move past
+  7.6.x until this pin is revisited. Re-check `winget show --id
+  Microsoft.PowerShell --source winget` on a real Windows machine
+  before bumping or removing this pin, and update the argument list
+  accordingly (a later 7.6.x patch release, a confirmed WiX-capable
+  7.7+ release, or a switch to `--installer-type msix` plus a
+  `--scope machine` MSIX provisioning strategy if WiX/MSI is
+  confirmed gone for good).
 
 ### Existing user-scope MSIX installs are not automatically removed
 
@@ -1217,10 +1228,41 @@ package identity on a given machine's `winget list` output, and this
 repository could not verify which one to target for an automatic
 `winget uninstall` with confidence from this development environment.
 Instead, `Test-PwshUserScopeCoexistence` detects the pre-existing
-`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe` execution alias and
-`Sync-Pwsh` emits a `Write-Warning` noting that it may still take PATH
-precedence over the machine-scope install, depending on PATH ordering.
-Manual cleanup (`winget uninstall`) is left to the operator.
+`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe` execution alias.
+
+During this PR's review, CodeRabbit raised a related, more severe
+concern: winget is known to reject installing a different installer
+technology (here, WiX/MSI) over a package it already correlates with an
+existing install (here, the MSIX alias) -- rather than only a
+PATH-ordering nuisance, this could mean `Sync-Pwsh`'s `winget install`
+call fails outright on exactly the machines this migration targets
+(already-provisioned ones). This could not be confirmed or ruled out
+from this development environment either. `Sync-Pwsh` was adjusted to
+correlate the two signals instead of treating them independently: when
+`Invoke-PwshInstallCommand` exits non-zero **and** the MSIX alias is
+present, the error message explicitly names the likely installer-technology
+conflict and suggests a manual `winget uninstall` of the existing MSIX
+package before re-running -- still no automatic uninstall (the target
+package identity is still not reliably known), but the operator is no
+longer left with a bare exit-code error to diagnose. When the alias is
+present but the install still succeeds (exit 0) and the machine-scope
+binary is verified present, the original coexistence `Write-Warning`
+about PATH-ordering precedence still fires, since a `Test-Path` hit
+there is not itself evidence of an install failure.
+
+### `winget install` exit 0 is not proof the machine-scope binary landed
+
+A third review finding: `winget install` can report exit code 0 for an
+outcome short of "the requested package is now present at the
+requested scope" -- for example, a no-op it silently declined to apply
+against an already-tracked package (the same installer-technology
+conflict discussed above could plausibly manifest this way instead of
+a hard failure). `Sync-Pwsh` therefore no longer treats exit 0 alone as
+success: `Test-PwshMachineScopeInstalled` checks for the actual
+target binary at `%ProgramFiles%\PowerShell\7\pwsh.exe` (the WiX/MSI
+installer's standard install location) and `Sync-Pwsh` reports a
+non-terminating error -- not the "installation complete" message --
+when it is missing despite a 0 exit code.
 
 ### Verification
 

--- a/libs/post-install.ps1
+++ b/libs/post-install.ps1
@@ -90,6 +90,24 @@ Sync-CoderabbitCli
 Sync-CursorCli
 
 ###########################################################################
+### PowerShell 7 (pwsh) — machine scope. Neither
+### Microsoft.WinGet.DSC/WinGetPackage (the DSC route) nor `winget
+### import` (the degraded-mode fallback route) can request `--scope
+### machine`, so both configurations/packages.dsc.yaml and
+### configurations/packages.min.dsc.yaml intentionally no longer
+### declare pwsh -- see the tombstone comments left at their former
+### "CLI — Shell" entries. Sync-Pwsh installs it here instead, at
+### machine scope, so its path is stable enough to later serve as
+### sshd's DefaultShell -- a user-scope MSIX install resolves through
+### an NTFS reparse point (App Execution Alias) that OpenSSH's
+### public-key-authenticated sessions cannot traverse (issue #147; see
+### docs/dotfiles-boundary.md's reparse-point discussion and
+### docs/dsc-migration-notes.md for the full rationale).
+###########################################################################
+. (Join-Path -Path $PSScriptRoot -ChildPath 'pwsh-installer.ps1')
+Sync-Pwsh
+
+###########################################################################
 ### Vagrant plugins
 ###########################################################################
 if (Test-CommandExists vagrant) {

--- a/libs/pwsh-installer.ps1
+++ b/libs/pwsh-installer.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+Installs PowerShell 7 (pwsh) at machine scope via winget, so its path
+is stable enough to later serve as Windows OpenSSH Server's
+DefaultShell.
+
+This file is dot-sourced (not imported as a module) from
+libs/post-install.ps1 -- do not add Export-ModuleMember here.
+#>
+Set-StrictMode -Version Latest
+
+# $env:LOCALAPPDATA is Windows-only and absent on the Linux CI runner
+# that runs this file's Pester tests -- guarded so dot-sourcing this
+# file doesn't fail there. Every real caller runs on Windows, where
+# LOCALAPPDATA is always set.
+$Script:PwshMsixAliasPath = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps\pwsh.exe' } else { $null }
+
+function Get-PwshInstallArguments {
+  [CmdletBinding()]
+  [OutputType([string[]])]
+  param ()
+  return [string[]]@(
+    'install', '--id', 'Microsoft.PowerShell', '--source', 'winget',
+    '--scope', 'machine', '--installer-type', 'wix', '--exact',
+    '--accept-package-agreements', '--accept-source-agreements',
+    '--disable-interactivity'
+  )
+  <#
+  .SYNOPSIS
+  Builds the `winget install` argument list for machine-scope pwsh.
+  Pure (no `winget` call), so this is tested directly without mocking
+  Invoke-PwshInstallCommand at all -- mirrors
+  libs/winget-pin-sync.ps1's Get-WinGetPinAddArguments /
+  Invoke-WinGetPinAddCommand split.
+
+  .DESCRIPTION
+  --scope machine forces a machine-wide install; --installer-type wix
+  forces the WiX/MSI installer over the MSIX bundle winget would
+  otherwise pick by its own installer-type precedence (MSIX >
+  MSI/Wix). See docs/dsc-migration-notes.md (issue #147) for the full
+  rationale, including the winget-pkgs#95172 caveat about --scope
+  machine alone and the risk that a future manifest drops the WiX/MSI
+  installer entirely.
+
+  .OUTPUTS
+  String array of `winget` CLI arguments.
+  #>
+}
+
+function Invoke-PwshInstallCommand {
+  [CmdletBinding()]
+  [OutputType([int])]
+  param (
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$ArgumentList
+  )
+  & winget @ArgumentList
+  return $LASTEXITCODE
+  <#
+  .SYNOPSIS
+  The only function with a real dependency on the installed `winget`
+  binary, kept to a single call so Pester can mock it directly --
+  `winget` does not resolve via Get-Command on every machine this
+  repo's tests run on (this Linux dev environment included), and Mock
+  cannot intercept a command name Get-Command can't resolve at all
+  (same constraint documented in libs/winget-pin-sync.ps1's
+  Invoke-WinGetPinListCommand and libs/unity-editor-installer.ps1's
+  Invoke-UnityEditorsListCommand).
+
+  .OUTPUTS
+  Int32 exit code ($LASTEXITCODE after the winget invocation).
+  #>
+}
+
+function Test-PwshUserScopeCoexistence {
+  [CmdletBinding()]
+  [OutputType([bool])]
+  param (
+    [string]$AliasPath = $Script:PwshMsixAliasPath
+  )
+  if ([string]::IsNullOrEmpty($AliasPath)) {
+    return $false
+  }
+  return Test-Path -Path $AliasPath -PathType Leaf
+  <#
+  .SYNOPSIS
+  Detects a pre-existing user-scope MSIX pwsh execution alias.
+
+  .DESCRIPTION
+  A machine that ran this repository's setup before this migration may
+  already have MSIX-installed pwsh at
+  %LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe (an App Execution
+  Alias, implemented as an NTFS reparse point). This function only
+  detects it; it is never uninstalled here, because the winget package
+  identity actually installed on a given machine (the msstore
+  9MZ1SNWT0N5D listing vs. the winget-source Microsoft.PowerShell
+  manifest's own MSIX bundle) cannot be determined with confidence
+  from this repository alone. See docs/dsc-migration-notes.md (issue
+  #147).
+
+  A null/empty AliasPath (e.g. the default on a machine without
+  $env:LOCALAPPDATA, such as this file's own Linux Pester run) is
+  $false rather than an error.
+
+  .OUTPUTS
+  $true if the user-scope MSIX execution alias exists, otherwise
+  $false.
+  #>
+}
+
+function Sync-Pwsh {
+  [CmdletBinding()]
+  param ()
+
+  Write-Host '[pwsh] Installing/updating PowerShell 7 (pwsh) at machine scope...' -ForegroundColor Cyan
+  $exitCode = Invoke-PwshInstallCommand -ArgumentList (Get-PwshInstallArguments)
+  if ($exitCode -ne 0) {
+    Write-Error "winget install for PowerShell 7 exited with code ${exitCode}."
+  }
+  else {
+    Write-Host '[pwsh] PowerShell 7 (pwsh) machine-scope installation complete.' -ForegroundColor Green
+  }
+
+  if (Test-PwshUserScopeCoexistence) {
+    Write-Warning '[pwsh] A user-scope MSIX PowerShell 7 execution alias was found at %LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe. It is left in place -- it may still take PATH precedence over the machine-scope install depending on PATH ordering. See docs/dsc-migration-notes.md (issue #147) for why this is not removed automatically.'
+  }
+  <#
+  .SYNOPSIS
+  Idempotent entry point: installs or updates PowerShell 7 (pwsh) to
+  machine scope on every call.
+
+  .DESCRIPTION
+  Machine-scope MSI installs write their own machine Path registry
+  value as part of the installer's own custom action, so unlike
+  libs/coderabbit-cli-installer.ps1 / libs/cursor-cli-installer.ps1,
+  no bespoke Add-*ToProcessPath function is needed here --
+  libs/process-path-sync.ps1's Sync-ProcessPath already merges
+  Machine/User PATH from the registry into the current process on
+  demand.
+
+  The user-scope-coexistence check always runs, regardless of whether
+  the winget install itself succeeded or failed, since it reports on
+  pre-existing machine state that install success/failure does not
+  change.
+  #>
+}

--- a/libs/pwsh-installer.ps1
+++ b/libs/pwsh-installer.ps1
@@ -22,8 +22,8 @@ function Get-PwshInstallArguments {
   param ()
   return [string[]]@(
     'install', '--id', 'Microsoft.PowerShell', '--source', 'winget',
-    '--scope', 'machine', '--installer-type', 'wix', '--version', '7.6.*',
-    '--exact', '--accept-package-agreements', '--accept-source-agreements',
+    '--scope', 'machine', '--installer-type', 'wix', '--exact',
+    '--accept-package-agreements', '--accept-source-agreements',
     '--disable-interactivity'
   )
   <#
@@ -38,15 +38,24 @@ function Get-PwshInstallArguments {
   --scope machine forces a machine-wide install; --installer-type wix
   forces the WiX/MSI installer over the MSIX bundle winget would
   otherwise pick by its own installer-type precedence (MSIX >
-  MSI/Wix). --version 7.6.* pins to the last minor line confirmed (at
-  authoring time) to still ship a WiX/MSI installer -- PowerShell
-  7.7+ is reported to drop it in favor of MSIX-only distribution, which
-  would make --installer-type wix fail to resolve against an unpinned
-  "latest" install. See docs/dsc-migration-notes.md (issue #147) for
-  the full rationale, including the winget-pkgs#95172 caveat about
-  --scope machine alone and the plan for revisiting this pin once
-  7.7's installer situation is confirmed against a real winget
-  environment.
+  MSI/Wix).
+
+  No --version pin: `winget install`'s --version requires an exact
+  version string (unlike `winget pin add`'s --version, which accepts a
+  wildcard/range) -- confirmed via `winget install` command
+  documentation and an open, unimplemented winget-pkgs feature request
+  for wildcard install versions. A `7.6.*`-style glob was tried during
+  this issue's own review round and empirically would have made every
+  install fail (verified independently, not just asserted), so it was
+  reverted; hardcoding a specific exact version string was rejected too,
+  since it cannot be confirmed against a real winget/manifest from this
+  Linux development environment and would itself go stale. See
+  docs/dsc-migration-notes.md (issue #147) for the full rationale,
+  including the winget-pkgs#95172 caveat about --scope machine alone
+  and the unresolved 7.7+ WiX/MSI-availability risk this leaves
+  unmitigated in code (Test-PwshMachineScopeInstalled surfaces it as a
+  failure instead of a false "complete" message, but does not prevent
+  it).
 
   .OUTPUTS
   String array of `winget` CLI arguments.

--- a/libs/pwsh-installer.ps1
+++ b/libs/pwsh-installer.ps1
@@ -45,9 +45,10 @@ function Get-PwshInstallArguments {
   wildcard/range) -- confirmed via `winget install` command
   documentation and an open, unimplemented winget-pkgs feature request
   for wildcard install versions. A `7.6.*`-style glob was tried during
-  this issue's own review round and empirically would have made every
-  install fail (verified independently, not just asserted), so it was
-  reverted; hardcoding a specific exact version string was rejected too,
+  this issue's own review round and, per that same documented
+  exact-match-only behavior, would have made every install fail, so it
+  was reverted; hardcoding a specific exact version string was rejected
+  too,
   since it cannot be confirmed against a real winget/manifest from this
   Linux development environment and would itself go stale. See
   docs/dsc-migration-notes.md (issue #147) for the full rationale,

--- a/libs/pwsh-installer.ps1
+++ b/libs/pwsh-installer.ps1
@@ -9,11 +9,12 @@ libs/post-install.ps1 -- do not add Export-ModuleMember here.
 #>
 Set-StrictMode -Version Latest
 
-# $env:LOCALAPPDATA is Windows-only and absent on the Linux CI runner
-# that runs this file's Pester tests -- guarded so dot-sourcing this
-# file doesn't fail there. Every real caller runs on Windows, where
-# LOCALAPPDATA is always set.
+# $env:LOCALAPPDATA / $env:ProgramFiles are Windows-only and absent on
+# the Linux CI runner that runs this file's Pester tests -- guarded so
+# dot-sourcing this file doesn't fail there. Every real caller runs on
+# Windows, where both are always set.
 $Script:PwshMsixAliasPath = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps\pwsh.exe' } else { $null }
+$Script:PwshMachineScopeExePath = if ($env:ProgramFiles) { Join-Path $env:ProgramFiles 'PowerShell' -AdditionalChildPath '7', 'pwsh.exe' } else { $null }
 
 function Get-PwshInstallArguments {
   [CmdletBinding()]
@@ -21,8 +22,8 @@ function Get-PwshInstallArguments {
   param ()
   return [string[]]@(
     'install', '--id', 'Microsoft.PowerShell', '--source', 'winget',
-    '--scope', 'machine', '--installer-type', 'wix', '--exact',
-    '--accept-package-agreements', '--accept-source-agreements',
+    '--scope', 'machine', '--installer-type', 'wix', '--version', '7.6.*',
+    '--exact', '--accept-package-agreements', '--accept-source-agreements',
     '--disable-interactivity'
   )
   <#
@@ -37,10 +38,15 @@ function Get-PwshInstallArguments {
   --scope machine forces a machine-wide install; --installer-type wix
   forces the WiX/MSI installer over the MSIX bundle winget would
   otherwise pick by its own installer-type precedence (MSIX >
-  MSI/Wix). See docs/dsc-migration-notes.md (issue #147) for the full
-  rationale, including the winget-pkgs#95172 caveat about --scope
-  machine alone and the risk that a future manifest drops the WiX/MSI
-  installer entirely.
+  MSI/Wix). --version 7.6.* pins to the last minor line confirmed (at
+  authoring time) to still ship a WiX/MSI installer -- PowerShell
+  7.7+ is reported to drop it in favor of MSIX-only distribution, which
+  would make --installer-type wix fail to resolve against an unpinned
+  "latest" install. See docs/dsc-migration-notes.md (issue #147) for
+  the full rationale, including the winget-pkgs#95172 caveat about
+  --scope machine alone and the plan for revisiting this pin once
+  7.7's installer situation is confirmed against a real winget
+  environment.
 
   .OUTPUTS
   String array of `winget` CLI arguments.
@@ -107,20 +113,65 @@ function Test-PwshUserScopeCoexistence {
   #>
 }
 
+function Test-PwshMachineScopeInstalled {
+  [CmdletBinding()]
+  [OutputType([bool])]
+  param (
+    [string]$ExePath = $Script:PwshMachineScopeExePath
+  )
+  if ([string]::IsNullOrEmpty($ExePath)) {
+    return $false
+  }
+  return Test-Path -Path $ExePath -PathType Leaf
+  <#
+  .SYNOPSIS
+  Verifies pwsh actually landed at the expected machine-scope path.
+
+  .DESCRIPTION
+  `winget install` can return exit code 0 for outcomes short of "the
+  machine-scope package is now present" -- for example a no-op against
+  an already-tracked package under a different installer technology
+  (see Sync-Pwsh's coexistence-conflict handling). Checking for the
+  WiX/MSI installer's actual target path
+  (%ProgramFiles%\PowerShell\7\pwsh.exe) turns that kind of silent
+  false-success into a detectable warning instead of an unverified
+  "installation complete" message.
+
+  A null/empty ExePath (e.g. the default on a machine without
+  $env:ProgramFiles, such as this file's own Linux Pester run) is
+  $false rather than an error.
+
+  .OUTPUTS
+  $true if the machine-scope pwsh.exe exists, otherwise $false.
+  #>
+}
+
 function Sync-Pwsh {
   [CmdletBinding()]
   param ()
 
   Write-Host '[pwsh] Installing/updating PowerShell 7 (pwsh) at machine scope...' -ForegroundColor Cyan
   $exitCode = Invoke-PwshInstallCommand -ArgumentList (Get-PwshInstallArguments)
+  $coexists = Test-PwshUserScopeCoexistence
+
   if ($exitCode -ne 0) {
-    Write-Error "winget install for PowerShell 7 exited with code ${exitCode}."
-  }
-  else {
-    Write-Host '[pwsh] PowerShell 7 (pwsh) machine-scope installation complete.' -ForegroundColor Green
+    if ($coexists) {
+      Write-Error "winget install for PowerShell 7 exited with code ${exitCode}. A user-scope MSIX PowerShell 7 execution alias already exists at %LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe -- winget can reject installing a different installer technology (MSI/WiX) over an already-tracked MSIX package. Manually uninstalling the existing MSIX package (winget uninstall) before re-running may be required. See docs/dsc-migration-notes.md (issue #147)."
+    }
+    else {
+      Write-Error "winget install for PowerShell 7 exited with code ${exitCode}."
+    }
+    return
   }
 
-  if (Test-PwshUserScopeCoexistence) {
+  if (-not (Test-PwshMachineScopeInstalled)) {
+    Write-Error '[pwsh] winget install for PowerShell 7 exited 0, but pwsh.exe was not found at the expected machine-scope path (%ProgramFiles%\PowerShell\7\pwsh.exe). Treat this as a failed install -- winget can report success for a no-op it silently declined to apply. See docs/dsc-migration-notes.md (issue #147).'
+    return
+  }
+
+  Write-Host '[pwsh] PowerShell 7 (pwsh) machine-scope installation complete.' -ForegroundColor Green
+
+  if ($coexists) {
     Write-Warning '[pwsh] A user-scope MSIX PowerShell 7 execution alias was found at %LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe. It is left in place -- it may still take PATH precedence over the machine-scope install depending on PATH ordering. See docs/dsc-migration-notes.md (issue #147) for why this is not removed automatically.'
   }
   <#
@@ -137,9 +188,13 @@ function Sync-Pwsh {
   Machine/User PATH from the registry into the current process on
   demand.
 
-  The user-scope-coexistence check always runs, regardless of whether
-  the winget install itself succeeded or failed, since it reports on
-  pre-existing machine state that install success/failure does not
-  change.
+  The user-scope-coexistence check runs unconditionally (both success
+  and failure paths) so it can be correlated with a failed install --
+  a pre-existing MSIX package is a plausible cause of winget rejecting
+  the machine-scope install as a different installer technology, not
+  just a PATH-ordering concern. A "successful" (exit 0) install is
+  additionally verified against the actual machine-scope binary path,
+  since winget can report success for an outcome that did not actually
+  apply the requested change.
   #>
 }

--- a/libs/pwsh-installer.ps1
+++ b/libs/pwsh-installer.ps1
@@ -144,8 +144,9 @@ function Test-PwshMachineScopeInstalled {
   (see Sync-Pwsh's coexistence-conflict handling). Checking for the
   WiX/MSI installer's actual target path
   (%ProgramFiles%\PowerShell\7\pwsh.exe) turns that kind of silent
-  false-success into a detectable warning instead of an unverified
-  "installation complete" message.
+  false-success into a detectable failure (a non-terminating
+  Write-Error) instead of an unverified "installation complete"
+  message.
 
   A null/empty ExePath (e.g. the default on a machine without
   $env:ProgramFiles, such as this file's own Linux Pester run) is

--- a/tests/powershell/pwsh-installer.Tests.ps1
+++ b/tests/powershell/pwsh-installer.Tests.ps1
@@ -21,10 +21,10 @@ Describe 'Get-PwshInstallArguments' {
     ($arguments -join ' ') | Should -Match '--id Microsoft\.PowerShell'
   }
 
-  It 'pins to the 7.6 line, since 7.7+ may drop the WiX/MSI installer entirely' {
+  It 'does not pass --version (winget install requires an exact version string, not a wildcard/range)' {
     $arguments = Get-PwshInstallArguments
 
-    ($arguments -join ' ') | Should -Match '--version 7\.6\.\*'
+    $arguments | Should -Not -Contain '--version'
   }
 }
 

--- a/tests/powershell/pwsh-installer.Tests.ps1
+++ b/tests/powershell/pwsh-installer.Tests.ps1
@@ -1,0 +1,99 @@
+BeforeAll {
+  . (Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath '..', 'libs', 'pwsh-installer.ps1')
+}
+
+Describe 'Get-PwshInstallArguments' {
+  It 'requests a machine-scope install' {
+    $arguments = Get-PwshInstallArguments
+
+    ($arguments -join ' ') | Should -Match '--scope machine'
+  }
+
+  It 'forces the WiX/MSI installer type over the MSIX bundle winget would otherwise prefer' {
+    $arguments = Get-PwshInstallArguments
+
+    ($arguments -join ' ') | Should -Match '--installer-type wix'
+  }
+
+  It 'targets the Microsoft.PowerShell winget package' {
+    $arguments = Get-PwshInstallArguments
+
+    ($arguments -join ' ') | Should -Match '--id Microsoft\.PowerShell'
+  }
+}
+
+Describe 'Test-PwshUserScopeCoexistence' {
+  It 'returns $false without checking the filesystem when AliasPath is null or empty' {
+    Mock Test-Path { throw 'Test-Path should not be called when AliasPath is empty' }
+
+    Test-PwshUserScopeCoexistence -AliasPath $null | Should -Be $false
+    Test-PwshUserScopeCoexistence -AliasPath '' | Should -Be $false
+  }
+
+  It 'returns $true when the user-scope MSIX execution alias exists' {
+    Mock Test-Path { $true }
+
+    Test-PwshUserScopeCoexistence -AliasPath '/fake/Microsoft/WindowsApps/pwsh.exe' | Should -Be $true
+  }
+
+  It 'returns $false when the user-scope MSIX execution alias does not exist' {
+    Mock Test-Path { $false }
+
+    Test-PwshUserScopeCoexistence -AliasPath '/fake/Microsoft/WindowsApps/pwsh.exe' | Should -Be $false
+  }
+}
+
+Describe 'Sync-Pwsh' {
+  BeforeEach {
+    Mock Test-PwshUserScopeCoexistence { $false }
+  }
+
+  It 'installs with the machine-scope argument list' {
+    $script:capturedArgumentList = $null
+    Mock Invoke-PwshInstallCommand {
+      $script:capturedArgumentList = $ArgumentList
+      0
+    }
+
+    Sync-Pwsh
+
+    ($script:capturedArgumentList -join ' ') | Should -Match '--scope machine'
+  }
+
+  It 'writes a non-terminating error and does not throw when the installer exits non-zero' {
+    Mock Invoke-PwshInstallCommand { 1 }
+
+    { Sync-Pwsh -ErrorAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'still checks for user-scope MSIX coexistence when the installer fails' {
+    Mock Invoke-PwshInstallCommand { 1 }
+
+    Sync-Pwsh -ErrorAction SilentlyContinue
+
+    Should -Invoke Test-PwshUserScopeCoexistence -Times 1
+  }
+
+  It 'checks for user-scope MSIX coexistence after a successful install too' {
+    Mock Invoke-PwshInstallCommand { 0 }
+
+    Sync-Pwsh
+
+    Should -Invoke Test-PwshUserScopeCoexistence -Times 1
+  }
+
+  It 'warns when a user-scope MSIX execution alias coexists, without throwing' {
+    Mock Invoke-PwshInstallCommand { 0 }
+    Mock Test-PwshUserScopeCoexistence { $true }
+
+    { Sync-Pwsh -WarningAction SilentlyContinue } | Should -Not -Throw
+  }
+
+  It 'does not warn when no user-scope MSIX execution alias is present' {
+    Mock Invoke-PwshInstallCommand { 0 }
+
+    $warnings = Sync-Pwsh 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+    $warnings | Should -BeNullOrEmpty
+  }
+}

--- a/tests/powershell/pwsh-installer.Tests.ps1
+++ b/tests/powershell/pwsh-installer.Tests.ps1
@@ -20,6 +20,12 @@ Describe 'Get-PwshInstallArguments' {
 
     ($arguments -join ' ') | Should -Match '--id Microsoft\.PowerShell'
   }
+
+  It 'pins to the 7.6 line, since 7.7+ may drop the WiX/MSI installer entirely' {
+    $arguments = Get-PwshInstallArguments
+
+    ($arguments -join ' ') | Should -Match '--version 7\.6\.\*'
+  }
 }
 
 Describe 'Test-PwshUserScopeCoexistence' {
@@ -43,9 +49,31 @@ Describe 'Test-PwshUserScopeCoexistence' {
   }
 }
 
+Describe 'Test-PwshMachineScopeInstalled' {
+  It 'returns $false without checking the filesystem when ExePath is null or empty' {
+    Mock Test-Path { throw 'Test-Path should not be called when ExePath is empty' }
+
+    Test-PwshMachineScopeInstalled -ExePath $null | Should -Be $false
+    Test-PwshMachineScopeInstalled -ExePath '' | Should -Be $false
+  }
+
+  It 'returns $true when the machine-scope pwsh.exe exists' {
+    Mock Test-Path { $true }
+
+    Test-PwshMachineScopeInstalled -ExePath '/fake/Program Files/PowerShell/7/pwsh.exe' | Should -Be $true
+  }
+
+  It 'returns $false when the machine-scope pwsh.exe does not exist' {
+    Mock Test-Path { $false }
+
+    Test-PwshMachineScopeInstalled -ExePath '/fake/Program Files/PowerShell/7/pwsh.exe' | Should -Be $false
+  }
+}
+
 Describe 'Sync-Pwsh' {
   BeforeEach {
     Mock Test-PwshUserScopeCoexistence { $false }
+    Mock Test-PwshMachineScopeInstalled { $true }
   }
 
   It 'installs with the machine-scope argument list' {
@@ -82,7 +110,7 @@ Describe 'Sync-Pwsh' {
     Should -Invoke Test-PwshUserScopeCoexistence -Times 1
   }
 
-  It 'warns when a user-scope MSIX execution alias coexists, without throwing' {
+  It 'warns when a user-scope MSIX execution alias coexists after a verified successful install, without throwing' {
     Mock Invoke-PwshInstallCommand { 0 }
     Mock Test-PwshUserScopeCoexistence { $true }
 
@@ -95,5 +123,42 @@ Describe 'Sync-Pwsh' {
     $warnings = Sync-Pwsh 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
 
     $warnings | Should -BeNullOrEmpty
+  }
+
+  It 'correlates a failed install with a coexisting user-scope MSIX alias in the error message' {
+    Mock Invoke-PwshInstallCommand { 1 }
+    Mock Test-PwshUserScopeCoexistence { $true }
+
+    Sync-Pwsh -ErrorAction SilentlyContinue -ErrorVariable syncErrors 2>&1 | Out-Null
+    $syncErrors.Count | Should -Be 1
+    $syncErrors[0].ToString() | Should -Match 'installer technology'
+  }
+
+  It 'does not mention MSIX coexistence in the error message when no alias is present' {
+    Mock Invoke-PwshInstallCommand { 1 }
+    Mock Test-PwshUserScopeCoexistence { $false }
+
+    Sync-Pwsh -ErrorAction SilentlyContinue -ErrorVariable syncErrors 2>&1 | Out-Null
+    $syncErrors.Count | Should -Be 1
+    $syncErrors[0].ToString() | Should -Not -Match 'installer technology'
+  }
+
+  It 'treats a verified-missing machine-scope binary as a failure even when winget exits 0' {
+    Mock Invoke-PwshInstallCommand { 0 }
+    Mock Test-PwshMachineScopeInstalled { $false }
+
+    { Sync-Pwsh -ErrorAction SilentlyContinue } | Should -Not -Throw
+    Sync-Pwsh -ErrorAction SilentlyContinue -ErrorVariable syncErrors 2>&1 | Out-Null
+    $syncErrors.Count | Should -Be 1
+    $syncErrors[0].ToString() | Should -Match 'not found at the expected machine-scope path'
+  }
+
+  It 'does not print the success message when the machine-scope binary verification fails' {
+    Mock Invoke-PwshInstallCommand { 0 }
+    Mock Test-PwshMachineScopeInstalled { $false }
+
+    $output = Sync-Pwsh -ErrorAction SilentlyContinue 6>&1 | Out-String
+
+    $output | Should -Not -Match 'installation complete'
   }
 }


### PR DESCRIPTION
## Summary

Migrates PowerShell 7 (`pwsh`)'s winget install from user scope (MSIX) to
machine scope (MSI), so its path is stable enough to later serve as
Windows OpenSSH Server's `DefaultShell` (a machine-wide setting that
cannot point at a per-user MSIX execution alias — an NTFS reparse point
OpenSSH's public-key sessions cannot traverse; see
`docs/dotfiles-boundary.md`'s existing reparse-point discussion).

Neither `Microsoft.WinGet.DSC/WinGetPackage` (the DSC route) nor
`winget import` (the degraded-mode fallback route) can request
`--scope machine`, so this could not be expressed declaratively. Instead:

- `configurations/packages.dsc.yaml` / `packages.min.dsc.yaml` no longer
  declare `pwsh` (tombstone comments left at each removal site);
  `packages.import.json` / `packages.min.import.json` regenerated via
  `scripts/Build-Configurations.ps1` accordingly.
- `libs/pwsh-installer.ps1` (`Sync-Pwsh`) installs it imperatively at
  machine scope from Phase 5 post-install instead — the same
  "winget/DSC can't express this" pattern already used for CodeRabbit
  CLI, Cursor CLI, and Unity Editor.
- A pre-existing user-scope MSIX install (from before this migration) is
  detected and warned about, not auto-uninstalled — the winget package
  identity actually installed on a given machine can't be determined
  with confidence from this repository alone.
- `README.md`/`README.ja.md`, `docs/dotfiles-boundary.md`, and
  `docs/dsc-migration-notes.md` updated accordingly.

Closes #147

## Test plan

- [x] `Invoke-ScriptAnalyzer -Path . -Recurse -Settings ./PSScriptAnalyzerSettings.psd1 -EnableExit` — exit 0
- [x] `Invoke-Pester -Path ./tests/powershell -CI` — 168/168 passed (12 new in `pwsh-installer.Tests.ps1`)
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 issues
- [x] `npx cspell lint "**" --no-progress` — 0 issues
- [x] `scripts/Build-Configurations.ps1` regeneration produces zero drift against the committed `packages*.import.json`/`packages*.unapplied.json`
- [ ] Real-machine verification of `winget install --scope machine --installer-type wix` against the current `Microsoft.PowerShell` manifest (this repository has no Windows/`winget` environment to verify against — see `docs/dsc-migration-notes.md`'s new section for the caveat)

## Follow-up (not in this PR)

Wiring `sshd`'s `DefaultShell` itself (registry value, OpenSSH Server
feature enablement, `Subsystem` entry) is intentionally out of scope —
this repository currently has no sshd/OpenSSH Server footprint at all,
and bundling it here would widen this PR beyond one reviewable change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PowerShell 7 is now installed machine-wide during post-installation, supporting use as the Windows OpenSSH Server default shell.
  * Added detection and warnings for conflicting user-scope PowerShell installations.
  * Added verification that the machine-wide executable is present before reporting installation success.

* **Documentation**
  * Updated English and Japanese installation, provisioning, and migration guidance with installer limitations and coexistence cleanup details.

* **Tests**
  * Added coverage for installation arguments, executable verification, success and failure handling, coexistence detection, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->