### PR TITLE
feat(ci): add idd-advisory-convergence-comment.yml as dogfooded copy

### DIFF
--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -37,15 +37,17 @@
 #     --no-audit --no-fund` on the install: this step only needs the
 #     plain .mjs file, so lifecycle scripts the tarball's package.json
 #     might define (e.g. a `prepare` hook) never need to run.
-#   - The rerun step is skipped for a fork-origin PR (local addition,
+#   - The whole job is skipped for a fork-origin PR (local addition,
 #     absent from the pinned template): GitHub forces `GITHUB_TOKEN` to
 #     read-only for `pull_request_review_comment` on a fork-originated
-#     PR regardless of `permissions:` above, so the rerun would 403.
-#     The required check itself still runs fine on fork PRs (its own
-#     permissions are all read-only); only this automatic refresh is
-#     unavailable there -- the manual `gh run rerun` fallback in
-#     docs/idd-policy.md's CI Gate (External Checks) section still
-#     applies.
+#     PR regardless of `permissions:` above, so the rerun step would
+#     403 there -- checkout/setup-node/npm install would be wasted CI
+#     minutes on every review-thread comment for a fork PR that can
+#     never succeed anyway. The required check itself still runs fine
+#     on fork PRs (its own permissions are all read-only); only this
+#     automatic refresh is unavailable there -- the manual
+#     `gh run rerun` fallback in docs/idd-policy.md's CI Gate (External
+#     Checks) section still applies.
 # If a future change adds a `ref:` override that resolves to the PR
 # head, vendors either script into this repository, or widens
 # `permissions:` below, re-review this trust model before merging that
@@ -83,6 +85,17 @@ jobs:
   # workflow's own check-run can never be mistaken for -- or overwrite
   # -- the required check's rollup.
   refresh-if-idd-originated:
+    # Fork-origin PRs are skipped for the whole job (local addition,
+    # absent from the pinned template): the rerun step below can never
+    # succeed there (GitHub forces GITHUB_TOKEN to read-only for
+    # pull_request_review_comment on a fork-originated PR regardless of
+    # permissions: above), so checkout/setup-node/npm install would be
+    # wasted CI minutes on every review-thread comment. The required
+    # check itself still runs fine on fork PRs (its own permissions are
+    # all read-only); only this automatic refresh is unavailable there
+    # -- the manual `gh run rerun` fallback in docs/idd-policy.md's CI
+    # Gate (External Checks) section still applies.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -104,16 +117,7 @@ jobs:
             https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
           node "$RUNNER_TEMP/idd-skill/node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs"
       - name: Rerun required HEAD check
-        # Fork-origin PRs are skipped here (local addition, absent from
-        # the pinned template): GitHub forces GITHUB_TOKEN to read-only
-        # for pull_request_review_comment on a fork-originated PR
-        # regardless of the permissions: block above, so this step's
-        # `gh run rerun` call would 403. The required check itself still
-        # runs fine on fork PRs (its own permissions are all read-only);
-        # only this automatic refresh is unavailable there -- the manual
-        # `gh run rerun` fallback in docs/idd-policy.md's CI Gate
-        # (External Checks) section still applies.
-        if: steps.origin.outputs.idd_originated == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.origin.outputs.idd_originated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -34,6 +34,15 @@
 #     path -- still sourced only from the pinned tarball, nothing
 #     vendored into this repository. The rerun step below has a
 #     published bin and uses the ordinary form.
+#   - The rerun step is skipped for a fork-origin PR (local addition,
+#     absent from the pinned template): GitHub forces `GITHUB_TOKEN` to
+#     read-only for `pull_request_review_comment` on a fork-originated
+#     PR regardless of `permissions:` above, so the rerun would 403.
+#     The required check itself still runs fine on fork PRs (its own
+#     permissions are all read-only); only this automatic refresh is
+#     unavailable there -- the manual `gh run rerun` fallback in
+#     docs/idd-policy.md's CI Gate (External Checks) section still
+#     applies.
 # If a future change adds a `ref:` override that resolves to the PR
 # head, vendors either script into this repository, or widens
 # `permissions:` below, re-review this trust model before merging that
@@ -91,7 +100,16 @@ jobs:
             https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
           node "$RUNNER_TEMP/idd-skill/node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs"
       - name: Rerun required HEAD check
-        if: steps.origin.outputs.idd_originated == 'true'
+        # Fork-origin PRs are skipped here (local addition, absent from
+        # the pinned template): GitHub forces GITHUB_TOKEN to read-only
+        # for pull_request_review_comment on a fork-originated PR
+        # regardless of the permissions: block above, so this step's
+        # `gh run rerun` call would 403. The required check itself still
+        # runs fine on fork PRs (its own permissions are all read-only);
+        # only this automatic refresh is unavailable there -- the manual
+        # `gh run rerun` fallback in docs/idd-policy.md's CI Gate
+        # (External Checks) section still applies.
+        if: steps.origin.outputs.idd_originated == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,0 +1,100 @@
+# Trust model: this is a NON-required companion to
+# idd-advisory-convergence.yml (the required-check gate; see that
+# file's own trust-model header). It cannot create, cancel, or resolve
+# the idd-advisory-convergence required check-run itself -- different
+# name, job id, and concurrency group -- it can only ask
+# rerun-advisory-convergence.mjs to re-run the EXISTING pull_request-
+# family run for the current HEAD SHA, and only for a comment
+# classified as IDD-originated (an E6/E13 disposition reply, reply-
+# identity stamp, or other operational marker the required check
+# already honors -- see scripts/review-comment-origin.mjs at the pin
+# below). Ordinary human review-thread chatter (a plain "LGTM",
+# "thanks") never triggers a rerun.
+#   - `ref: master` on the checkout step means a PR cannot substitute
+#     its own edited `.github/idd/config.json` to widen which comments
+#     count as IDD-originated.
+#   - `${{ github.event.comment.body }}` is passed only via `env:` and
+#     read from `$COMMENT_BODY` inside the classifier -- never
+#     interpolated into a shell command -- so PR-authored comment text
+#     is never executed.
+#   - `actions: write` is scoped to re-running an EXISTING check-run
+#     for this PR's own current HEAD SHA; neither the classifier nor
+#     the rerun helper accepts an attacker-chosen target or command.
+#     Worst case for a spoofed IDD-originated stamp is a wasted,
+#     bounded CI re-run, not code execution or privilege escalation
+#     (accepted risk; see kurone-kito/setup.windows#124's Trust/Safety
+#     analysis).
+#   - The classify step below has no published `idd-*` CLI command at
+#     this pin (scripts/review-comment-origin.mjs carries no `bin`
+#     entry), so it cannot use this repository's usual
+#     `npx --yes --package <tarball> idd-<command>` form. It instead
+#     installs the same pinned tarball into a runner-temp prefix
+#     (`npm install --prefix`, the same mechanism `npx --package`
+#     itself uses internally) and calls the script by its resolved
+#     path -- still sourced only from the pinned tarball, nothing
+#     vendored into this repository. The rerun step below has a
+#     published bin and uses the ordinary form.
+# If a future change adds a `ref:` override that resolves to the PR
+# head, vendors either script into this repository, or widens
+# `permissions:` below, re-review this trust model before merging that
+# change.
+name: IDD advisory-convergence comment refresh
+on:
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  actions: write
+concurrency:
+  # Different job id and group from idd-advisory-convergence.yml
+  # (#2136) so a human review-thread reply here can never create or
+  # cancel that required check-run. Does not cancel an in-flight
+  # refresh: a later human reply on the same PR must not abort an
+  # in-progress IDD-originated rerun.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+defaults:
+  run:
+    # Pins every run: step's shell regardless of runner OS -- GitHub
+    # Actions otherwise picks bash on Linux/macOS but PowerShell Core
+    # on Windows, which would silently misinterpret this file's POSIX
+    # shell syntax instead of failing loudly. Available on every
+    # GitHub-hosted runner, including Windows via Git Bash.
+    shell: bash
+jobs:
+  # Job id is deliberately NOT `idd-advisory-convergence`, so this
+  # workflow's own check-run can never be mistaken for -- or overwrite
+  # -- the required check's rollup.
+  refresh-if-idd-originated:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+      - name: Classify review comment
+        id: origin
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          npm install --no-save --prefix "$RUNNER_TEMP/idd-skill" \
+            https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
+          node "$RUNNER_TEMP/idd-skill/node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs"
+      - name: Rerun required HEAD check
+        if: steps.origin.outputs.idd_originated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0 \
+            idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -33,7 +33,10 @@
 #     itself uses internally) and calls the script by its resolved
 #     path -- still sourced only from the pinned tarball, nothing
 #     vendored into this repository. The rerun step below has a
-#     published bin and uses the ordinary form.
+#     published bin and uses the ordinary form. `--ignore-scripts
+#     --no-audit --no-fund` on the install: this step only needs the
+#     plain .mjs file, so lifecycle scripts the tarball's package.json
+#     might define (e.g. a `prepare` hook) never need to run.
 #   - The rerun step is skipped for a fork-origin PR (local addition,
 #     absent from the pinned template): GitHub forces `GITHUB_TOKEN` to
 #     read-only for `pull_request_review_comment` on a fork-originated
@@ -96,7 +99,8 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          npm install --no-save --prefix "$RUNNER_TEMP/idd-skill" \
+          npm install --no-save --ignore-scripts --no-audit --no-fund \
+            --prefix "$RUNNER_TEMP/idd-skill" \
             https://codeload.github.com/kurone-kito/idd-skill/tar.gz/f51a8bb73a47452eff5799e8a27251b660ba4ae0
           node "$RUNNER_TEMP/idd-skill/node_modules/@kurone-kito/idd-skill/scripts/review-comment-origin.mjs"
       - name: Rerun required HEAD check

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -47,15 +47,6 @@ on:
   pull_request_review:
     types:
       - submitted
-  # Covers E6 disposition replies (and any other reply/edit/delete on a
-  # review thread): Clause 2 of the verdict is "every advisory-bot
-  # thread resolved or dispositioned", which changes exactly when one of
-  # these events fires, not just on a new push or review submission.
-  pull_request_review_comment:
-    types:
-      - created
-      - edited
-      - deleted
   workflow_dispatch:
     inputs:
       pr_number:
@@ -67,24 +58,18 @@ permissions:
   issues: read
   pull-requests: read
 concurrency:
-  # Grouped by PR number, not github.ref: pull_request_review and
-  # pull_request_review_comment are not pull_request-family events, so
-  # github.ref does not resolve the same way for them as it does for
-  # lint.yml's pull_request-only trigger. cancel-in-progress stays true
-  # deliberately: a narrower group or cancel-in-progress:false both trade
-  # this race for an equally-racy alternative rather than closing it (see
-  # upstream idd-skill#1381) -- if the rollup ever appears stuck on a
-  # stale run for the current HEAD SHA, `gh run rerun <run-id>` on the
-  # existing pull_request-family run for that SHA is the known recovery.
-  # Upstream v0.7.0 (idd-skill#2136) closes this race a different way, by
-  # moving pull_request_review_comment into a separate
-  # idd-advisory-convergence-comment.yml companion workflow with its own
-  # job id and concurrency group. This repository deliberately keeps the
-  # combined single-workflow form for now: adopting the split needs a new
-  # companion workflow file (which would carry `actions: write`, tripping
-  # the trust-model header's "widens permissions" re-review clause) and
-  # is tracked as a follow-up rather than done as part of this pin bump
-  # (see kurone-kito/setup.windows#124).
+  # Grouped by PR number, not github.ref: pull_request_review is not a
+  # pull_request-family event, so github.ref does not resolve the same
+  # way for it as it does for lint.yml's pull_request-only trigger.
+  # Review-thread comments live in the companion
+  # idd-advisory-convergence-comment.yml workflow and must not share
+  # this group (#2136, kurone-kito/setup.windows#124).
+  # cancel-in-progress stays true deliberately: a narrower group or
+  # cancel-in-progress:false both trade this race for an equally-racy
+  # alternative rather than closing it (see upstream idd-skill#1381) --
+  # if the rollup ever appears stuck on a stale run for the current
+  # HEAD SHA, `gh run rerun <run-id>` on the existing pull_request-
+  # family run for that SHA is the known recovery.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 defaults:

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -61,12 +61,15 @@ recorded in `.github/idd/config.json`)
   stamp, or other operational marker `scripts/review-comment-origin.mjs`
   already recognizes — ordinary human chatter like "LGTM" is not),
   reruns the existing `idd-advisory-convergence` required-check run for
-  the PR's current HEAD SHA. It has a different job id and concurrency
-  group from the required check itself, so it can never create or
-  cancel that check-run directly (#2136, kurone-kito/setup.windows#124).
-  This automates only the reply-triggered case; it is unrelated to the
-  waiver-comment rerun case below, which still requires the manual
-  `gh run rerun` step.
+  the PR's current HEAD SHA, for same-repository PRs only — a
+  fork-originated PR falls back to the manual `gh run rerun` step below,
+  since GitHub forces a read-only `GITHUB_TOKEN` for this trigger on
+  fork PRs regardless of the workflow's own `permissions:`. It has a
+  different job id and concurrency group from the required check
+  itself, so it can never create or cancel that check-run directly
+  (#2136, kurone-kito/setup.windows#124). This automates only the
+  reply-triggered case; it is unrelated to the waiver-comment rerun
+  case below, which still requires the manual `gh run rerun` step.
 - **`ciGate.externalChecks.waivable`**: `[{ "selector":
   "idd-advisory-convergence" }]` — this repository's only waivable
   external check.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -54,6 +54,19 @@ recorded in `.github/idd/config.json`)
   status check is recorded in
   [CI Gate (Required Status Checks)](#ci-gate-required-status-checks)
   below (#61).
+- **Comment-triggered rerun (non-required companion)**:
+  `.github/workflows/idd-advisory-convergence-comment.yml` listens for
+  `pull_request_review_comment` events and, only when the comment is
+  classified IDD-originated (an E6/E13 disposition reply, reply-identity
+  stamp, or other operational marker `scripts/review-comment-origin.mjs`
+  already recognizes — ordinary human chatter like "LGTM" is not),
+  reruns the existing `idd-advisory-convergence` required-check run for
+  the PR's current HEAD SHA. It has a different job id and concurrency
+  group from the required check itself, so it can never create or
+  cancel that check-run directly (#2136, kurone-kito/setup.windows#124).
+  This automates only the reply-triggered case; it is unrelated to the
+  waiver-comment rerun case below, which still requires the manual
+  `gh run rerun` step.
 - **`ciGate.externalChecks.waivable`**: `[{ "selector":
   "idd-advisory-convergence" }]` — this repository's only waivable
   external check.
@@ -276,6 +289,14 @@ Template files and helper scripts are pinned to:
 ```text
 kurone-kito/idd-skill @ f51a8bb73a47452eff5799e8a27251b660ba4ae0
 ```
+
+This repository additionally hosts the following template workflow
+files as dogfooded copies at this pin, kept in sync manually on each
+pin bump:
+
+- `.github/workflows/idd-advisory-convergence.yml`
+- `.github/workflows/idd-advisory-convergence-comment.yml`
+- `.github/workflows/post-merge-cleanup.yml`
 
 When a future change bumps this pin, treat it as a **named-gap
 import**, not a blind resync: reconcile only the specific files that


### PR DESCRIPTION
## Summary

Adopts `kurone-kito/idd-skill` v0.7.0's `idd-advisory-convergence-comment.yml`
companion workflow (upstream #2136) as a dogfooded copy, per the
repository owner's 2026-09-03 decision recorded on the issue.

- Adds `.github/workflows/idd-advisory-convergence-comment.yml`: a
  non-required workflow that reruns the existing
  `idd-advisory-convergence` required-check run whenever a
  `pull_request_review_comment` is classified IDD-originated (an
  E6/E13 disposition reply, reply-identity stamp, or other operational
  marker) — never for ordinary human chatter. Different job id and
  concurrency group from the required check, so it can never create or
  cancel that check-run itself.
- Removes the `pull_request_review_comment` trigger from
  `.github/workflows/idd-advisory-convergence.yml` (all three
  `created`/`edited`/`deleted` types) now that this companion workflow
  owns that responsibility, closing the same race upstream v0.7.0
  closed with the same split (#2136). Updates the concurrency block's
  explanatory comment accordingly.
- Records the new workflow in `docs/idd-policy.md`'s Upstream pin
  section (dogfooded-files list) and adds a new CI Gate (External
  Checks) bullet describing its scope as distinct from the existing
  waiver-comment manual-rerun procedure, which is unchanged.

Closes #124

## Design note: the classify step's non-standard invocation

`scripts/review-comment-origin.mjs` — the classifier that gates
whether a comment triggers a rerun — has **no `idd-*` bin entry** at
pin `f51a8bb7` (confirmed against the tarball's `package.json#bin`;
37 bins exist, none for this script). This repository's
`ephemeral-npx` helper-runtime profile only resolves helper execution
through published `npx --yes --package <tarball> idd-<command>`
commands, so the classify step cannot use that form the way every
other helper invocation in this repository (including this same new
workflow's own rerun step) does.

Two alternatives were rejected: inline-reimplementing the 4-signal
classifier (drifts from upstream on the next pin bump, and the issue's
own acceptance criteria rule out pasting upstream logic), and skipping
the classifier entirely (changes the upstream design — every comment,
not just IDD-originated ones, would attempt a rerun).

Adopted instead: `npm install --no-save --ignore-scripts --no-audit --no-fund --prefix "$RUNNER_TEMP/idd-skill" <same pinned tarball URL>`,
then invoke the script by its resolved path. This is the same install
mechanism `npx --package` uses internally, just made addressable since
no bin exists to resolve it automatically — still sourced only from
the pinned tarball, nothing vendored into this repository. Documented
in the new file's own trust-model header.

Two review-round follow-ups on this same file, both accepted: the
fork-origin PR case (GitHub forces `GITHUB_TOKEN` read-only for
`pull_request_review_comment` on a fork PR regardless of
`permissions:`, so the rerun step would 403 there — independently
confirmed against GitHub's own documentation, not just the reviewer's
claim) is guarded at the job level so a fork PR skips
checkout/setup-node/install entirely instead of only skipping the
rerun call; and the install now also passes `--ignore-scripts
--no-audit --no-fund` since the step only needs the plain script file.

## Verification

- No `actionlint` available in this environment, and this repository's
  own CI (`lint.yml`) has no YAML-syntax/actionlint job — both new/
  changed workflow YAML files were verified to parse cleanly with
  `powershell-yaml`'s `ConvertFrom-Yaml`, the acceptance criteria's
  documented fallback.
- `pre-push-validate` passes on a clean tree: markdownlint (0 issues),
  cspell (0 issues), PSScriptAnalyzer (0 issues), Pester (186/186
  passed) — this change touches no PowerShell, so the Pester/analyzer
  runs are a no-op confirmation rather than new coverage.
- Manually verified the classify step end-to-end against the real
  pinned tarball and this repository's own `.github/idd/config.json`
  (`markerPrefix: "setup-windows"`, read via the script's own
  `process.cwd()`-relative config loader, so no `--marker-prefix` flag
  is needed): a `**Accepted**`-prefixed comment body classifies
  `idd_originated=true` (reason `disposition-prefix`); a plain `LGTM`
  classifies `idd_originated=false`.
- GitHub Actions execution itself cannot be run ahead of time in this
  environment, but this PR's own review-thread activity gave live,
  on-runner proof once posted: the companion workflow correctly
  classified CodeRabbit's own review body as `idd_originated=false`
  (skipped, no rerun), and later — for each disposition reply this PR's
  own author posted (`**Accepted** — …`) — classified
  `idd_originated=true` and successfully called `gh run rerun` on the
  required check's previously-failed instance for the current HEAD,
  which then passed. Confirmed via `gh run list
  --workflow=idd-advisory-convergence-comment.yml` and the required
  check's own run history for the same HEAD SHAs.

## Out of scope

- No change to `post-merge-cleanup.yml` or the `idd-skill` pin SHA
  itself.
- No post-pin upstream content (e.g. `issue_comment` trigger support,
  SHA-pinned checkout actions, a Node-floor-assertion step — all
  present in idd-skill's own self-hosted copy of the required-check
  workflow, but not in the exportable template this PR ports from, and
  not requested by the issue).
- No additional actor-trust filtering added to the classifier beyond
  what upstream ships — the issue's own Trust/Safety analysis already
  accepted the current design's worst case (a wasted, bounded CI
  rerun) as low-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9TCtbMGY6nAmB2vUvadVM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic rerun of the advisory convergence check when an IDD-originated pull-request review comment changes.
  * The new rerun process is non-required and operates separately from the primary check.

* **Documentation**
  * Documented the new review-comment rerun process and clarified the existing manual waiver-rerun procedure.
  * Updated tracked policy workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
